### PR TITLE
Fix a hang due to a WireMessage deserialization error.

### DIFF
--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -244,10 +244,10 @@ namespace CoreRemoting
                 
                 _currentlyProcessedMessagesCounter.AddCount(1);
                 
-                var message = _server.Serializer.Deserialize<WireMessage>(rawMessage);
-
                 try
                 {
+                    var message = _server.Serializer.Deserialize<WireMessage>(rawMessage);
+                    
                     switch (message.MessageType.ToLower())
                     {
                         case "auth":


### PR DESCRIPTION
If WireMessage deserialization occurs with an error, then the CountdownEvent increment is performed without a guaranteed decrement in the finally block.  Therefore, deserialization is included in the try block.