### PR TITLE
Running RpcTests on all supported channel

### DIFF
--- a/CoreRemoting.Tests/AsyncTests.cs
+++ b/CoreRemoting.Tests/AsyncTests.cs
@@ -11,6 +11,7 @@ namespace CoreRemoting.Tests
         public AsyncTests(ServerFixture serverFixture)
         {
             _serverFixture = serverFixture;
+            _serverFixture.Start();
         }
         
         [Fact]

--- a/CoreRemoting.Tests/CallContextTests.cs
+++ b/CoreRemoting.Tests/CallContextTests.cs
@@ -12,6 +12,7 @@ namespace CoreRemoting.Tests
         public CallContextTests(ServerFixture serverFixture)
         {
             _serverFixture = serverFixture;
+            _serverFixture.Start();
         }
         
         [Fact]

--- a/CoreRemoting.Tests/LinqExpressionTests.cs
+++ b/CoreRemoting.Tests/LinqExpressionTests.cs
@@ -11,6 +11,7 @@ namespace CoreRemoting.Tests
         public LinqExpressionTests(ServerFixture serverFixture)
         {
             _serverFixture = serverFixture;
+            _serverFixture.Start();
         }
         
         [Fact]

--- a/CoreRemoting.Tests/RemotingConfigurationTests.cs
+++ b/CoreRemoting.Tests/RemotingConfigurationTests.cs
@@ -12,7 +12,12 @@ using Xunit;
 namespace CoreRemoting.Tests
 {
     public class RemotingConfigurationTests : IClassFixture<ServerFixture>
-    {   
+    {
+        public RemotingConfigurationTests(ServerFixture serverFixture)
+        {
+            serverFixture.Start();
+        }
+
         [Fact]
         public void RegisterWellKnownServiceType_should_register_type_resolved_at_runtime()
         {

--- a/CoreRemoting.Tests/ReturnAsProxyTests.cs
+++ b/CoreRemoting.Tests/ReturnAsProxyTests.cs
@@ -17,6 +17,7 @@ namespace CoreRemoting.Tests
         {
             _serverFixture = serverFixture;
             _testOutputHelper = testOutputHelper;
+            _serverFixture.Start();
         }
         
         [Fact]

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using CoreRemoting.Channels;
 using CoreRemoting.Serialization;
 using CoreRemoting.Tests.ExternalTypes;
 using CoreRemoting.Tests.Tools;
@@ -18,6 +19,10 @@ namespace CoreRemoting.Tests
         private readonly ITestOutputHelper _testOutputHelper;
         private bool _remoteServiceCalled;
 
+        protected virtual IServerChannel ServerChannel => null;
+
+        protected virtual IClientChannel ClientChannel => null;
+
         public RpcTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
         {
             _serverFixture = serverFixture;
@@ -28,6 +33,8 @@ namespace CoreRemoting.Tests
                 _remoteServiceCalled = true;
                 return arg;
             };
+
+            _serverFixture.Start(ServerChannel);
         }
 
         [Fact]
@@ -44,7 +51,8 @@ namespace CoreRemoting.Tests
                     {
                         ConnectionTimeout = 0,
                         MessageEncryption = false,
-                        ServerPort = _serverFixture.Server.Config.NetworkPort
+                        Channel = ClientChannel,
+                        ServerPort = _serverFixture.Server.Config.NetworkPort,
                     });
 
                     stopWatch.Stop();
@@ -115,8 +123,9 @@ namespace CoreRemoting.Tests
                     using var client = new RemotingClient(new ClientConfig()
                     {
                         ConnectionTimeout = 0,
+                        Channel = ClientChannel,
                         ServerPort = _serverFixture.Server.Config.NetworkPort,
-                        MessageEncryption = true
+                        MessageEncryption = true,
                     });
 
                     stopWatch.Stop();
@@ -183,6 +192,7 @@ namespace CoreRemoting.Tests
                         new ClientConfig()
                         {
                             ConnectionTimeout = 0,
+                            Channel = ClientChannel,
                             MessageEncryption = false,
                             ServerPort = _serverFixture.Server.Config.NetworkPort,
                         });
@@ -218,6 +228,7 @@ namespace CoreRemoting.Tests
                 {
                     ConnectionTimeout = 0,
                     SendTimeout = 0,
+                    Channel = ClientChannel,
                     MessageEncryption = false,
                     ServerPort = _serverFixture.Server.Config.NetworkPort,
                 });
@@ -270,6 +281,7 @@ namespace CoreRemoting.Tests
                     using var client = new RemotingClient(new ClientConfig()
                     {
                         ConnectionTimeout = 0,
+                        Channel = ClientChannel,
                         MessageEncryption = false,
                         ServerPort = _serverFixture.Server.Config.NetworkPort,
                     });
@@ -302,6 +314,7 @@ namespace CoreRemoting.Tests
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
+                Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
@@ -320,6 +333,7 @@ namespace CoreRemoting.Tests
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
+                Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
@@ -338,6 +352,7 @@ namespace CoreRemoting.Tests
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
+                Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort
             });
@@ -360,6 +375,7 @@ namespace CoreRemoting.Tests
                 ConnectionTimeout = 0,
                 InvocationTimeout = 0,
                 SendTimeout = 0,
+                Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort
             });
@@ -395,6 +411,7 @@ namespace CoreRemoting.Tests
                 ConnectionTimeout = 0,
                 InvocationTimeout = 0,
                 SendTimeout = 0,
+                Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort
             });
@@ -419,6 +436,7 @@ namespace CoreRemoting.Tests
                     ConnectionTimeout = 5,
                     InvocationTimeout = 5,
                     SendTimeout = 5,
+                    Channel = ClientChannel,
                     MessageEncryption = false,
                     ServerPort = _serverFixture.Server.Config.NetworkPort
                 });
@@ -450,6 +468,7 @@ namespace CoreRemoting.Tests
                     ConnectionTimeout = 5,
                     InvocationTimeout = 5,
                     SendTimeout = 5,
+                    Channel = ClientChannel,
                     MessageEncryption = false,
                     ServerPort = _serverFixture.Server.Config.NetworkPort
                 });
@@ -481,6 +500,7 @@ namespace CoreRemoting.Tests
                     ConnectionTimeout = 5,
                     InvocationTimeout = 5,
                     SendTimeout = 5,
+                    Channel = ClientChannel,
                     MessageEncryption = false,
                     ServerPort = _serverFixture.Server.Config.NetworkPort
                 });
@@ -523,6 +543,7 @@ namespace CoreRemoting.Tests
                 {
                     RemotingClient CreateClient() => new RemotingClient(new ClientConfig()
                     {
+                        Channel = ClientChannel,
                         ServerPort = _serverFixture.Server.Config.NetworkPort,
                         MessageEncryption = encryption,
                     });
@@ -570,6 +591,7 @@ namespace CoreRemoting.Tests
                 ConnectionTimeout = 0,
                 InvocationTimeout = 0,
                 SendTimeout = 0,
+                Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
             });

--- a/CoreRemoting.Tests/RpcTests_WatsonTcp.cs
+++ b/CoreRemoting.Tests/RpcTests_WatsonTcp.cs
@@ -1,0 +1,18 @@
+using CoreRemoting.Channels;
+using CoreRemoting.Channels.Tcp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreRemoting.Tests
+{
+    public class RpcTests_WatsonTcp : RpcTests
+    {
+        protected override IServerChannel ServerChannel => new TcpServerChannel();
+
+        protected override IClientChannel ClientChannel => new TcpClientChannel();
+
+        public RpcTests_WatsonTcp(ServerFixture s, ITestOutputHelper h) : base(s, h)
+        {
+        }
+    }
+}

--- a/CoreRemoting.Tests/RpcTests_Websockets.cs
+++ b/CoreRemoting.Tests/RpcTests_Websockets.cs
@@ -1,0 +1,18 @@
+using CoreRemoting.Channels;
+using CoreRemoting.Channels.Websocket;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreRemoting.Tests
+{
+    public class RpcTests_Websockets : RpcTests
+    {
+        protected override IServerChannel ServerChannel => new WebsocketServerChannel();
+
+        protected override IClientChannel ClientChannel => new WebsocketClientChannel();
+
+        public RpcTests_Websockets(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
+        {
+        }
+    }
+}

--- a/CoreRemoting.Tests/ServerFixture.cs
+++ b/CoreRemoting.Tests/ServerFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using CoreRemoting.Channels;
 using CoreRemoting.DependencyInjection;
 using CoreRemoting.Tests.Tools;
 using Xunit;
@@ -14,7 +15,7 @@ public class ServerFixture : IDisposable
     {
         TestService = new TestService();
         
-        var serverConfig =
+        ServerConfig =
             new ServerConfig()
             {
                 UniqueServerInstanceName = "DefaultServer",
@@ -49,20 +50,31 @@ public class ServerFixture : IDisposable
                         lifetime: ServiceLifetime.Singleton);
                 }
             };
-            
-        Server = new RemotingServer(serverConfig);
-        
-        Server.Error += (_ , _)  =>
+    }
+
+    public void Start(IServerChannel channel = null)
+    {
+        if (Server != null)
+            return;
+
+        if (channel != null)
+            ServerConfig.Channel = channel;
+
+        Server = new RemotingServer(ServerConfig);
+        Server.Error += (_, _) =>
         {
             ServerErrorCount++;
         };
-        
+
         Server.Start();
     }
-    
-    public RemotingServer Server { get; }
+
+    public RemotingServer Server { get; private set;  }
+
+    public ServerConfig ServerConfig { get; set; }
+
     public TestService TestService { get; }
-    
+
     public void Dispose()
     {
         if (Server != null)

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -19,6 +19,7 @@ namespace CoreRemoting.Tests
         public SessionTests(ServerFixture serverFixture)
         {
             _serverFixture = serverFixture;
+            _serverFixture.Start();
         }
         
         [Fact]


### PR DESCRIPTION
Note: this pull request changes only the unit tests.

`RpcTests` currently test only default channel.
My proposal is to subclass `RpcTests` to test Tcp and Websocket channels explicitly.
With this change it should be easier to test alternative channels such as System.Net.Websockets or QUIC.

Example:
```csharp
public class RpcTests_Websockets : RpcTests
{
    protected override IServerChannel ServerChannel => new WebsocketServerChannel();

    protected override IClientChannel ClientChannel => new WebsocketClientChannel();

    public RpcTests_Websockets(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
    {
    }
}
```