### PR TITLE
Experimental QUIC channel (.NET 9-only)

### DIFF
--- a/CoreRemoting.Channels.Quic/CertificateHelper.cs
+++ b/CoreRemoting.Channels.Quic/CertificateHelper.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace CoreRemoting.Channels.Quic;
+
+internal class CertificateHelper
+{
+    public static X509Certificate2 LoadFromPfx(string pfxFilePath, string pfxPassword) =>
+        X509CertificateLoader.LoadPkcs12FromFile(pfxFilePath, pfxPassword);
+
+    public static X509Certificate2 GenerateSelfSigned(string hostName = "localhost")
+    {
+        // generate a new certificate
+        var now = DateTimeOffset.UtcNow;
+        SubjectAlternativeNameBuilder sanBuilder = new();
+        sanBuilder.AddDnsName(hostName);
+
+        using var ec = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        CertificateRequest req = new($"CN={hostName}", ec, HashAlgorithmName.SHA256);
+
+        // Adds purpose
+        req.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection
+        {
+            new("1.3.6.1.5.5.7.3.1") // serverAuth
+		},
+        false));
+
+        // Adds usage
+        req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false));
+
+        // Adds subject alternate names
+        req.CertificateExtensions.Add(sanBuilder.Build());
+
+        // Sign
+        using var crt = req.CreateSelfSigned(now, now.AddDays(14)); // 14 days is the max duration of a certificate for this type
+
+        var password = Guid.NewGuid().ToString();
+        var pfx = crt.Export(X509ContentType.Pfx, password);
+        var cert = X509CertificateLoader.LoadPkcs12(pfx, password);
+        return cert;
+    }
+}

--- a/CoreRemoting.Channels.Quic/CoreRemoting.Channels.Quic.csproj
+++ b/CoreRemoting.Channels.Quic/CoreRemoting.Channels.Quic.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0.0</TargetFramework>
+	<RootNamespace>CoreRemoting.Channels.Quic</RootNamespace>
+	<AssemblyName>CoreRemoting.Channels.Quic</AssemblyName>
+	<PackageVersion>1.2.1</PackageVersion>
+	<Authors>Alexey Yakovlev</Authors>
+	<Description>Quic channels for CoreRemoting</Description>
+	<Copyright>2024 Alexey Yakovlev</Copyright>
+	<PackageProjectUrl>https://github.com/theRainbird/CoreRemoting</PackageProjectUrl>
+	<PackageLicenseUrl></PackageLicenseUrl>
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<Title>CoreRemoting.Channels.Quic</Title>
+	<RepositoryUrl>https://github.com/theRainbird/CoreRemoting.git</RepositoryUrl>
+	<RepositoryType>git</RepositoryType>
+	<AssemblyVersion>1.2.1</AssemblyVersion>
+	<LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CA1416</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1416</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CoreRemoting\CoreRemoting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CoreRemoting.Channels.Quic/QuicClientChannel.cs
+++ b/CoreRemoting.Channels.Quic/QuicClientChannel.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Channels.Quic;
+
+/// <summary>
+/// Client side QUIC channel implementation based on System.Net.Quic.
+/// </summary>
+public class QuicClientChannel : IClientChannel, IRawMessageTransport
+{
+    internal const int MaxMessageSize = 1024 * 1024 * 128;
+    internal const string ProtocolName = nameof(CoreRemoting);
+
+    /// <summary>
+    /// Gets or sets the URL this channel is connected to.
+    /// </summary>
+    public string Url { get; private set; }
+
+    private Uri Uri { get; set; }
+
+    private IRemotingClient Client { get; set; }
+
+    private QuicClientConnectionOptions Options { get; set; }
+
+    private QuicConnection Connection { get; set; }
+
+    private QuicStream ClientStream { get; set; }
+
+    private BinaryReader ClientReader { get; set; }
+
+    private BinaryWriter ClientWriter { get; set; }
+
+    /// <inheritdoc />
+    public bool IsConnected { get; private set; }
+
+    /// <inheritdoc />
+    public IRawMessageTransport RawMessageTransport => this;
+
+    /// <inheritdoc />
+    public NetworkException LastException { get; set; }
+
+    /// <summary>
+    /// Event: fires when the channel is connected.
+    /// </summary>
+    public event Action Connected;
+
+    /// <inheritdoc />
+    public event Action Disconnected;
+
+    /// <inheritdoc />
+    public event Action<byte[]> ReceiveMessage;
+
+    /// <inheritdoc />
+    public event Action<string, Exception> ErrorOccured;
+
+    /// <inheritdoc />
+    public void Init(IRemotingClient client)
+    {
+        Client = client ?? throw new ArgumentNullException(nameof(client));
+        if (!QuicConnection.IsSupported)
+            throw new NotSupportedException("QUIC is not supported.");
+
+        Url =
+            "quic://" +
+            client.Config.ServerHostName + ":" +
+            Convert.ToString(client.Config.ServerPort) +
+            "/rpc";
+
+        Uri = new Uri(Url);
+
+        // prepare QUIC client connection options
+        Options = new QuicClientConnectionOptions
+        {
+            RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, Uri.Port), //new DnsEndPoint(Uri.Host, Uri.Port),
+            DefaultStreamErrorCode = 0x0A,
+            DefaultCloseErrorCode = 0x0B,
+            MaxInboundUnidirectionalStreams = 10,
+            MaxInboundBidirectionalStreams = 100,
+            ClientAuthenticationOptions = new SslClientAuthenticationOptions()
+            {
+                // accept self-signed certificates generated on-the-fly
+                RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true,
+                ApplicationProtocols = new List<SslApplicationProtocol>()
+                {
+                    new SslApplicationProtocol(ProtocolName)
+                }
+            }
+        };
+    }
+
+    /// <inheritdoc />
+    public void Connect()
+    {
+        ConnectTask = ConnectTask ?? Task.Factory.StartNew(async () =>
+        {
+            // connect and open duplex stream
+            Connection = await QuicConnection.ConnectAsync(Options);
+            ClientStream = await Connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+            ClientReader = new BinaryReader(ClientStream, Encoding.UTF8, leaveOpen: true);
+            ClientWriter = new BinaryWriter(ClientStream, Encoding.UTF8, leaveOpen: true);
+
+            // prepare handshake message
+            var handshakeMessage = Array.Empty<byte>();
+            if (Client.MessageEncryption)
+            {
+                handshakeMessage = Client.PublicKey;
+            }
+
+            // send handshake message
+            SendMessage(handshakeMessage);
+            IsConnected = true;
+            Connected?.Invoke();
+
+            // start listening for incoming messages
+            _ = Task.Factory.StartNew(() => StartListening());
+        });
+
+        ConnectTask.ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    private Task ConnectTask { get; set; }
+
+    private void StartListening()
+    {
+        try
+        {
+            while (IsConnected)
+            {
+                var messageSize = ClientReader.Read7BitEncodedInt();
+                var message = ClientReader.ReadBytes(Math.Min(messageSize, MaxMessageSize));
+                if (message.Length > 0)
+                {
+                    ReceiveMessage(message);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            ErrorOccured?.Invoke(ex.Message, ex);
+            Disconnected?.Invoke();
+        }
+        finally
+        {
+            Disconnect();
+        }
+    }
+
+    /// <inheritdoc />
+    public bool SendMessage(byte[] rawMessage)
+    {
+        try
+        {
+            if (rawMessage.Length > MaxMessageSize)
+                throw new InvalidOperationException("Message is too large. Max size: " +
+                    MaxMessageSize + ", actual size: " + rawMessage.Length);
+
+            // message length + message body
+            ClientWriter.Write7BitEncodedInt(rawMessage.Length);
+            ClientWriter.Write(rawMessage, 0, rawMessage.Length);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            ErrorOccured?.Invoke(ex.Message, ex);
+            return false;
+        }
+    }
+
+    private Task DisconnectTask { get; set; }
+
+    /// <inheritdoc />
+    public void Disconnect()
+    {
+        DisconnectTask = DisconnectTask ?? Task.Factory.StartNew(async () =>
+        {
+            await Connection.CloseAsync(0x0C);
+            IsConnected = false;
+            Disconnected?.Invoke();
+        });
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Connection == null)
+            return;
+
+        if (IsConnected)
+            Disconnect();
+
+        var task = DisconnectTask;
+        if (task != null)
+            task.ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+
+        Connection.DisposeAsync()
+            .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+        Connection = null;
+
+        // clean up readers/writers
+        ClientReader.Dispose();
+        ClientReader = null;
+        ClientWriter.Dispose();
+        ClientWriter = null;
+    }
+}

--- a/CoreRemoting.Channels.Quic/QuicServerChannel.cs
+++ b/CoreRemoting.Channels.Quic/QuicServerChannel.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Channels.Quic;
+
+/// <summary>
+/// Server side QUIC channel implementation based on System.Net.Quic.
+/// </summary>
+public class QuicServerChannel : IServerChannel
+{
+    private IRemotingServer Server { get; set; }
+
+    private ConcurrentDictionary<Guid, QuicServerConnection> Connections { get; } =
+        new ConcurrentDictionary<Guid, QuicServerConnection>();
+
+    /// <inheritdoc/>
+    public bool IsListening { get; private set; }
+
+    private QuicServerConnectionOptions Options { get; set; }
+
+    private QuicListener Listener { get; set; }
+
+    private IPEndPoint ListenEndPoint { get; set; }
+
+    /// <inheritdoc/>
+    public void Init(IRemotingServer server)
+    {
+        Server = server ?? throw new ArgumentNullException(nameof(server));
+        if (!QuicListener.IsSupported)
+            throw new NotSupportedException("QUIC is not supported.");
+
+        var url = "quic://" +
+            Server.Config.HostName + ":" +
+            Server.Config.NetworkPort + "/rpc";
+
+        // validate URL and create listener endpoint
+        var uri = new Uri(url);
+        var certificate = CertificateHelper.GenerateSelfSigned(uri.DnsSafeHost);
+        ListenEndPoint = new IPEndPoint(IPAddress.Loopback, uri.Port); // TODO: Loopback
+
+        Options = new QuicServerConnectionOptions()
+        {
+            DefaultStreamErrorCode = 0x0A,
+            DefaultCloseErrorCode = 0x0B,
+            ServerAuthenticationOptions = new SslServerAuthenticationOptions
+            {
+                ServerCertificate = certificate,
+                ApplicationProtocols = new List<SslApplicationProtocol>()
+                {
+                    new SslApplicationProtocol(QuicClientChannel.ProtocolName)
+                },
+            }
+        };
+    }
+
+    /// <inheritdoc/>
+    public void StartListening()
+    {
+        _ = Task.Factory.StartNew(async () =>
+        {
+            // start the listener
+            Listener = await QuicListener.ListenAsync(new QuicListenerOptions()
+            {
+                ListenEndPoint = ListenEndPoint,
+                ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(Options),
+                ApplicationProtocols = new List<SslApplicationProtocol>()
+                {
+                    new SslApplicationProtocol(QuicClientChannel.ProtocolName)
+                },
+            });
+
+            // accept incoming connections
+            IsListening = true;
+            while (IsListening)
+            {
+                try
+                {
+                    var connection = await Listener.AcceptConnectionAsync();
+                    var stream = await connection.AcceptInboundStreamAsync();
+                    var session = new QuicServerConnection(connection, stream, Server);
+                    var sessionId = session.StartListening();
+                    Connections[sessionId] = session;
+                }
+                catch
+                {
+                    IsListening = false; // TODO: not sure??
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public void StopListening()
+    {
+        if (Listener != null && IsListening)
+        {
+            IsListening = false;
+            Listener.DisposeAsync()
+                .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        StopListening();
+        Listener = null;
+    }
+}

--- a/CoreRemoting.Channels.Quic/QuicServerConnection.cs
+++ b/CoreRemoting.Channels.Quic/QuicServerConnection.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.IO;
+using System.Net.Quic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Channels.Quic;
+
+/// <summary>
+/// Quic server-side connection.
+/// </summary>
+public class QuicServerConnection : IRawMessageTransport
+{
+    private const int MaxMessageSize = QuicClientChannel.MaxMessageSize;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuicServerConnection"/> class.
+    /// </summary>
+    public QuicServerConnection(QuicConnection connection, QuicStream stream, IRemotingServer remotingServer)
+    {
+        Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        ClientStream = stream ?? throw new ArgumentNullException(nameof(stream));
+        RemotingServer = remotingServer ?? throw new ArgumentNullException(nameof(remotingServer));
+        ClientReader = new BinaryReader(stream, Encoding.UTF8, true);
+        ClientWriter = new BinaryWriter(stream, Encoding.UTF8, true);
+    }
+
+    private QuicConnection Connection { get; set; }
+
+    private QuicStream ClientStream { get; set; }
+
+    private BinaryReader ClientReader { get; set; }
+
+    private BinaryWriter ClientWriter { get; set; }
+
+    private IRemotingServer RemotingServer { get; set; }
+
+    private RemotingSession Session { get; set; }
+
+    /// <inheritdoc/>
+    public NetworkException LastException { get; set; }
+
+    /// <inheritdoc/>
+    public event Action<byte[]> ReceiveMessage;
+
+    /// <inheritdoc/>
+    public event Action<string, Exception> ErrorOccured;
+
+    /// <summary>
+    /// Event: fires when a web socket is disconnected.
+    /// </summary>
+    public event Action Disconnected;
+
+    /// <inheritdoc/>
+    public bool SendMessage(byte[] rawMessage)
+    {
+        try
+        {
+            if (rawMessage.Length > MaxMessageSize)
+                throw new InvalidOperationException("Message is too large. Max size: " +
+                    MaxMessageSize + ", actual size: " + rawMessage.Length);
+
+            // message length + message body
+            ClientWriter.Write7BitEncodedInt(rawMessage.Length);
+            ClientWriter.Write(rawMessage, 0, rawMessage.Length);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            ErrorOccured?.Invoke(ex.Message, ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Starts listening to the incoming messages.
+    /// </summary>
+    public Guid StartListening()
+    {
+        var sessionId = CreateRemotingSession();
+        _ = Task.Factory.StartNew(() => ReadIncomingMessages());
+        return sessionId;
+    }
+
+    /// <summary>
+    /// Creates <see cref="RemotingSession"/> for the incoming QUIC connection.
+    /// </summary>
+    private Guid CreateRemotingSession()
+    {
+        // read handshake message
+        var clientPublicKey = ReadIncomingMessage();
+
+        // disable message encryption if handshake is empty
+        if (clientPublicKey != null && clientPublicKey.Length == 0)
+            clientPublicKey = null;
+
+        Session = RemotingServer.SessionRepository.CreateSession(
+            clientPublicKey, RemotingServer, this);
+
+        return Session.SessionId;
+    }
+
+    private byte[] ReadIncomingMessage()
+    {
+        var messageSize = ClientReader.Read7BitEncodedInt();
+        return ClientReader.ReadBytes(Math.Min(messageSize, MaxMessageSize));
+    }
+
+    private void ReadIncomingMessages()
+    {
+        try
+        {
+            while (true)
+            {
+                var message = ReadIncomingMessage();
+                if (message != null && message.Length > 0)
+                {
+                    // flush received QUIC message
+                    ReceiveMessage(message);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            ErrorOccured?.Invoke(ex.Message, LastException);
+            Disconnected?.Invoke();
+        }
+        finally
+        {
+            Connection?.DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Connection = null;
+        }
+    }
+}

--- a/CoreRemoting.Tests/Tools/ITestService.cs
+++ b/CoreRemoting.Tests/Tools/ITestService.cs
@@ -38,5 +38,7 @@ namespace CoreRemoting.Tests.Tools
         void NonSerializableError(string text, params object[] data);
 
         DataTable TestDt(DataTable dt, long num);
+
+        (T duplicate, int size) Duplicate<T>(T sample) where T : class;
     }
 }

--- a/CoreRemoting.Tests/Tools/TestService.cs
+++ b/CoreRemoting.Tests/Tools/TestService.cs
@@ -99,5 +99,24 @@ namespace CoreRemoting.Tests.Tools
             dt.Rows.Clear();
             return dt;
         }
+
+        public (T, int) Duplicate<T>(T sample) where T : class
+        {
+            return sample switch
+            {
+                byte[] arr => (Dup(arr) as T, arr.Length * 2),
+                int[] iarr => (Dup(iarr) as T, iarr.Length * 2 * sizeof(int)),
+                string str => ((str + str) as T, str.Length * 2 * sizeof(char)),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+
+            TItem[] Dup<TItem>(TItem[] arr)
+            {
+                var length = arr.Length;
+                Array.Resize(ref arr, length * 2);
+                Array.Copy(arr, 0, arr, length, length);
+                return arr;
+            }
+        }
     }
 }


### PR DESCRIPTION
Added sketch channel based on QUIC network protocol (requires .NET 9.0).
QUIC is a fast reliable UDP-based protocol developed by Google as a foundation for HTTP/3.
It includes built-in TLS 1.3 layer and solves a few TCP performance issues.

Docs: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview
Wikipedia article: https://en.wikipedia.org/wiki/QUIC

The project is not included in the solution, currently for testing only.
Doesn't support anything but localhost connections.
The speed is roughly the same as websockets based on HttpListener:

![image](https://github.com/user-attachments/assets/f09377ab-4c0f-47ea-8f92-5fd42b025f73)

The unit tests are not included, but they are trivial to add, i.e.:

```csharp
using CoreRemoting.Channels;
using CoreRemoting.Channels.Quic;
namespace CoreRemoting.Tests;

public class RpcTests_Quic : RpcTests
{
    protected override IServerChannel ServerChannel => new QuicServerChannel();

    protected override IClientChannel ClientChannel => new QuicClientChannel();

    public RpcTests_Quic(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
    {
    }
}
```