### PR TITLE
Do not send rawMessage to _tcpClient when it disconnected

### DIFF
--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -133,7 +133,7 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     /// <param name="rawMessage">Raw message data</param>
     public void SendMessage(byte[] rawMessage)
     {
-        _tcpClient.Send(rawMessage);
+        _tcpClient?.Send(rawMessage);
     }
     
     /// <summary>


### PR DESCRIPTION
After RemotingServer dispose there may be executing call at client side and it will throw NullReferenceException in TcpClientChannel.SendMessage