### PR TITLE
Add net8.0 as separate target framework in example and tests #79

### DIFF
--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="xunit" Version="2.5.1" />

--- a/Examples/HelloWorld/HelloWorld.Client/HelloWorld.Client.csproj
+++ b/Examples/HelloWorld/HelloWorld.Client/HelloWorld.Client.csproj
@@ -2,9 +2,14 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\CoreRemoting\CoreRemoting.csproj" />

--- a/Examples/HelloWorld/HelloWorld.Server/HelloWorld.Server.csproj
+++ b/Examples/HelloWorld/HelloWorld.Server/HelloWorld.Server.csproj
@@ -2,9 +2,14 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\CoreRemoting\CoreRemoting.csproj" />


### PR DESCRIPTION
With the release of .NET 9 a few weeks back, the automatic ability to run CoreRemoting on .NET 8 and later versions was disabled. It is necessary to explicitly give permission to binary formatter serialization, and to use the latest *System.Runtime.Serialization.Formatters* NuGet package when using CoreRemoting on .NET 8 and later.

This PR has added .NET 8 as an alternative target framework in the *Hello World* example and unit tests.

The issue was reported as #79 .