### PR TITLE
Fix missing ConfigureAwait(false) calls

### DIFF
--- a/CoreRemoting.Tests/AsyncTests.cs
+++ b/CoreRemoting.Tests/AsyncTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CoreRemoting.Tests.Tools;
 using Xunit;
 
@@ -13,8 +14,9 @@ namespace CoreRemoting.Tests
             _serverFixture = serverFixture;
             _serverFixture.Start();
         }
-        
+
         [Fact]
+        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
         public async void AsyncMethods_should_work()
         {
             using var client = new RemotingClient(new ClientConfig()
@@ -34,9 +36,10 @@ namespace CoreRemoting.Tests
         }
 
         /// <summary>
-        /// Awaiting for ordinary non-generic task method should not hangs. 
+        /// Awaiting for ordinary non-generic task method should not hangs.
         /// </summary>
         [Fact(Timeout = 15000)]
+        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
         public async void AwaitingNonGenericTask_should_not_hang_forever()
         {
             using var client = new RemotingClient(new ClientConfig()

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -25,8 +25,11 @@ namespace CoreRemoting.Tests
         }
         
         [Fact]
+        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
         public async Task Client_Connect_should_create_new_session_AND_Disconnect_should_close_session()
         {
+            using var ctx = ValidationSyncContext.Install();
+
             var clientStarted1 = new TaskCompletionSource();
             var clientStarted2 = new TaskCompletionSource();
             var clientStopSignal = new TaskCompletionSource();
@@ -46,7 +49,7 @@ namespace CoreRemoting.Tests
                 connected.TrySetResult();
                 Assert.True(client.HasSession);
 
-                await clientStopSignal.Task;
+                await clientStopSignal.Task.ConfigureAwait(false);
                 client.Dispose();
             }
 
@@ -58,13 +61,13 @@ namespace CoreRemoting.Tests
             var client2 = ClientTask(clientStarted2);
 
             // Wait for connection of both clients
-            await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(1);
+            await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(1).ConfigureAwait(false);
 
             Assert.Equal(2, _serverFixture.Server.SessionRepository.Sessions.Count());
 
             clientStopSignal.TrySetResult();
 
-            await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(1);
+            await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(1).ConfigureAwait(false);
 
             // There should be no sessions left, after both clients disconnected
             Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
@@ -73,6 +76,8 @@ namespace CoreRemoting.Tests
         [Fact]
         public void Client_Connect_should_throw_exception_on_invalid_auth_credentials()
         {
+            using var ctx = ValidationSyncContext.Install();
+
             var serverConfig =
                 new ServerConfig()
                 {
@@ -138,6 +143,8 @@ namespace CoreRemoting.Tests
                 return null;
             };
 
+            using var ctx = ValidationSyncContext.Install();
+
             var client =
                 new RemotingClient(new ClientConfig()
                 {
@@ -168,6 +175,8 @@ namespace CoreRemoting.Tests
         [Fact]
         public void RemotingSession_should_be_accessible_to_the_component_constructor()
         {
+            using var ctx = ValidationSyncContext.Install();
+
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,

--- a/CoreRemoting.Tests/Tools/TestService.cs
+++ b/CoreRemoting.Tests/Tools/TestService.cs
@@ -78,7 +78,7 @@ namespace CoreRemoting.Tests.Tools
 
         public async Task ErrorAsync(string text)
         {
-            await Task.Delay(1);
+            await Task.Delay(1).ConfigureAwait(false);
             Error(text);
         }
 

--- a/CoreRemoting.Tests/Tools/ValidationSyncContext.cs
+++ b/CoreRemoting.Tests/Tools/ValidationSyncContext.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using CoreRemoting.Toolbox;
+using Xunit;
+
+namespace CoreRemoting.Tests.Tools
+{
+    /// <summary>
+    /// Synchronization context for validating the ConfigureAwait usage across the library.
+    /// The idea is that if ConfigureAwait(false) is missing somewhere, then the continuation
+    /// is posted to the current synchronization context and can be detected automatically.
+    /// 
+    /// Post or Send methods are called on the worker threads and the exceptions will be lost.
+    /// But Dispose is called on the main thread, so it can throw, and the exception will be
+    /// detected and reported by the unit test runner.
+    /// 
+    /// References:
+    /// 1. https://btburnett.com/2016/04/testing-an-sdk-for-asyncawait-synchronizationcontext-deadlocks.html
+    /// 2. https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
+    /// </summary>
+    public class ValidationSyncContext : SynchronizationContext, IDisposable
+    {
+        private ConcurrentDictionary<int, (string method, StackTrace trace)> errors = new();
+
+        public void Dispose()
+        {
+            if (errors.Any())
+            {
+                var message = "Post or Send methods were called " + errors.Count + " times.";
+                Console.WriteLine(message);
+                foreach (var pair in errors)
+                {
+                    Console.WriteLine("====================");
+                    Console.WriteLine($"{pair.Value.method}");
+                    Console.WriteLine("====================");
+                    Console.WriteLine($"{pair.Value.trace}");
+                }
+
+                Assert.Fail(message);
+            }
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            errors.GetOrAdd(errors.Count, c => (nameof(Post), new StackTrace()));
+
+            base.Post(d, state);
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            errors.GetOrAdd(errors.Count, c => (nameof(Send), new StackTrace()));
+
+            base.Send(d, state);
+        }
+
+        public static IDisposable UseSyncContext(SynchronizationContext ctx)
+        {
+            var oldSyncContext = Current;
+            SetSynchronizationContext(ctx);
+            
+            return Disposable.Create(() =>
+            {
+                SetSynchronizationContext(oldSyncContext);
+                if (ctx is IDisposable disposable)
+                    disposable.Dispose();
+            });
+        }
+
+        public static IDisposable Install() =>
+            UseSyncContext(new ValidationSyncContext());
+    }
+}

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -277,13 +277,13 @@ namespace CoreRemoting
                 switch (message.MessageType.ToLower())
                 {
                     case "auth":
-                        await ProcessAuthenticationRequestMessage(message);
+                        await ProcessAuthenticationRequestMessage(message).ConfigureAwait(false);
                         break;
                     case "rpc":
-                        await ProcessRpcMessage(message);
+                        await ProcessRpcMessage(message).ConfigureAwait(false);
                         break;
                     case "goodbye":
-                        await ProcessGoodbyeMessage(message);
+                        await ProcessGoodbyeMessage(message).ConfigureAwait(false);
                         break;
                     default:
                         OnErrorOccured("Invalid message type " + message.MessageType + ".", ex: null);

--- a/CoreRemoting/Toolbox/TaskExtensions.cs
+++ b/CoreRemoting/Toolbox/TaskExtensions.cs
@@ -22,7 +22,7 @@ public static class TaskExtensions
     public static async Task<T> Timeout<T>(this Task<T> task, double secTimeout, Action throwAction)
     {
         if (secTimeout <= 0)
-            return await task;
+            return await task.ConfigureAwait(false);
 
         var delay = Task.Delay(TimeSpan.FromSeconds(secTimeout));
         var result = await Task.WhenAny(task, delay).ConfigureAwait(false);
@@ -46,7 +46,7 @@ public static class TaskExtensions
     {
         if (secTimeout <= 0)
         {
-            await task;
+            await task.ConfigureAwait(false);
             return;
         }
 


### PR DESCRIPTION
Added validation synchronization context to the unit tests to fix missing ConfigureAwait(false) calls.

Based on idea from this blog post: 
https://btburnett.com/2016/04/testing-an-sdk-for-asyncawait-synchronizationcontext-deadlocks.html

Deadlock issue explanation: 
https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
