### PR TITLE
Preventing Leakage of the RemotingSession

### DIFF
--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -86,7 +86,7 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     {
         if (e.Metadata != null && e.Metadata.ContainsKey("ServerAcceptConnection"))
         {
-            if (!_tcpClient.Send(new byte[1] { 0x0 }, _handshakeMetadata) && !_tcpClient.Connected)
+            if (!_tcpClient.SendAsync(new byte[1] { 0x0 }, _handshakeMetadata).Result && !_tcpClient.Connected)
                 _tcpClient = null;
         }
         else
@@ -140,7 +140,7 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     {
         if (_tcpClient != null)
         {
-            if (_tcpClient.Send(rawMessage))
+            if (_tcpClient.SendAsync(rawMessage).Result)
                 return true;
             if (!_tcpClient.Connected)
                 _tcpClient = null;

--- a/CoreRemoting/Channels/Tcp/TcpConnection.cs
+++ b/CoreRemoting/Channels/Tcp/TcpConnection.cs
@@ -97,7 +97,7 @@ public class TcpConnection : IRawMessageTransport
     private void BeforeDisposeSession()
     {
         _session = null;
-        _tcpServer.DisconnectClient(_clientMetadata.Guid, MessageStatus.Shutdown);
+        _tcpServer.DisconnectClientAsync(_clientMetadata.Guid, MessageStatus.Shutdown);
     }
 
     /// <summary>
@@ -106,6 +106,6 @@ public class TcpConnection : IRawMessageTransport
     /// <param name="rawMessage">Raw message data</param>
     public bool SendMessage(byte[] rawMessage)
     {
-        return _tcpServer.Send(_clientMetadata.Guid, rawMessage);
+        return _tcpServer.SendAsync(_clientMetadata.Guid, rawMessage).Result;
     }
 }

--- a/CoreRemoting/Channels/Tcp/TcpServerChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpServerChannel.cs
@@ -46,7 +46,7 @@ public class TcpServerChannel : IServerChannel
                 { "ServerAcceptConnection", true }
             };
         
-            _tcpServer.Send(e.Client.Guid, new byte[]{ 0x02 }, metadata);
+            _tcpServer.SendAsync(e.Client.Guid, new byte[]{ 0x02 }, metadata);
         }
     }
     

--- a/CoreRemoting/CoreRemoting.csproj
+++ b/CoreRemoting/CoreRemoting.csproj
@@ -45,12 +45,12 @@
       <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
       <PackageReference Include="System.Security.Cryptography.OpenSsl" Version="5.0.0" />
       <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
-      <PackageReference Include="WatsonTcp" Version="5.1.7" />
+      <PackageReference Include="WatsonTcp" Version="6.0.5" />
       <PackageReference Include="websocketsharp.core" Version="1.0.0" />
     </ItemGroup>
     
     <ItemGroup>
       <Protobuf Include="**/*.proto" />
     </ItemGroup>
-
+    
 </Project>

--- a/CoreRemoting/Encryption/RsaKeyExchange.cs
+++ b/CoreRemoting/Encryption/RsaKeyExchange.cs
@@ -21,7 +21,7 @@ namespace CoreRemoting.Encryption
             using var receiversPublicKey = new RSACryptoServiceProvider(dwKeySize: keySize);
             receiversPublicKey.ImportCspBlob(receiversPublicKeyBlob);
             
-            using Aes aes = new AesCryptoServiceProvider();
+            using Aes aes = Aes.Create();
 
             // Encrypt the session key
             var keyFormatter = new RSAPKCS1KeyExchangeFormatter(receiversPublicKey);
@@ -53,7 +53,7 @@ namespace CoreRemoting.Encryption
             using var receiversPrivateKey = new RSACryptoServiceProvider(dwKeySize: keySize);
             receiversPrivateKey.ImportCspBlob(receiversPrivateKeyBlob);
 
-            using Aes aes = new AesCryptoServiceProvider();
+            using Aes aes = Aes.Create();
             aes.IV = encryptedSecret.Iv;
 
             // Decrypt the session key

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -758,6 +758,7 @@ namespace CoreRemoting
             catch (Exception)
             {
                 // ignored
+                // TODO: dispatch the exception
             }
 
             BeforeDispose?.Invoke();

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -750,9 +750,16 @@ namespace CoreRemoting
                     keyPair: _keyPair,
                     messageType: "session_closed");
 
-            _rawMessageTransport.SendMessage(
-                _server.Serializer.Serialize(wireMessage));
-            
+            try
+            {
+                _rawMessageTransport.SendMessage(
+                    _server.Serializer.Serialize(wireMessage));
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
             BeforeDispose?.Invoke();
             
             _keyPair?.Dispose();


### PR DESCRIPTION
If the client process crashes, then checking idle sessions will not be able to close the session, because the _rawMessageTransport.SendMessage call will throw an exception.