### PR TITLE
Don't serialize read-only properties in Envelope

### DIFF
--- a/CoreRemoting/Serialization/Bson/Envelope.cs
+++ b/CoreRemoting/Serialization/Bson/Envelope.cs
@@ -36,11 +36,13 @@ namespace CoreRemoting.Serialization.Bson
         /// <summary>
         /// Gets the type of the wrapped value.
         /// </summary>
+        [JsonIgnore]
         public Type Type => _type;
 
         /// <summary>
         /// Gets the wrapped value.
         /// </summary>
+        [JsonIgnore]
         public object Value
         {
             get


### PR DESCRIPTION
It's not necessary to serialize the read-only properties in `Envelope`. Ignoring them decreases the message size.