### PR TITLE
Do not freeze client when server is disconnected

### DIFF
--- a/CoreRemoting/Channels/IClientChannel.cs
+++ b/CoreRemoting/Channels/IClientChannel.cs
@@ -32,5 +32,10 @@ namespace CoreRemoting.Channels
         /// Gets the raw message transport component for this connection.
         /// </summary>
         IRawMessageTransport RawMessageTransport { get; }
+
+        /// <summary>
+        /// Event: Fires when the server disconnects.
+        /// </summary>
+        event Action Disconnected;
     }
 }

--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -22,6 +22,9 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     /// </summary>
     public event Action<string, Exception> ErrorOccured;
 
+    /// <inheritdoc />
+    public event Action Disconnected;
+
     /// <summary>
     /// Initializes the channel.
     /// </summary>
@@ -54,9 +57,15 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
 
         _tcpClient.Events.ExceptionEncountered += OnError;
         _tcpClient.Events.MessageReceived += OnMessage;
+        _tcpClient.Events.ServerDisconnected += OnDisconnected;
         _tcpClient.Connect();
 
         _tcpClient.Send(new byte[1] { 0x0 }, _handshakeMetadata);
+    }
+
+    private void OnDisconnected(object o, DisconnectionEventArgs disconnectionEventArgs)
+    {
+        Disconnected.Invoke();
     }
 
     /// <summary>

--- a/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
@@ -22,7 +22,10 @@ namespace CoreRemoting.Channels.Websocket
         /// Event: Fires when an error is occurred.
         /// </summary>
         public event Action<string, Exception> ErrorOccured;
-        
+
+        /// <inheritdoc />
+        public event Action Disconnected;
+
         /// <summary>
         /// Initializes the channel.
         /// </summary>
@@ -87,9 +90,15 @@ namespace CoreRemoting.Channels.Websocket
             
             _webSocket.OnMessage += OnMessage;
             _webSocket.OnError += OnError;
+            _webSocket.OnClose += OnDisconnected;
 
             _webSocket.Connect();
             _webSocket.Send(string.Empty);
+        }
+
+        private void OnDisconnected(object o, CloseEventArgs closeEventArgs)
+        {
+            Disconnected.Invoke();
         }
 
         /// <summary>

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -121,7 +121,7 @@ namespace CoreRemoting
             foreach (var activeCall in _activeCalls)
             {
                 activeCall.Value.Error = true;
-                activeCall.Value.RemoteException = new RemoteInvocationException("ServerDisconnected");
+                activeCall.Value.RemoteException = new RemoteInvocationException("Server Disconnected");
                 activeCall.Value.WaitHandle.Set();
             }
         }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -90,6 +90,7 @@ namespace CoreRemoting
             _channel = config.Channel ?? new TcpClientChannel();
             
             _channel.Init(this);
+            _channel.Disconnected += OnDisconnected;
             _rawMessageTransport = _channel.RawMessageTransport;
             _rawMessageTransport.ReceiveMessage += OnMessage;
             _rawMessageTransport.ErrorOccured += (s, exception) =>
@@ -113,6 +114,16 @@ namespace CoreRemoting
                 return;
             
             RemotingClient.DefaultRemotingClient ??= this;
+        }
+
+        private void OnDisconnected()
+        {
+            foreach (var activeCall in _activeCalls)
+            {
+                activeCall.Value.Error = true;
+                activeCall.Value.RemoteException = new RemoteInvocationException("ServerDisconnected");
+                activeCall.Value.WaitHandle.Set();
+            }
         }
 
         #endregion


### PR DESCRIPTION
Continue executing pending InvokeRemoteMethod tasks in
https://github.com/theRainbird/CoreRemoting/blob/5e8dea023bb1b78e022927b22f599c12655813ed/CoreRemoting/RemotingClient.cs#L600-L601
 when the server shuts down so that the client does not wait for them to be executed indefinitely with InvocationTimeout set to infinity