### PR TITLE
Fixed send task start

### DIFF
--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -575,7 +575,7 @@ namespace CoreRemoting
         internal Task<ClientRpcContext> InvokeRemoteMethod(MethodCallMessage methodCallMessage, bool oneWay = false)
         {
             var sendTask =
-                new Task<ClientRpcContext>(() =>
+                Task.Run(() =>
                 {
                     byte[] sharedSecret =
                         MessageEncryption
@@ -616,8 +616,6 @@ namespace CoreRemoting
                     return clientRpcContext;
                 });
 
-            sendTask.Start();
-            
             return sendTask;
         }
         


### PR DESCRIPTION
1. Task.Start() is using TaskScheduler.Current and I have UI deadlock with it
2. Other places in CoreRemoting are using Task.Run
3. https://blog.stephencleary.com/2014/05/a-tour-of-task-part-1-constructors.html