### PR TITLE
Do not hide errors during deserialization

### DIFF
--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -616,8 +616,10 @@ namespace CoreRemoting
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e);
-                    throw;
+                    clientRpcContext.Error = true;
+                    clientRpcContext.RemoteException = new RemoteInvocationException(
+                        message: e.Message,
+                        innerEx: e.GetType().IsSerializable ? e : null);
                 }
             }
             clientRpcContext.WaitHandle.Set();


### PR DESCRIPTION
Deserialization errors may occur when using BSON, for example, if the object being deserialized has several constructors, none of which is marked with the JsonConstructor attribute. As a result, the RPC may freeze.