### PR TITLE
[BUGFIX] Awaiting of non-generic task does not hang forever/cause invocation exception.

### DIFF
--- a/CoreRemoting.Tests/AsyncTests.cs
+++ b/CoreRemoting.Tests/AsyncTests.cs
@@ -10,10 +10,12 @@ namespace CoreRemoting.Tests
     public class AsyncTests
     {
         #region Service with async method
-        
+
         public interface IAsyncService
         {
             Task<string> ConvertToBase64Async(string text);
+
+            Task NonGenericTask();
         }
 
         public class AsyncService : IAsyncService
@@ -30,10 +32,15 @@ namespace CoreRemoting.Tests
 
                 return base64String;
             }
+
+            public Task NonGenericTask()
+            {
+                return Task.CompletedTask;
+            }
         }
 
         #endregion
-        
+
         [Fact]
         public async void AsyncMethods_should_work()
         {
@@ -60,8 +67,41 @@ namespace CoreRemoting.Tests
             var proxy = client.CreateProxy<IAsyncService>();
 
             var base64String = await proxy.ConvertToBase64Async("Yay");
-            
+
             Assert.Equal("WWF5", base64String);
+        }
+
+        /// <summary>
+        /// Awaiting for ordinary non-generic task method should not hangs. 
+        /// </summary>
+        [Fact(Timeout = 15000)]
+        public async void AwaitingNonGenericTask_should_not_hang_forever()
+        {
+            var port = 9197;
+            
+            var serverConfig =
+                new ServerConfig()
+                {
+                    NetworkPort = port,
+                    RegisterServicesAction = container =>
+                        container.RegisterService<IAsyncService, AsyncService>(
+                            lifetime: ServiceLifetime.Singleton)
+                };
+
+            using var server = new RemotingServer(serverConfig);
+            server.Start();
+
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                ServerPort = port
+            });
+
+            client.Connect();
+            var proxy = client.CreateProxy<IAsyncService>();
+
+            await proxy.NonGenericTask();
         }
     }
 }

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -457,12 +457,19 @@ namespace CoreRemoting
                 if (result != null)
                 {
                     // Wait for result value if result is a Task
-                    if (typeof(Task).IsAssignableFrom(returnType) && returnType.IsGenericType)
+                    if (typeof(Task).IsAssignableFrom(returnType))
                     {
                         var resultTask = (Task)result;
                         resultTask.Wait();
-
-                        result = returnType.GetProperty("Result")?.GetValue(resultTask);
+                        
+                        if (returnType.IsGenericType)
+                        {
+                            result = returnType.GetProperty("Result")?.GetValue(resultTask);
+                        }
+                        else // ordinary non-generic task
+                        {
+                            result = null;
+                        }
                     }
                     else if (returnType.GetCustomAttribute<ReturnAsProxyAttribute>() != null)
                     {


### PR DESCRIPTION
Awaiting of ordinary non-generic Task always causes invocation exception or hangs if invocation timeout is 0.
Little fix for such a trouble.