### PR TITLE
Update Github Actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
     - name: Checkout source

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 10
 
     steps:
     - name: Checkout source

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -1,10 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
+
+    <!-- Exclude the unnecessary tests to save Github Actions time -->
+    <!-- WatsonTcp is the default channel, WebSocketSharp is optional -->
+    <ItemGroup>
+      <Compile Remove="RpcTests_WatsonTcp.cs" />
+      <Compile Remove="RpcTests_WebsocketSharp.cs" />
+      <Compile Remove="RpcTests_WsClientWsharpServer.cs" />
+      <Compile Remove="RpcTests_WsharpClientWsServer.cs" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />


### PR DESCRIPTION
1. CodeQL v1 is deprecated, replaced with v2
2. Disabled WebSocketSharp tests and duplicate WatsonTcp tests to save some Github Actions time.