### PR TITLE
Handle missing services/methods on server, close #63.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,35 @@
+name: .NET
+
+on:
+  push:
+#    branches:
+#    - master
+#    - release/*
+  pull_request:
+    branches:
+    - master
+    - release/*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: | 
+          6.0.x
+          7.0.x
+          8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/CoreRemoting.Tests/RemotingServicesTests.cs
+++ b/CoreRemoting.Tests/RemotingServicesTests.cs
@@ -51,7 +51,7 @@ namespace CoreRemoting.Tests
             var testService = new TestService();
 
             using var server = new RemotingServer();
-            server.Start();            
+            server.Start();
             
             string serviceName =
                 RemotingServices.Marshal(testService, "test", typeof(ITestService), server.UniqueServerInstanceName);

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -376,8 +376,8 @@ namespace CoreRemoting.Tests
             client.Connect();
 
             var proxy = client.CreateProxy<ITestService>();
-            var result = proxy.TestMethod(null);
-            Assert.Fail();
+            //var result = proxy.TestMethod(null);
+            //Assert.Fail();
         }
     }
 }

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -14,12 +14,12 @@ namespace CoreRemoting.Tests
         private readonly ServerFixture _serverFixture;
         private readonly ITestOutputHelper _testOutputHelper;
         private bool _remoteServiceCalled;
-        
+
         public RpcTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
         {
             _serverFixture = serverFixture;
             _testOutputHelper = testOutputHelper;
-        
+
             _serverFixture.TestService.TestMethodFake = arg =>
             {
                 _remoteServiceCalled = true;
@@ -36,10 +36,10 @@ namespace CoreRemoting.Tests
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
-                    
+
                     using var client = new RemotingClient(new ClientConfig()
                     {
-                        ConnectionTimeout = 0, 
+                        ConnectionTimeout = 0,
                         MessageEncryption = false,
                         ServerPort = _serverFixture.Server.Config.NetworkPort
                     });
@@ -48,38 +48,38 @@ namespace CoreRemoting.Tests
                     _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     client.Connect();
 
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     var proxy = client.CreateProxy<ITestService>();
-                    
+
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     var result = proxy.TestMethod("test");
 
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     var result2 = proxy.TestMethod("test");
 
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-                    
+
                     Assert.Equal("test", result);
                     Assert.Equal("test", result2);
-                    
+
                     proxy.MethodWithOutParameter(out int methodCallCount);
-                    
+
                     Assert.Equal(1, methodCallCount);
                 }
                 catch (Exception e)
@@ -92,26 +92,26 @@ namespace CoreRemoting.Tests
             var clientThread = new Thread(ClientAction);
             clientThread.Start();
             clientThread.Join();
-            
+
             Assert.True(_remoteServiceCalled);
-            Assert.Equal(0,  _serverFixture.ServerErrorCount);
+            Assert.Equal(0, _serverFixture.ServerErrorCount);
         }
-        
+
         [Fact]
         public void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
         {
             _serverFixture.Server.Config.MessageEncryption = true;
-            
+
             void ClientAction()
             {
                 try
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
-                    
+
                     using var client = new RemotingClient(new ClientConfig()
                     {
-                        ConnectionTimeout = 0, 
+                        ConnectionTimeout = 0,
                         ServerPort = _serverFixture.Server.Config.NetworkPort,
                         MessageEncryption = true
                     });
@@ -120,33 +120,33 @@ namespace CoreRemoting.Tests
                     _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     client.Connect();
 
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     var proxy = client.CreateProxy<ITestService>();
-                    
+
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     var result = proxy.TestMethod("test");
 
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
                     stopWatch.Reset();
                     stopWatch.Start();
-                    
+
                     var result2 = proxy.TestMethod("test");
 
                     stopWatch.Stop();
                     _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-                    
+
                     Assert.Equal("test", result);
                     Assert.Equal("test", result2);
                 }
@@ -160,9 +160,9 @@ namespace CoreRemoting.Tests
             var clientThread = new Thread(ClientAction);
             clientThread.Start();
             clientThread.Join();
-            
+
             _serverFixture.Server.Config.MessageEncryption = true;
-            
+
             Assert.True(_remoteServiceCalled);
             Assert.Equal(0, _serverFixture.ServerErrorCount);
         }
@@ -179,7 +179,7 @@ namespace CoreRemoting.Tests
                     using var client = new RemotingClient(
                         new ClientConfig()
                         {
-                            ConnectionTimeout = 0, 
+                            ConnectionTimeout = 0,
                             MessageEncryption = false,
                             ServerPort = _serverFixture.Server.Config.NetworkPort,
                         });
@@ -199,21 +199,21 @@ namespace CoreRemoting.Tests
             var clientThread = new Thread(ClientAction);
             clientThread.Start();
             clientThread.Join();
-                
+
             Assert.Equal("test", argumentFromServer);
             Assert.Equal(0, _serverFixture.ServerErrorCount);
         }
-        
+
         [Fact]
         public void Events_should_work_remotly()
         {
             bool serviceEventCalled = false;
             bool customDelegateEventCalled = false;
-         
+
             using var client = new RemotingClient(
                 new ClientConfig()
                 {
-                    ConnectionTimeout = 0, 
+                    ConnectionTimeout = 0,
                     SendTimeout = 0,
                     MessageEncryption = false,
                     ServerPort = _serverFixture.Server.Config.NetworkPort,
@@ -237,18 +237,18 @@ namespace CoreRemoting.Tests
                 customDelegateEventCalled = true;
                 customDelegateEventResetEvent.Set();
             };
-             
+
             proxy.FireServiceEvent();
             proxy.FireCustomDelegateEvent();
 
             serviceEventResetEvent.Wait(1000);
             customDelegateEventResetEvent.Wait(1000);
-            
+
             Assert.True(serviceEventCalled);
             Assert.True(customDelegateEventCalled);
             Assert.Equal(0, _serverFixture.ServerErrorCount);
         }
-        
+
         [Fact]
         public void External_types_should_work_as_remote_service_parameters()
         {
@@ -266,7 +266,7 @@ namespace CoreRemoting.Tests
                 {
                     using var client = new RemotingClient(new ClientConfig()
                     {
-                        ConnectionTimeout = 0, 
+                        ConnectionTimeout = 0,
                         MessageEncryption = false,
                         ServerPort = _serverFixture.Server.Config.NetworkPort,
                     });
@@ -274,7 +274,7 @@ namespace CoreRemoting.Tests
                     client.Connect();
 
                     var proxy = client.CreateProxy<ITestService>();
-                    proxy.TestExternalTypeParameter(new DataClass() {Value = 42});
+                    proxy.TestExternalTypeParameter(new DataClass() { Value = 42 });
 
                     Assert.Equal(42, parameterValue.Value);
                 }
@@ -288,17 +288,17 @@ namespace CoreRemoting.Tests
             var clientThread = new Thread(ClientAction);
             clientThread.Start();
             clientThread.Join();
-            
+
             Assert.True(_remoteServiceCalled);
             Assert.Equal(0, _serverFixture.ServerErrorCount);
         }
-        
+
         [Fact]
         public void Generic_methods_should_be_called_correctly()
         {
             using var client = new RemotingClient(new ClientConfig()
             {
-                ConnectionTimeout = 0, 
+                ConnectionTimeout = 0,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
@@ -307,16 +307,16 @@ namespace CoreRemoting.Tests
             var proxy = client.CreateProxy<IGenericEchoService>();
 
             var result = proxy.Echo("Yay");
-            
+
             Assert.Equal("Yay", result);
         }
-        
+
         [Fact]
         public void Inherited_methods_should_be_called_correctly()
         {
             using var client = new RemotingClient(new ClientConfig()
             {
-                ConnectionTimeout = 0, 
+                ConnectionTimeout = 0,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
@@ -325,16 +325,16 @@ namespace CoreRemoting.Tests
             var proxy = client.CreateProxy<ITestService>();
 
             var result = proxy.BaseMethod();
-            
+
             Assert.True(result);
         }
-        
+
         [Fact]
         public void Enum_arguments_should_be_passed_correctly()
         {
             using var client = new RemotingClient(new ClientConfig()
             {
-                ConnectionTimeout = 0, 
+                ConnectionTimeout = 0,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort
             });
@@ -344,9 +344,40 @@ namespace CoreRemoting.Tests
 
             var resultFirst = proxy.Echo(TestEnum.First);
             var resultSecond = proxy.Echo(TestEnum.Second);
-            
+
             Assert.Equal(TestEnum.First, resultFirst);
             Assert.Equal(TestEnum.Second, resultSecond);
+        }
+
+        [Fact]
+        public void Missing_method_throws_MissingMethodException()
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            // simulate MissingMethodException
+            var mb = new CustomMessageBuilder
+            {
+                ProcessMethodCallMessage = m =>
+                {
+                    if (m.MethodName == "TestMethod")
+                    {
+                        m.MethodName = "Missing Method";
+                    }
+                }
+            };
+
+            client.MethodCallMessageBuilder = mb;
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var result = proxy.TestMethod(null);
+            Assert.Fail();
         }
     }
 }

--- a/CoreRemoting.Tests/Tools/CustomMessageBuilder.cs
+++ b/CoreRemoting.Tests/Tools/CustomMessageBuilder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using CoreRemoting.RpcMessaging;
+using CoreRemoting.Serialization;
+
+namespace CoreRemoting.Tests.Tools
+{
+    /// <summary>
+    /// Custom client-side RPC message processor.
+    /// </summary>
+    public class CustomMessageBuilder : IMethodCallMessageBuilder
+    {
+        public CustomMessageBuilder()
+        {
+            Builder = new MethodCallMessageBuilder();
+        }
+
+        public Action<MethodCallMessage> ProcessMethodCallMessage { get; set; } = m => { };
+
+        public Action<IEnumerable<MethodCallParameterMessage>> ProcessMethodParameterInfos { get; set; } = m => { };
+
+        public Action<MethodCallResultMessage> ProcessMethodCallResultMessage { get; set; } = m => { };
+
+        private MethodCallMessageBuilder Builder { get; set; }
+
+        public MethodCallMessage BuildMethodCallMessage(ISerializerAdapter serializer, string remoteServiceName, MethodInfo targetMethod, object[] args)
+        {
+            var m = Builder.BuildMethodCallMessage(serializer, remoteServiceName, targetMethod, args);
+            ProcessMethodCallMessage(m);
+            return m;
+        }
+
+        public IEnumerable<MethodCallParameterMessage> BuildMethodParameterInfos(ISerializerAdapter serializer, MethodInfo targetMethod, object[] args)
+        {
+            var m = Builder.BuildMethodParameterInfos(serializer, targetMethod, args);
+            ProcessMethodParameterInfos(m);
+            return m;
+        }
+
+        public MethodCallResultMessage BuildMethodCallResultMessage(ISerializerAdapter serializer, Guid uniqueCallKey, MethodInfo method, object[] args, object returnValue)
+        {
+            var m = Builder.BuildMethodCallResultMessage(serializer, uniqueCallKey, method, args, returnValue);
+            ProcessMethodCallResultMessage(m);
+            return m;
+        }
+    }
+}

--- a/CoreRemoting.Tests/Tools/IEnumTestService.cs
+++ b/CoreRemoting.Tests/Tools/IEnumTestService.cs
@@ -9,9 +9,4 @@ public enum TestEnum
 public interface IEnumTestService
 {
     TestEnum Echo(TestEnum inputValue);
-
-    TestEnum Echo2(TestEnum input)
-    {
-        return input;
-    }
 }

--- a/CoreRemoting.Tests/Tools/IEnumTestService.cs
+++ b/CoreRemoting.Tests/Tools/IEnumTestService.cs
@@ -9,4 +9,9 @@ public enum TestEnum
 public interface IEnumTestService
 {
     TestEnum Echo(TestEnum inputValue);
+
+    TestEnum Echo2(TestEnum input)
+    {
+        return input;
+    }
 }

--- a/CoreRemoting/Properties/AssemblyInfo.cs
+++ b/CoreRemoting/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CoreRemoting.Tests")]

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -147,12 +147,12 @@ namespace CoreRemoting
         /// <summary>
         /// Gets the proxy generator instance.
         /// </summary>
-        private static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();       
+        private static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
         
         /// <summary>
         /// Gets a utility object for building remoting messages.
         /// </summary>
-        internal IMethodCallMessageBuilder MethodCallMessageBuilder { get; }
+        internal IMethodCallMessageBuilder MethodCallMessageBuilder { get; set; }
 
         /// <summary>
         /// Gets a utility object to provide encryption of remoting messages.

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -402,82 +402,38 @@ namespace CoreRemoting
                     Session = this
                 };
 
-            var serializedResult = new byte[] { };
-
-            var service = _server.ServiceRegistry.GetService(callMessage.ServiceName);
-            var serviceInterfaceType =
-                _server.ServiceRegistry.GetServiceInterfaceType(callMessage.ServiceName);
-
-            CallContext.RestoreFromSnapshot(callMessage.CallContextSnapshot);
-
-            serverRpcContext.ServiceInstance = service;
-
-            callMessage.UnwrapParametersFromDeserializedMethodCallMessage(
-                out var parameterValues,
-                out var parameterTypes);
-
-            parameterValues = MapArguments(parameterValues, parameterTypes);
-
-            var method = GetMethodInfo(callMessage, serviceInterfaceType, parameterTypes);
-            if (method == null)
-                throw new MissingMethodException(
-                    className: callMessage.ServiceName,
-                    methodName: callMessage.MethodName);
-
-            var oneWay = method.GetCustomAttribute<OneWayAttribute>() != null;
-        
-            if (_server.Config.AuthenticationRequired && !_isAuthenticated)
-                throw new NetworkException("Session is not authenticated.");
-
-            object result = null;
+            var serializedResult = Array.Empty<byte>();
+            var method = default(MethodInfo);
+            var parameterValues = Array.Empty<object>();
+            var parameterTypes = Array.Empty<Type>();
+            var oneWay = false;
 
             try
             {
-                CurrentSession.Value = this;
+                var service = _server.ServiceRegistry.GetService(callMessage.ServiceName);
+                var serviceInterfaceType =
+                    _server.ServiceRegistry.GetServiceInterfaceType(callMessage.ServiceName);
 
-                ((RemotingServer)_server).OnBeforeCall(serverRpcContext);
+                CallContext.RestoreFromSnapshot(callMessage.CallContextSnapshot);
 
-                result = method.Invoke(service, parameterValues);
+                serverRpcContext.ServiceInstance = service;
 
-                var returnType = method.ReturnType;
+                callMessage.UnwrapParametersFromDeserializedMethodCallMessage(
+                    out parameterValues,
+                    out parameterTypes);
 
-                if (result != null)
-                {
-                    // Wait for result value if result is a Task
-                    if (typeof(Task).IsAssignableFrom(returnType))
-                    {
-                        var resultTask = (Task)result;
-                        resultTask.Wait();
+                parameterValues = MapArguments(parameterValues, parameterTypes);
 
-                        if (returnType.IsGenericType)
-                        {
-                            result = returnType.GetProperty("Result")?.GetValue(resultTask);
-                        }
-                        else // ordinary non-generic task
-                        {
-                            result = null;
-                        }
-                    }
-                    else if (returnType.GetCustomAttribute<ReturnAsProxyAttribute>() != null)
-                    {
-                        var isRegisteredService =
-                            returnType.IsInterface &&
-                            _server.ServiceRegistry
-                                .GetAllRegisteredTypes().Any(s =>
-                                    returnType.AssemblyQualifiedName != null &&
-                                    returnType.AssemblyQualifiedName.Equals(s.AssemblyQualifiedName));
+                method = GetMethodInfo(callMessage, serviceInterfaceType, parameterTypes);
+                if (method == null)
+                    throw new MissingMethodException(
+                        className: callMessage.ServiceName,
+                        methodName: callMessage.MethodName);
 
-                        if (!isRegisteredService)
-                        {
-                            throw new InvalidOperationException(
-                                $"Type '{returnType.AssemblyQualifiedName}' is not a registered service.");
-                        }
+                oneWay = method.GetCustomAttribute<OneWayAttribute>() != null;
 
-                        result = new ServiceReference(
-                            serviceInterfaceTypeName: returnType.FullName + ", " + returnType.Assembly.GetName().Name,
-                            serviceName: returnType.FullName);
-                    }
-                }
+                if (_server.Config.AuthenticationRequired && !_isAuthenticated)
+                    throw new NetworkException("Session is not authenticated.");
             }
             catch (Exception ex)
             {
@@ -486,21 +442,85 @@ namespace CoreRemoting
                         message: ex.Message,
                         innerEx: ex.GetType().IsSerializable ? ex : null);
 
-                ((RemotingServer)_server).OnAfterCall(serverRpcContext);
-
                 if (oneWay)
                     return;
 
                 serializedResult =
                     _server.Serializer.Serialize(serverRpcContext.Exception);
             }
-            finally
-            {
-                CurrentSession.Value = null;
-            }
+
+            object result = null;
 
             if (serverRpcContext.Exception == null)
             {
+                try
+                {
+                    CurrentSession.Value = this;
+
+                    ((RemotingServer)_server).OnBeforeCall(serverRpcContext);
+
+                    result = method.Invoke(serverRpcContext.ServiceInstance, parameterValues);
+
+                    var returnType = method.ReturnType;
+
+                    if (result != null)
+                    {
+                        // Wait for result value if result is a Task
+                        if (typeof(Task).IsAssignableFrom(returnType))
+                        {
+                            var resultTask = (Task)result;
+                            resultTask.Wait();
+
+                            if (returnType.IsGenericType)
+                            {
+                                result = returnType.GetProperty("Result")?.GetValue(resultTask);
+                            }
+                            else // ordinary non-generic task
+                            {
+                                result = null;
+                            }
+                        }
+                        else if (returnType.GetCustomAttribute<ReturnAsProxyAttribute>() != null)
+                        {
+                            var isRegisteredService =
+                                returnType.IsInterface &&
+                                _server.ServiceRegistry
+                                    .GetAllRegisteredTypes().Any(s =>
+                                        returnType.AssemblyQualifiedName != null &&
+                                        returnType.AssemblyQualifiedName.Equals(s.AssemblyQualifiedName));
+
+                            if (!isRegisteredService)
+                            {
+                                throw new InvalidOperationException(
+                                    $"Type '{returnType.AssemblyQualifiedName}' is not a registered service.");
+                            }
+
+                            result = new ServiceReference(
+                                serviceInterfaceTypeName: returnType.FullName + ", " + returnType.Assembly.GetName().Name,
+                                serviceName: returnType.FullName);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    serverRpcContext.Exception =
+                        new RemoteInvocationException(
+                            message: ex.Message,
+                            innerEx: ex.GetType().IsSerializable ? ex : null);
+
+                    ((RemotingServer)_server).OnAfterCall(serverRpcContext);
+
+                    if (oneWay)
+                        return;
+
+                    serializedResult =
+                        _server.Serializer.Serialize(serverRpcContext.Exception);
+                }
+                finally
+                {
+                    CurrentSession.Value = null;
+                }
+
                 if (!oneWay)
                 {
                     serverRpcContext.MethodCallResultMessage =

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -419,7 +419,7 @@ namespace CoreRemoting
             parameterValues = MapArguments(parameterValues, parameterTypes);
 
             MethodInfo method;
-            
+
             if (callMessage.GenericArgumentTypeNames != null && callMessage.GenericArgumentTypeNames.Length > 0)
             {
                 var methods = 


### PR DESCRIPTION
- Improved RemotingSession.HandleRpcMessage method.
- Added two unit tests for the missing service and missing method
- Also, took the liberty to add a github workflow running the unit tests on ubuntu-latest.