### PR TITLE
Added the unit tests for the BeforeCall and AfterCall events.

### DIFF
--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -555,7 +555,8 @@ namespace CoreRemoting
                                 returnValue: result);
                 }
 
-                ((RemotingServer)_server).OnAfterCall(serverRpcContext);
+                if (serverRpcContext.Exception == null)
+                    ((RemotingServer)_server).OnAfterCall(serverRpcContext);
 
                 if (oneWay)
                     return;


### PR DESCRIPTION
AfterCall event is triggered twice on errors:

![image](https://github.com/user-attachments/assets/db2b9f7f-3328-4a14-920a-07e21d31366a)
