### PR TITLE
Remove RemotingSession in a separate task

### DIFF
--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -310,7 +310,7 @@ namespace CoreRemoting
             
             _rawMessageTransport.SendMessage(_server.Serializer.Serialize(resultMessage));
             
-            _server.SessionRepository.RemoveSession(_sessionId);
+            Task.Run(() => _server.SessionRepository.RemoveSession(_sessionId));
         }
 
         /// <summary>


### PR DESCRIPTION
to allow _currentlyProcessedMessagesCounter.Signal() to be executed, which we are waiting for in Dispose.