### PR TITLE
RemotingSession.Current is null in the component constructor

### DIFF
--- a/CoreRemoting.Tests/ServerFixture.cs
+++ b/CoreRemoting.Tests/ServerFixture.cs
@@ -49,8 +49,12 @@ public class ServerFixture : IDisposable
                     container.RegisterService<IEnumTestService, EnumTestService>(
                         lifetime: ServiceLifetime.Singleton);
 
-                    // Service for session tests
+                    // Failing constructor service
                     container.RegisterService<IFailingService, FailingService>(
+                        lifetime: ServiceLifetime.SingleCall);
+
+                    // Service for session tests
+                    container.RegisterService<ISessionAwareService, SessionAwareService>(
                         lifetime: ServiceLifetime.SingleCall);
                 }
             };

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -21,7 +21,7 @@ namespace CoreRemoting.Tests
             _serverFixture = serverFixture;
             _serverFixture.Start();
         }
-
+        
         [Fact]
         public void Client_Connect_should_create_new_session_AND_Disconnect_should_close_session()
         {
@@ -54,7 +54,7 @@ namespace CoreRemoting.Tests
 
                 client.Dispose();
             });
-
+            
             var clientThread1 = new Thread(() => clientAction(0));
             var clientThread2 = new Thread(() => clientAction(1));
 
@@ -94,7 +94,7 @@ namespace CoreRemoting.Tests
                         AuthenticateFake = credentials => credentials[1].Value == "secret"
                     }
                 };
-
+            
             var server = new RemotingServer(serverConfig);
             server.Start();
 
@@ -102,7 +102,7 @@ namespace CoreRemoting.Tests
             {
                 var clientAction = new Action<string, bool>((password, shouldThrow) =>
                 {
-                    using var client =
+                    using var client = 
                         new RemotingClient(new ClientConfig()
                         {
                             ConnectionTimeout = 0,
@@ -114,7 +114,7 @@ namespace CoreRemoting.Tests
                                 new Credential() {Name = "Password", Value = password }
                             }
                         });
-
+                
                     if (shouldThrow)
                         Assert.Throws<SecurityException>(() => client.Connect());
                     else
@@ -124,7 +124,7 @@ namespace CoreRemoting.Tests
                 var clientThread1 = new Thread(() => clientAction("wrong", true));
                 clientThread1.Start();
                 clientThread1.Join();
-
+            
                 var clientThread2 = new Thread(() => clientAction("secret", false));
                 clientThread2.Start();
                 clientThread2.Join();
@@ -161,7 +161,7 @@ namespace CoreRemoting.Tests
             {
                 waitForDisconnect.Set();
             };
-
+            
             client.Connect();
             var proxy = client.CreateProxy<ITestService>();
 
@@ -169,8 +169,29 @@ namespace CoreRemoting.Tests
 
             waitForDisconnect.Wait();
             Assert.False(client.IsConnected);
-
+            
             client.Dispose();
+        }
+
+        [Fact]
+        public void RemotingSession_should_be_accessible_to_the_component_constructor()
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            // RemotingSession.Current should be accessible to the component constructor
+            var proxy = client.CreateProxy<ISessionAwareService>();
+
+            // RemotingSession should be the same as in the constructor
+            Assert.True(proxy.HasSameSessionInstance);
         }
     }
 }

--- a/CoreRemoting.Tests/Tools/ISessionAwareService.cs
+++ b/CoreRemoting.Tests/Tools/ISessionAwareService.cs
@@ -1,0 +1,7 @@
+﻿namespace CoreRemoting.Tests.Tools
+{
+    public interface ISessionAwareService
+    {
+        bool HasSameSessionInstance { get; }
+    }
+}

--- a/CoreRemoting.Tests/Tools/SessionAwareService.cs
+++ b/CoreRemoting.Tests/Tools/SessionAwareService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace CoreRemoting.Tests.Tools
+{
+    internal class SessionAwareService : ISessionAwareService
+    {
+        public SessionAwareService()
+        {
+            CurrentSession = RemotingSession.Current;
+            if (CurrentSession == null)
+                throw new ArgumentNullException(nameof(CurrentSession));
+        }
+
+        public RemotingSession CurrentSession { get; }
+
+        public bool HasSameSessionInstance =>
+            ReferenceEquals(CurrentSession, RemotingSession.Current);
+    }
+}

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -425,6 +425,8 @@ namespace CoreRemoting
 
             try
             {
+                CurrentSession.Value = this;
+
                 var service = _server.ServiceRegistry.GetService(callMessage.ServiceName);
                 var serviceInterfaceType =
                     _server.ServiceRegistry.GetServiceInterfaceType(callMessage.ServiceName);
@@ -462,6 +464,10 @@ namespace CoreRemoting
 
                 serializedResult =
                     _server.Serializer.Serialize(serverRpcContext.Exception);
+            }
+            finally
+            {
+                CurrentSession.Value = null;
             }
 
             object result = null;


### PR DESCRIPTION
Single-call server component doesn't see the current remote user's session in its constructor, see #87.