### PR TITLE
Calling CloseSession via a RPC call

### DIFF
--- a/CoreRemoting.Tests/BinarySerializationTests.cs
+++ b/CoreRemoting.Tests/BinarySerializationTests.cs
@@ -4,63 +4,62 @@ using CoreRemoting.Serialization.Binary;
 using CoreRemoting.Tests.Tools;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class BinarySerializationTests
 {
-    public class BinarySerializationTests
+    [Fact]
+    public void BinarySerializerAdapter_should_deserialize_MethodCallMessage()
     {
-        [Fact]
-        public void BinarySerializerAdapter_should_deserialize_MethodCallMessage()
-        {
-            var serializer = new BinarySerializerAdapter();
-            var testServiceInterfaceType = typeof(ITestService);
-            
-            var messageBuilder = new MethodCallMessageBuilder();
+        var serializer = new BinarySerializerAdapter();
+        var testServiceInterfaceType = typeof(ITestService);
+        
+        var messageBuilder = new MethodCallMessageBuilder();
 
-            var message =
-                messageBuilder.BuildMethodCallMessage(
-                    serializer,
-                    testServiceInterfaceType.Name,
-                    testServiceInterfaceType.GetMethod("TestMethod"),
-                    new object[] { 4711});
+        var message =
+            messageBuilder.BuildMethodCallMessage(
+                serializer,
+                testServiceInterfaceType.Name,
+                testServiceInterfaceType.GetMethod("TestMethod"),
+                new object[] { 4711});
 
-            var rawData = serializer.Serialize(message);
-            
-            var deserializedMessage = serializer.Deserialize<MethodCallMessage>(rawData);
-            
-            deserializedMessage.UnwrapParametersFromDeserializedMethodCallMessage(
-                out var parameterValues,
-                out var parameterTypes);
+        var rawData = serializer.Serialize(message);
+        
+        var deserializedMessage = serializer.Deserialize<MethodCallMessage>(rawData);
+        
+        deserializedMessage.UnwrapParametersFromDeserializedMethodCallMessage(
+            out var parameterValues,
+            out var parameterTypes);
 
-            var parametersLength = deserializedMessage.Parameters.Length;
-            
-            Assert.Equal(1, parametersLength);
-            Assert.NotNull(deserializedMessage.Parameters[0]);
-            Assert.Equal("arg", deserializedMessage.Parameters[0].ParameterName);
-            Assert.StartsWith("System.Object,", deserializedMessage.Parameters[0].ParameterTypeName);
-            Assert.Equal(typeof(int), parameterValues[0].GetType());
-            Assert.Equal(typeof(object), parameterTypes[0]);
-            Assert.Equal(4711, parameterValues[0]);
-        }
+        var parametersLength = deserializedMessage.Parameters.Length;
+        
+        Assert.Equal(1, parametersLength);
+        Assert.NotNull(deserializedMessage.Parameters[0]);
+        Assert.Equal("arg", deserializedMessage.Parameters[0].ParameterName);
+        Assert.StartsWith("System.Object,", deserializedMessage.Parameters[0].ParameterTypeName);
+        Assert.Equal(typeof(int), parameterValues[0].GetType());
+        Assert.Equal(typeof(object), parameterTypes[0]);
+        Assert.Equal(4711, parameterValues[0]);
+    }
 
-        [Fact]
-        public void BinarySerializerAdapter_should_deserialize_CompleteHandshakeWireMessage()
-        {
-            var sessionId = Guid.NewGuid();
-            
-            var completeHandshakeMessage =
-                new WireMessage
-                {
-                    MessageType = "complete_handshake",
-                    Data = sessionId.ToByteArray()
-                };   
-            
-            var serializer = new BinarySerializerAdapter();
-            var rawData = serializer.Serialize(completeHandshakeMessage);
+    [Fact]
+    public void BinarySerializerAdapter_should_deserialize_CompleteHandshakeWireMessage()
+    {
+        var sessionId = Guid.NewGuid();
+        
+        var completeHandshakeMessage =
+            new WireMessage
+            {
+                MessageType = "complete_handshake",
+                Data = sessionId.ToByteArray()
+            };   
+        
+        var serializer = new BinarySerializerAdapter();
+        var rawData = serializer.Serialize(completeHandshakeMessage);
 
-            var deserializedMessage = serializer.Deserialize<WireMessage>(rawData);
-            
-            Assert.Equal("complete_handshake", deserializedMessage.MessageType);
-            Assert.Equal(sessionId, new Guid(deserializedMessage.Data));
-        }
+        var deserializedMessage = serializer.Deserialize<WireMessage>(rawData);
+        
+        Assert.Equal("complete_handshake", deserializedMessage.MessageType);
+        Assert.Equal(sessionId, new Guid(deserializedMessage.Data));
     }
 }

--- a/CoreRemoting.Tests/BsonSerializationTests.cs
+++ b/CoreRemoting.Tests/BsonSerializationTests.cs
@@ -6,228 +6,227 @@ using CoreRemoting.Tests.Tools;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class BsonSerializationTests
 {
-    public class BsonSerializationTests
+    #region Fake DateTime Json Converter
+
+    private class FakeDateTimeConverter : JsonConverter
     {
-        #region Fake DateTime Json Converter
+        public int WriteCount { get; private set; }
 
-        private class FakeDateTimeConverter : JsonConverter
+        public override bool CanConvert(Type objectType)
         {
-            public int WriteCount { get; private set; }
-
-            public override bool CanConvert(Type objectType)
-            {
-                return objectType == typeof(DateTime) || objectType == typeof(string);
-            }
-
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                WriteCount++;
-                writer.WriteValue(value);
-            }
+            return objectType == typeof(DateTime) || objectType == typeof(string);
         }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            WriteCount++;
+            writer.WriteValue(value);
+        }
+    }
+    
+    #endregion
+    
+    [Fact]
+    public void BsonSerializerAdapter_should_deserialize_MethodCallMessage()
+    {
+        var serializer = new BsonSerializerAdapter();
+        var testServiceInterfaceType = typeof(ITestService);
         
-        #endregion
+        var messageBuilder = new MethodCallMessageBuilder();
+
+        var message =
+            messageBuilder.BuildMethodCallMessage(
+                serializer,
+                testServiceInterfaceType.Name,
+                testServiceInterfaceType.GetMethod("TestMethod"),
+                new object[] { 4711});
+
+        var rawData = serializer.Serialize(message);
         
-        [Fact]
-        public void BsonSerializerAdapter_should_deserialize_MethodCallMessage()
-        {
-            var serializer = new BsonSerializerAdapter();
-            var testServiceInterfaceType = typeof(ITestService);
-            
-            var messageBuilder = new MethodCallMessageBuilder();
+        var deserializedMessage = serializer.Deserialize<MethodCallMessage>(rawData);
+        
+        deserializedMessage.UnwrapParametersFromDeserializedMethodCallMessage(
+            out var parameterValues,
+            out var parameterTypes);
 
-            var message =
-                messageBuilder.BuildMethodCallMessage(
-                    serializer,
-                    testServiceInterfaceType.Name,
-                    testServiceInterfaceType.GetMethod("TestMethod"),
-                    new object[] { 4711});
+        var parametersLength = deserializedMessage.Parameters.Length;
+        
+        Assert.Equal(1, parametersLength);
+        Assert.NotNull(deserializedMessage.Parameters[0]);
+        Assert.Equal("arg", deserializedMessage.Parameters[0].ParameterName);
+        Assert.StartsWith("System.Object,", deserializedMessage.Parameters[0].ParameterTypeName);
+        Assert.Equal(typeof(int), parameterValues[0].GetType());
+        Assert.Equal(typeof(object), parameterTypes[0]);
+        Assert.Equal(4711, parameterValues[0]);
+    }
 
-            var rawData = serializer.Serialize(message);
-            
-            var deserializedMessage = serializer.Deserialize<MethodCallMessage>(rawData);
-            
-            deserializedMessage.UnwrapParametersFromDeserializedMethodCallMessage(
-                out var parameterValues,
-                out var parameterTypes);
-
-            var parametersLength = deserializedMessage.Parameters.Length;
-            
-            Assert.Equal(1, parametersLength);
-            Assert.NotNull(deserializedMessage.Parameters[0]);
-            Assert.Equal("arg", deserializedMessage.Parameters[0].ParameterName);
-            Assert.StartsWith("System.Object,", deserializedMessage.Parameters[0].ParameterTypeName);
-            Assert.Equal(typeof(int), parameterValues[0].GetType());
-            Assert.Equal(typeof(object), parameterTypes[0]);
-            Assert.Equal(4711, parameterValues[0]);
-        }
-
-        [Fact]
-        public void BsonSerializerAdapter_should_deserialize_CompleteHandshakeWireMessage()
-        {
-            var sessionId = Guid.NewGuid();
-            
-            var completeHandshakeMessage =
-                new WireMessage
-                {
-                    MessageType = "complete_handshake",
-                    Data = sessionId.ToByteArray()
-                };   
-            
-            var serializer = new BsonSerializerAdapter();
-            var rawData = serializer.Serialize(completeHandshakeMessage);
-
-            var deserializedMessage = serializer.Deserialize<WireMessage>(rawData);
-            
-            Assert.Equal("complete_handshake", deserializedMessage.MessageType);
-            Assert.Equal(sessionId, new Guid(deserializedMessage.Data));
-        }
-
-        [Fact]
-        public void BsonSerializerAdapter_should_use_configured_JsonConverters()
-        {
-            var fakeConverter = new FakeDateTimeConverter();
-            var config = new BsonSerializerConfig(new []
+    [Fact]
+    public void BsonSerializerAdapter_should_deserialize_CompleteHandshakeWireMessage()
+    {
+        var sessionId = Guid.NewGuid();
+        
+        var completeHandshakeMessage =
+            new WireMessage
             {
-                fakeConverter
-            });
-
-            var serializerAdapter = new BsonSerializerAdapter(config);
-
-            var dateToSerialize = DateTime.Today;
-            var raw = serializerAdapter.Serialize(dateToSerialize);
-            
-            Assert.NotEqual(0, fakeConverter.WriteCount);
-
-            var deserializedDate = serializerAdapter.Deserialize<DateTime>(raw);
-
-            Assert.Equal(dateToSerialize, deserializedDate);
-        }
-
-        private class PrimitiveValuesContainer
-        {
-            public byte ByteValue { get; set; }
-            public sbyte SByteValue { get; set; }
-            public short Int16Value { get; set; }
-            public ushort UInt16Value { get; set; }
-            public int Int32Value { get; set; }
-            public uint UInt32Value { get; set; }
-            public long Int64Value { get; set; }
-            public ulong UInt64Value { get; set; }
-            public float SingleValue { get; set; }
-            public double DoubleValue { get; set; }
-            public decimal DecimalValue { get; set; }
-            public bool BoolValue { get; set; }
-            public DateTime DateTimeValue { get; set; }
-            public Guid GuidValue { get; set; }
-        }
-
-        [Fact]
-        public void BsonSerializerAdapter_should_deserialize_primitive_properties_correctly()
-        {
-            var csharpDateTime = DateTime.Now;
-            var ticksTruncatedCSharpDate =
-                new DateTime(
-                    csharpDateTime.Year,
-                    csharpDateTime.Month,
-                    csharpDateTime.Day,
-                    csharpDateTime.Hour,
-                    csharpDateTime.Minute,
-                    csharpDateTime.Second,
-                    csharpDateTime.Millisecond);
-            
-            var test = new PrimitiveValuesContainer()
-            {
-                ByteValue = byte.MaxValue,
-                SByteValue = sbyte.MinValue,
-                BoolValue = true,
-                DecimalValue = 10^6145,
-                SingleValue = float.MaxValue,
-                DoubleValue = double.MaxValue,
-                GuidValue = Guid.NewGuid(),
-                Int16Value = short.MaxValue,
-                Int32Value = int.MaxValue,
-                Int64Value = long.MaxValue,
-                DateTimeValue = ticksTruncatedCSharpDate,
-                UInt16Value = ushort.MaxValue,
-                UInt32Value = int.MaxValue, // BSON doesn't support integer values larger than Int32
-                UInt64Value = int.MaxValue // BSON doesn't support integer values larger than Int32
-            };
-
-            var serializer = new BsonSerializerAdapter();
-            var raw = serializer.Serialize(test);
-            var deserializedTest = serializer.Deserialize<PrimitiveValuesContainer>(raw);
-            
-            Assert.Equal(test.ByteValue, deserializedTest.ByteValue);
-            Assert.Equal(test.SByteValue, deserializedTest.SByteValue);
-            Assert.Equal(test.BoolValue, deserializedTest.BoolValue);
-            Assert.Equal(test.DecimalValue, deserializedTest.DecimalValue);
-            Assert.Equal(test.DoubleValue, deserializedTest.DoubleValue);
-            Assert.Equal(test.SingleValue, deserializedTest.SingleValue);
-            Assert.Equal(test.GuidValue, deserializedTest.GuidValue);
-            Assert.Equal(test.Int16Value, deserializedTest.Int16Value);
-            Assert.Equal(test.Int32Value, deserializedTest.Int32Value);
-            Assert.Equal(test.Int64Value, deserializedTest.Int64Value);
-            Assert.Equal(test.DateTimeValue, deserializedTest.DateTimeValue);
-            Assert.Equal(test.UInt16Value, deserializedTest.UInt16Value);
-            Assert.Equal(test.UInt32Value, deserializedTest.UInt32Value);
-            Assert.Equal(test.UInt64Value, deserializedTest.UInt64Value);
-        }
-
-        [Fact]
-        public void BsonSerializerAdapter_should_deserialize_Int32_value_in_envelope_correctly()
-        {
-            var envelope = new Envelope(Int32.MaxValue);
-            
-            var serializer = new BsonSerializerAdapter();
-            var raw = serializer.Serialize(envelope);
-            var deserializedValue = serializer.Deserialize<Envelope>(raw);
-
-            Assert.Equal(envelope.Value, deserializedValue.Value);
-            Assert.IsType<Int32>(envelope.Value);
-        }
-
-        [Fact]
-        public void BsonSerializerAdapter_should_serialize_DataSet_as_Diffgram()
-        {
-            var originalTable = new DataTable("TestTable");
-            originalTable.Columns.Add("UserName", typeof(string));
-            originalTable.Columns.Add("Age", typeof(short));
-            var originalDataSet = new DataSet("TestDataSet");
-            originalDataSet.Tables.Add(originalTable);
-
-            var originalRow = originalTable.NewRow();
-            originalRow["UserName"] = "Tester";
-            originalRow["Age"] = 44;
-            originalTable.Rows.Add(originalRow);
+                MessageType = "complete_handshake",
+                Data = sessionId.ToByteArray()
+            };   
         
-            originalTable.AcceptChanges();
+        var serializer = new BsonSerializerAdapter();
+        var rawData = serializer.Serialize(completeHandshakeMessage);
 
-            originalRow["Age"] = 43;
-
-            var envelope = new Envelope(originalDataSet);
-            
-            var serializer = new BsonSerializerAdapter();
-            var raw = serializer.Serialize(envelope);
-            var deserializedEnvelope = serializer.Deserialize<Envelope>(raw);
-
-            var deserializedDataSet = (DataSet)deserializedEnvelope.Value;
-            var deserializedTable = deserializedDataSet.Tables["TestTable"];
-            var deserializedRow = deserializedTable!.Rows[0];
+        var deserializedMessage = serializer.Deserialize<WireMessage>(rawData);
         
-            Assert.Equal(originalDataSet.DataSetName, deserializedDataSet.DataSetName);
-            Assert.Equal(originalTable.TableName, deserializedTable.TableName);
-            Assert.Equal(originalRow.RowState, deserializedRow.RowState);
-            Assert.Equal(originalRow["Age", DataRowVersion.Original], deserializedRow["Age", DataRowVersion.Original]);
-            Assert.Equal(originalRow["Age", DataRowVersion.Current], deserializedRow["Age", DataRowVersion.Current]);
-            Assert.Equal(originalRow["UserName", DataRowVersion.Current], deserializedRow["UserName", DataRowVersion.Current]);
-        }
+        Assert.Equal("complete_handshake", deserializedMessage.MessageType);
+        Assert.Equal(sessionId, new Guid(deserializedMessage.Data));
+    }
+
+    [Fact]
+    public void BsonSerializerAdapter_should_use_configured_JsonConverters()
+    {
+        var fakeConverter = new FakeDateTimeConverter();
+        var config = new BsonSerializerConfig(new []
+        {
+            fakeConverter
+        });
+
+        var serializerAdapter = new BsonSerializerAdapter(config);
+
+        var dateToSerialize = DateTime.Today;
+        var raw = serializerAdapter.Serialize(dateToSerialize);
+        
+        Assert.NotEqual(0, fakeConverter.WriteCount);
+
+        var deserializedDate = serializerAdapter.Deserialize<DateTime>(raw);
+
+        Assert.Equal(dateToSerialize, deserializedDate);
+    }
+
+    private class PrimitiveValuesContainer
+    {
+        public byte ByteValue { get; set; }
+        public sbyte SByteValue { get; set; }
+        public short Int16Value { get; set; }
+        public ushort UInt16Value { get; set; }
+        public int Int32Value { get; set; }
+        public uint UInt32Value { get; set; }
+        public long Int64Value { get; set; }
+        public ulong UInt64Value { get; set; }
+        public float SingleValue { get; set; }
+        public double DoubleValue { get; set; }
+        public decimal DecimalValue { get; set; }
+        public bool BoolValue { get; set; }
+        public DateTime DateTimeValue { get; set; }
+        public Guid GuidValue { get; set; }
+    }
+
+    [Fact]
+    public void BsonSerializerAdapter_should_deserialize_primitive_properties_correctly()
+    {
+        var csharpDateTime = DateTime.Now;
+        var ticksTruncatedCSharpDate =
+            new DateTime(
+                csharpDateTime.Year,
+                csharpDateTime.Month,
+                csharpDateTime.Day,
+                csharpDateTime.Hour,
+                csharpDateTime.Minute,
+                csharpDateTime.Second,
+                csharpDateTime.Millisecond);
+        
+        var test = new PrimitiveValuesContainer()
+        {
+            ByteValue = byte.MaxValue,
+            SByteValue = sbyte.MinValue,
+            BoolValue = true,
+            DecimalValue = 10^6145,
+            SingleValue = float.MaxValue,
+            DoubleValue = double.MaxValue,
+            GuidValue = Guid.NewGuid(),
+            Int16Value = short.MaxValue,
+            Int32Value = int.MaxValue,
+            Int64Value = long.MaxValue,
+            DateTimeValue = ticksTruncatedCSharpDate,
+            UInt16Value = ushort.MaxValue,
+            UInt32Value = int.MaxValue, // BSON doesn't support integer values larger than Int32
+            UInt64Value = int.MaxValue // BSON doesn't support integer values larger than Int32
+        };
+
+        var serializer = new BsonSerializerAdapter();
+        var raw = serializer.Serialize(test);
+        var deserializedTest = serializer.Deserialize<PrimitiveValuesContainer>(raw);
+        
+        Assert.Equal(test.ByteValue, deserializedTest.ByteValue);
+        Assert.Equal(test.SByteValue, deserializedTest.SByteValue);
+        Assert.Equal(test.BoolValue, deserializedTest.BoolValue);
+        Assert.Equal(test.DecimalValue, deserializedTest.DecimalValue);
+        Assert.Equal(test.DoubleValue, deserializedTest.DoubleValue);
+        Assert.Equal(test.SingleValue, deserializedTest.SingleValue);
+        Assert.Equal(test.GuidValue, deserializedTest.GuidValue);
+        Assert.Equal(test.Int16Value, deserializedTest.Int16Value);
+        Assert.Equal(test.Int32Value, deserializedTest.Int32Value);
+        Assert.Equal(test.Int64Value, deserializedTest.Int64Value);
+        Assert.Equal(test.DateTimeValue, deserializedTest.DateTimeValue);
+        Assert.Equal(test.UInt16Value, deserializedTest.UInt16Value);
+        Assert.Equal(test.UInt32Value, deserializedTest.UInt32Value);
+        Assert.Equal(test.UInt64Value, deserializedTest.UInt64Value);
+    }
+
+    [Fact]
+    public void BsonSerializerAdapter_should_deserialize_Int32_value_in_envelope_correctly()
+    {
+        var envelope = new Envelope(Int32.MaxValue);
+        
+        var serializer = new BsonSerializerAdapter();
+        var raw = serializer.Serialize(envelope);
+        var deserializedValue = serializer.Deserialize<Envelope>(raw);
+
+        Assert.Equal(envelope.Value, deserializedValue.Value);
+        Assert.IsType<Int32>(envelope.Value);
+    }
+
+    [Fact]
+    public void BsonSerializerAdapter_should_serialize_DataSet_as_Diffgram()
+    {
+        var originalTable = new DataTable("TestTable");
+        originalTable.Columns.Add("UserName", typeof(string));
+        originalTable.Columns.Add("Age", typeof(short));
+        var originalDataSet = new DataSet("TestDataSet");
+        originalDataSet.Tables.Add(originalTable);
+
+        var originalRow = originalTable.NewRow();
+        originalRow["UserName"] = "Tester";
+        originalRow["Age"] = 44;
+        originalTable.Rows.Add(originalRow);
+    
+        originalTable.AcceptChanges();
+
+        originalRow["Age"] = 43;
+
+        var envelope = new Envelope(originalDataSet);
+        
+        var serializer = new BsonSerializerAdapter();
+        var raw = serializer.Serialize(envelope);
+        var deserializedEnvelope = serializer.Deserialize<Envelope>(raw);
+
+        var deserializedDataSet = (DataSet)deserializedEnvelope.Value;
+        var deserializedTable = deserializedDataSet.Tables["TestTable"];
+        var deserializedRow = deserializedTable!.Rows[0];
+    
+        Assert.Equal(originalDataSet.DataSetName, deserializedDataSet.DataSetName);
+        Assert.Equal(originalTable.TableName, deserializedTable.TableName);
+        Assert.Equal(originalRow.RowState, deserializedRow.RowState);
+        Assert.Equal(originalRow["Age", DataRowVersion.Original], deserializedRow["Age", DataRowVersion.Original]);
+        Assert.Equal(originalRow["Age", DataRowVersion.Current], deserializedRow["Age", DataRowVersion.Current]);
+        Assert.Equal(originalRow["UserName", DataRowVersion.Current], deserializedRow["UserName", DataRowVersion.Current]);
     }
 }

--- a/CoreRemoting.Tests/CallContextTests.cs
+++ b/CoreRemoting.Tests/CallContextTests.cs
@@ -2,59 +2,58 @@ using System.Threading;
 using CoreRemoting.Tests.Tools;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class CallContextTests : IClassFixture<ServerFixture>
 {
-    [Collection("CoreRemoting")]
-    public class CallContextTests : IClassFixture<ServerFixture>
+    private ServerFixture _serverFixture;
+    
+    public CallContextTests(ServerFixture serverFixture)
     {
-        private ServerFixture _serverFixture;
-        
-        public CallContextTests(ServerFixture serverFixture)
+        _serverFixture = serverFixture;
+        _serverFixture.Start();
+    }
+    
+    [Fact]
+    public void CallContext_should_flow_from_client_to_server_and_back()
+    {
+        _serverFixture.TestService.TestMethodFake = _ =>
         {
-            _serverFixture = serverFixture;
-            _serverFixture.Start();
-        }
+            CallContext.SetData("test", "Changed");
+            return CallContext.GetData("test");
+        };
         
-        [Fact]
-        public void CallContext_should_flow_from_client_to_server_and_back()
-        {
-            _serverFixture.TestService.TestMethodFake = _ =>
+        var clientThread =
+            new Thread(() =>
             {
-                CallContext.SetData("test", "Changed");
-                return CallContext.GetData("test");
-            };
-            
-            var clientThread =
-                new Thread(() =>
-                {
-                    CallContext.SetData("test", "CallContext");
+                CallContext.SetData("test", "CallContext");
 
-                    var client =
-                        new RemotingClient(new ClientConfig()
-                        {
-                            ServerPort = _serverFixture.Server.Config.NetworkPort,
-                            MessageEncryption = false,
-                            ConnectionTimeout = 0
-                        });
+                var client =
+                    new RemotingClient(new ClientConfig()
+                    {
+                        ServerPort = _serverFixture.Server.Config.NetworkPort,
+                        MessageEncryption = false,
+                        ConnectionTimeout = 0
+                    });
 
-                    client.Connect();
+                client.Connect();
 
-                    var localCallContextValueBeforeRpc = CallContext.GetData("test");
-                    
-                    var proxy = client.CreateProxy<ITestService>();
-                    var result = (string) proxy.TestMethod("x");
+                var localCallContextValueBeforeRpc = CallContext.GetData("test");
+                
+                var proxy = client.CreateProxy<ITestService>();
+                var result = (string) proxy.TestMethod("x");
 
-                    var localCallContextValueAfterRpc = CallContext.GetData("test");
-                    
-                    Assert.NotEqual(localCallContextValueBeforeRpc, result);
-                    Assert.Equal("Changed", result);
-                    Assert.Equal("Changed", localCallContextValueAfterRpc);
+                var localCallContextValueAfterRpc = CallContext.GetData("test");
+                
+                Assert.NotEqual(localCallContextValueBeforeRpc, result);
+                Assert.Equal("Changed", result);
+                Assert.Equal("Changed", localCallContextValueAfterRpc);
 
-                    client.Dispose();
-                });
-            
-            clientThread.Start();
-            clientThread.Join();
-        }
+                client.Dispose();
+            });
+        
+        clientThread.Start();
+        clientThread.Join();
     }
 }

--- a/CoreRemoting.Tests/DataSetSerializationTests.cs
+++ b/CoreRemoting.Tests/DataSetSerializationTests.cs
@@ -1,6 +1,4 @@
 using System.Data;
-using System.IO;
-using System.Reflection;
 using CoreRemoting.Serialization.Bson.DataSetDiffGramSupport;
 using Newtonsoft.Json;
 using Xunit;

--- a/CoreRemoting.Tests/DisposableTests.Sync.cs
+++ b/CoreRemoting.Tests/DisposableTests.Sync.cs
@@ -1,52 +1,50 @@
 using CoreRemoting.Toolbox;
 using System;
-using System.Threading.Tasks;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public partial class DisposableTests
 {
-    public partial class DisposableTests
+    [Fact]
+    public void Disposable_executes_action_on_Dispose()
     {
-        [Fact]
-        public void Disposable_executes_action_on_Dispose()
+        var disposed = false;
+
+        void Dispose() =>
+            disposed = true;
+
+        using (Disposable.Create(Dispose))
+            Assert.False(disposed);
+
+        Assert.True(disposed);
+    }
+
+    [Fact]
+    public void Disposable_ignores_nulls()
+    {
+        Action dispose = null;
+
+        using (Disposable.Create(dispose))
         {
-            var disposed = false;
-
-            void Dispose() =>
-                disposed = true;
-
-            using (Disposable.Create(Dispose))
-                Assert.False(disposed);
-
-            Assert.True(disposed);
+            // doesn't throw
         }
+    }
 
-        [Fact]
-        public void Disposable_ignores_nulls()
-        {
-            Action dispose = null;
+    [Fact]
+    public void Disposable_combines_disposables()
+    {
+        var count = 0;
+        void Dispose() =>
+            count++;
 
-            using (Disposable.Create(dispose))
-            {
-                // doesn't throw
-            }
-        }
+        var d1 = Disposable.Create(Dispose);
+        var d2 = Disposable.Create(Dispose);
+        var d3 = Disposable.Create(Dispose);
 
-        [Fact]
-        public void Disposable_combines_disposables()
-        {
-            var count = 0;
-            void Dispose() =>
-                count++;
+        using (Disposable.Create(d1, d2, d3))
+            Assert.Equal(0, count);
 
-            var d1 = Disposable.Create(Dispose);
-            var d2 = Disposable.Create(Dispose);
-            var d3 = Disposable.Create(Dispose);
-
-            using (Disposable.Create(d1, d2, d3))
-                Assert.Equal(0, count);
-
-            Assert.Equal(3, count);
-        }
+        Assert.Equal(3, count);
     }
 }

--- a/CoreRemoting.Tests/ExceptionTests.cs
+++ b/CoreRemoting.Tests/ExceptionTests.cs
@@ -3,69 +3,68 @@ using System.Reflection;
 using CoreRemoting.Serialization;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class ExceptionTests
 {
-    public class ExceptionTests
+    /// <summary>
+    /// Private non-serializable exception class.
+    /// </summary>
+    class NonSerializableException : Exception
     {
-        /// <summary>
-        /// Private non-serializable exception class.
-        /// </summary>
-        class NonSerializableException : Exception
+        public NonSerializableException()
+            : this("This exception is not serializable")
         {
-            public NonSerializableException()
-                : this("This exception is not serializable")
-            {
-            }
-
-            public NonSerializableException(string message, Exception inner = null)
-                : base(message, inner)
-            {
-            }
         }
 
-        [Fact]
-        public void Exception_can_be_checked_if_it_is_serializable()
+        public NonSerializableException(string message, Exception inner = null)
+            : base(message, inner)
         {
-            Assert.True(new Exception().IsSerializable());
-            Assert.False(new NonSerializableException().IsSerializable());
-            Assert.True(new Exception("Hello", new Exception()).IsSerializable());
-            Assert.False(new Exception("Goodbye", new NonSerializableException()).IsSerializable());
         }
+    }
 
-        [Fact]
-        public void Exception_can_be_turned_to_serializable()
-        {
-            var slotName = "SomeData";
-            var ex = new Exception("Bang!", new NonSerializableException("Zoom!"));
-            ex.Data[slotName] = DateTime.Now.ToString();
-            ex.InnerException.Data[slotName] = DateTime.Today.Ticks;
-            Assert.False(ex.IsSerializable());
+    [Fact]
+    public void Exception_can_be_checked_if_it_is_serializable()
+    {
+        Assert.True(new Exception().IsSerializable());
+        Assert.False(new NonSerializableException().IsSerializable());
+        Assert.True(new Exception("Hello", new Exception()).IsSerializable());
+        Assert.False(new Exception("Goodbye", new NonSerializableException()).IsSerializable());
+    }
 
-            var sx = ex.ToSerializable();
-            Assert.True(sx.IsSerializable());
-            Assert.NotSame(ex, sx);
-            Assert.NotSame(ex.InnerException, sx.InnerException);
+    [Fact]
+    public void Exception_can_be_turned_to_serializable()
+    {
+        var slotName = "SomeData";
+        var ex = new Exception("Bang!", new NonSerializableException("Zoom!"));
+        ex.Data[slotName] = DateTime.Now.ToString();
+        ex.InnerException.Data[slotName] = DateTime.Today.Ticks;
+        Assert.False(ex.IsSerializable());
 
-            Assert.Equal(ex.Message, sx.Message);
-            Assert.Equal(ex.Data[slotName], sx.Data[slotName]);
-            Assert.Equal(ex.InnerException.Message, sx.InnerException.Message);
-            Assert.Equal(ex.InnerException.Data[slotName], sx.InnerException.Data[slotName]);
-        }
+        var sx = ex.ToSerializable();
+        Assert.True(sx.IsSerializable());
+        Assert.NotSame(ex, sx);
+        Assert.NotSame(ex.InnerException, sx.InnerException);
 
-        [Fact]
-        public void SkipTargetInvocationException_returns_the_first_meaningful_inner_exception()
-        {
-            // the first meaningful exception
-            var ex = new Exception("Hello");
-            var tex = new TargetInvocationException(ex);
-            Assert.Equal(ex, tex.SkipTargetInvocationExceptions());
+        Assert.Equal(ex.Message, sx.Message);
+        Assert.Equal(ex.Data[slotName], sx.Data[slotName]);
+        Assert.Equal(ex.InnerException.Message, sx.InnerException.Message);
+        Assert.Equal(ex.InnerException.Data[slotName], sx.InnerException.Data[slotName]);
+    }
 
-            // no inner exceptions, return as is
-            tex = new TargetInvocationException(null);
-            Assert.Equal(tex, tex.SkipTargetInvocationExceptions());
+    [Fact]
+    public void SkipTargetInvocationException_returns_the_first_meaningful_inner_exception()
+    {
+        // the first meaningful exception
+        var ex = new Exception("Hello");
+        var tex = new TargetInvocationException(ex);
+        Assert.Equal(ex, tex.SkipTargetInvocationExceptions());
 
-            // null, return as is
-            Assert.Null(default(Exception).SkipTargetInvocationExceptions());
-        }
+        // no inner exceptions, return as is
+        tex = new TargetInvocationException(null);
+        Assert.Equal(tex, tex.SkipTargetInvocationExceptions());
+
+        // null, return as is
+        Assert.Null(default(Exception).SkipTargetInvocationExceptions());
     }
 }

--- a/CoreRemoting.Tests/LinqExpressionTests.cs
+++ b/CoreRemoting.Tests/LinqExpressionTests.cs
@@ -1,35 +1,34 @@
 using CoreRemoting.Tests.Tools;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class LinqExpressionTests : IClassFixture<ServerFixture>
 {
-    [Collection("CoreRemoting")]
-    public class LinqExpressionTests : IClassFixture<ServerFixture>
+    private ServerFixture _serverFixture;
+
+    public LinqExpressionTests(ServerFixture serverFixture)
     {
-        private ServerFixture _serverFixture;
-
-        public LinqExpressionTests(ServerFixture serverFixture)
+        _serverFixture = serverFixture;
+        _serverFixture.Start();
+    }
+    
+    [Fact]
+    public void LinqExpression_should_be_serialized_and_deserialized()
+    {
+        using var client = new RemotingClient(new ClientConfig()
         {
-            _serverFixture = serverFixture;
-            _serverFixture.Start();
-        }
+            ConnectionTimeout = 0, 
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<IHobbitService>();
+
+        var result = proxy.QueryHobbits(h => h.FirstName == "Frodo");
         
-        [Fact]
-        public void LinqExpression_should_be_serialized_and_deserialized()
-        {
-            using var client = new RemotingClient(new ClientConfig()
-            {
-                ConnectionTimeout = 0, 
-                MessageEncryption = false,
-                ServerPort = _serverFixture.Server.Config.NetworkPort
-            });
-
-            client.Connect();
-            var proxy = client.CreateProxy<IHobbitService>();
-
-            var result = proxy.QueryHobbits(h => h.FirstName == "Frodo");
-            
-            Assert.True(result.FirstName == "Frodo");
-        }
+        Assert.True(result.FirstName == "Frodo");
     }
 }

--- a/CoreRemoting.Tests/RemotingConfigurationTests.cs
+++ b/CoreRemoting.Tests/RemotingConfigurationTests.cs
@@ -9,117 +9,116 @@ using CoreRemoting.Serialization.Binary;
 using CoreRemoting.Tests.Tools;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class RemotingConfigurationTests : IClassFixture<ServerFixture>
 {
-    public class RemotingConfigurationTests : IClassFixture<ServerFixture>
+    public RemotingConfigurationTests(ServerFixture serverFixture)
     {
-        public RemotingConfigurationTests(ServerFixture serverFixture)
-        {
-            serverFixture.Start();
-        }
+        serverFixture.Start();
+    }
 
-        [Fact]
-        public void RegisterWellKnownServiceType_should_register_type_resolved_at_runtime()
+    [Fact]
+    public void RegisterWellKnownServiceType_should_register_type_resolved_at_runtime()
+    {
+        RemotingConfiguration.RegisterServer(new ServerConfig()
         {
-            RemotingConfiguration.RegisterServer(new ServerConfig()
+            UniqueServerInstanceName = "Server1"
+        });
+
+        var server = RemotingConfiguration.GetRegisteredServer("Server1");
+        
+        RemotingConfiguration.RegisterWellKnownServiceType(
+            interfaceType: typeof(ITestService),
+            implementationType: typeof(TestService),
+            lifetime: ServiceLifetime.Singleton,
+            serviceName: "Service1",
+            uniqueServerInstanceName: "Server1");
+
+        var service =  server.ServiceRegistry.GetService("Service1");
+        
+        Assert.NotNull(service);
+        Assert.Equal(typeof(TestService), service.GetType());
+        
+        RemotingConfiguration.ShutdownAll();
+    }
+    
+    [Fact]
+    public void RemotingServer_should_register_on_construction_AND_unregister_on_Dispose()
+    {
+        RemotingConfiguration.RegisterServer(new ServerConfig()
+        {
+            UniqueServerInstanceName = "Server1"
+        });
+        
+        Assert.NotNull(RemotingConfiguration.GetRegisteredServer("Server1"));
+        
+        var server = RemotingConfiguration.GetRegisteredServer("Server1");
+        
+        server.Dispose();
+        
+        Assert.Null(RemotingConfiguration.GetRegisteredServer("Server1"));
+    }
+
+    [Fact]
+    public void RemotingConfiguration_Configure_should_configure_a_server_and_a_client()
+    {
+        // See TestConfig.xml to check test configuration
+        var configFileName =
+            Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+                "TestConfig.xml");
+        
+        RemotingConfiguration.Configure(
+            fileName: configFileName,
+            credentials: new []
             {
-                UniqueServerInstanceName = "Server1"
+                new Credential() { Name = "token", Value = "123" }
             });
 
-            var server = RemotingConfiguration.GetRegisteredServer("Server1");
-            
-            RemotingConfiguration.RegisterWellKnownServiceType(
-                interfaceType: typeof(ITestService),
-                implementationType: typeof(TestService),
-                lifetime: ServiceLifetime.Singleton,
-                serviceName: "Service1",
-                uniqueServerInstanceName: "Server1");
+        var server = RemotingConfiguration.GetRegisteredServer("TestServer4711");
 
-            var service =  server.ServiceRegistry.GetService("Service1");
-            
-            Assert.NotNull(service);
-            Assert.Equal(typeof(TestService), service.GetType());
-            
-            RemotingConfiguration.ShutdownAll();
-        }
+        if (!server.Config.Channel.IsListening)
+            throw new ApplicationException("Channel is listening.");
         
-        [Fact]
-        public void RemotingServer_should_register_on_construction_AND_unregister_on_Dispose()
-        {
-            RemotingConfiguration.RegisterServer(new ServerConfig()
-            {
-                UniqueServerInstanceName = "Server1"
-            });
-            
-            Assert.NotNull(RemotingConfiguration.GetRegisteredServer("Server1"));
-            
-            var server = RemotingConfiguration.GetRegisteredServer("Server1");
-            
-            server.Dispose();
-            
-            Assert.Null(RemotingConfiguration.GetRegisteredServer("Server1"));
-        }
-
-        [Fact]
-        public void RemotingConfiguration_Configure_should_configure_a_server_and_a_client()
-        {
-            // See TestConfig.xml to check test configuration
-            var configFileName =
-                Path.Combine(
-                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
-                    "TestConfig.xml");
-            
-            RemotingConfiguration.Configure(
-                fileName: configFileName,
-                credentials: new []
-                {
-                    new Credential() { Name = "token", Value = "123" }
-                });
-
-            var server = RemotingConfiguration.GetRegisteredServer("TestServer4711");
-
-            if (!server.Config.Channel.IsListening)
-                throw new ApplicationException("Channel is listening.");
-            
-            var authProvider = (FakeAuthProvider) server.Config.AuthenticationProvider;
-            authProvider.AuthenticateFake = credentials => 
-                credentials.Length == 1 && 
-                credentials[0].Name == "token" &&
-                credentials[0].Value == "123";
-            
-            Assert.NotNull(server);
-            Assert.Equal(8089, server.Config.NetworkPort);
-            Assert.Equal("localhost", server.Config.HostName);
-            Assert.Equal(2048, server.Config.KeySize);
-            Assert.IsType<BinarySerializerAdapter>(server.Serializer);
-            Assert.IsType<WebsocketServerChannel>(server.Config.Channel);
-            Assert.IsType<FakeAuthProvider>(server.Config.AuthenticationProvider);
-            Assert.True(server.Config.AuthenticationRequired);
-            Assert.True(server.Config.MessageEncryption);
-            Assert.NotNull(server.ServiceRegistry.GetService("TestService"));
-            Assert.IsType<TestService>(server.ServiceRegistry.GetService("TestService"));
-
-            var client = RemotingConfiguration.GetRegisteredClient("TestClient");
+        var authProvider = (FakeAuthProvider) server.Config.AuthenticationProvider;
+        authProvider.AuthenticateFake = credentials => 
+            credentials.Length == 1 && 
+            credentials[0].Name == "token" &&
+            credentials[0].Value == "123";
         
-            Assert.NotNull(client);
-            Assert.Equal(8089, client.Config.ServerPort);
-            Assert.Equal("localhost", client.Config.ServerHostName);
-            Assert.Equal(2048, client.Config.KeySize);
-            Assert.IsType<BinarySerializerAdapter>(client.Config.Serializer);
-            Assert.IsType<WebsocketClientChannel>(client.Config.Channel);
-            Assert.True(client.Config.MessageEncryption);
-            Assert.True(client.Config.IsDefault);
-            Assert.Equal(200, client.Config.ConnectionTimeout);
-            Assert.Equal(110, client.Config.AuthenticationTimeout);
-            Assert.Equal(30000, client.Config.InvocationTimeout);
+        Assert.NotNull(server);
+        Assert.Equal(8089, server.Config.NetworkPort);
+        Assert.Equal("localhost", server.Config.HostName);
+        Assert.Equal(2048, server.Config.KeySize);
+        Assert.IsType<BinarySerializerAdapter>(server.Serializer);
+        Assert.IsType<WebsocketServerChannel>(server.Config.Channel);
+        Assert.IsType<FakeAuthProvider>(server.Config.AuthenticationProvider);
+        Assert.True(server.Config.AuthenticationRequired);
+        Assert.True(server.Config.MessageEncryption);
+        Assert.NotNull(server.ServiceRegistry.GetService("TestService"));
+        Assert.IsType<TestService>(server.ServiceRegistry.GetService("TestService"));
 
-            var proxy = (ITestService)RemotingServices.Connect(typeof(ITestService), "TestService");
-            Assert.True(client.IsConnected);
-            
-            var result = proxy.Echo("hello");
-            Assert.Equal("hello", result);
+        var client = RemotingConfiguration.GetRegisteredClient("TestClient");
+    
+        Assert.NotNull(client);
+        Assert.Equal(8089, client.Config.ServerPort);
+        Assert.Equal("localhost", client.Config.ServerHostName);
+        Assert.Equal(2048, client.Config.KeySize);
+        Assert.IsType<BinarySerializerAdapter>(client.Config.Serializer);
+        Assert.IsType<WebsocketClientChannel>(client.Config.Channel);
+        Assert.True(client.Config.MessageEncryption);
+        Assert.True(client.Config.IsDefault);
+        Assert.Equal(200, client.Config.ConnectionTimeout);
+        Assert.Equal(110, client.Config.AuthenticationTimeout);
+        Assert.Equal(30000, client.Config.InvocationTimeout);
 
-            RemotingConfiguration.ShutdownAll();
-        }
+        var proxy = (ITestService)RemotingServices.Connect(typeof(ITestService), "TestService");
+        Assert.True(client.IsConnected);
+        
+        var result = proxy.Echo("hello");
+        Assert.Equal("hello", result);
+
+        RemotingConfiguration.ShutdownAll();
     }
 }

--- a/CoreRemoting.Tests/RemotingServicesTests.cs
+++ b/CoreRemoting.Tests/RemotingServicesTests.cs
@@ -4,106 +4,105 @@ using CoreRemoting.ClassicRemotingApi;
 using CoreRemoting.Tests.Tools;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class RemotingServicesTests
 {
-    [Collection("CoreRemoting")]
-    public class RemotingServicesTests
+    [Fact]
+    public void IsOneWay_should_return_true_if_provided_method_is_OneWay()
     {
-        [Fact]
-        public void IsOneWay_should_return_true_if_provided_method_is_OneWay()
-        {
-            var serviceType = typeof(ITestService);
-            var isOneWay = RemotingServices.IsOneWay(serviceType.GetMethod("OneWayMethod"));
-            
-            Assert.True(isOneWay);
-            
-            isOneWay = RemotingServices.IsOneWay(serviceType.GetMethod("TestMethod"));
-            
-            Assert.False(isOneWay);
-        }
+        var serviceType = typeof(ITestService);
+        var isOneWay = RemotingServices.IsOneWay(serviceType.GetMethod("OneWayMethod"));
+        
+        Assert.True(isOneWay);
+        
+        isOneWay = RemotingServices.IsOneWay(serviceType.GetMethod("TestMethod"));
+        
+        Assert.False(isOneWay);
+    }
 
-        [Fact]
-        public void IsTransparentProxy_should_return_true_if_the_provided_object_is_a_proxy()
-        {
-            var client = new RemotingClient(
-                new ClientConfig()
-                {
-                    MessageEncryption = false,
-                    ServerPort = 9199,
-                    ServerHostName = "localhost"
-                });
-            
-            var proxy = client.CreateProxy<ITestService>();
-
-            var isProxy = RemotingServices.IsTransparentProxy(proxy);
-            
-            Assert.True(isProxy);
-
-            var service = new TestService();
-            isProxy = RemotingServices.IsTransparentProxy(service);
-            
-            Assert.False(isProxy);
-        }
-
-        [Fact]
-        public void Marshal_should_register_a_service_instance()
-        {
-            var testService = new TestService();
-
-            using var server = new RemotingServer();
-            server.Start();
-            
-            string serviceName =
-                RemotingServices.Marshal(testService, "test", typeof(ITestService), server.UniqueServerInstanceName);
-
-            var registeredServiceInstance = server.ServiceRegistry.GetService(serviceName);
-
-            Assert.Same(testService, registeredServiceInstance);
-            Assert.True(registeredServiceInstance is ITestService);
-        }
-
-        [Fact]
-        public void Connect_should_create_a_proxy_for_a_remote_service()
-        {
-            var testService = 
-                new TestService 
-                {
-                    TestMethodFake = arg => 
-                        arg
-                };
-
-            using var server = 
-                new RemotingServer(new ServerConfig
-                {
-                    NetworkPort = 9199, 
-                    IsDefault = true
-                });
-            
-            RemotingServices.Marshal(testService, "test", typeof(ITestService));
-            server.Start();
-
-            var clientThread = new Thread(() =>
+    [Fact]
+    public void IsTransparentProxy_should_return_true_if_the_provided_object_is_a_proxy()
+    {
+        var client = new RemotingClient(
+            new ClientConfig()
             {
-                // ReSharper disable once ObjectCreationAsStatement
-                new RemotingClient(new ClientConfig {ServerPort = 9199, MessageEncryption = false, IsDefault = true});
-                
-                var proxy = 
-                    RemotingServices.Connect(
-                        typeof(ITestService),
-                        "test",
-                        string.Empty);
-                
-                Assert.True(RemotingServices.IsTransparentProxy(proxy));
-
-                object result = ((ITestService) proxy).TestMethod(1);
-                
-                RemotingClient.DefaultRemotingClient.Dispose();
-                
-                Assert.Equal(1, Convert.ToInt32(result));
+                MessageEncryption = false,
+                ServerPort = 9199,
+                ServerHostName = "localhost"
             });
+        
+        var proxy = client.CreateProxy<ITestService>();
+
+        var isProxy = RemotingServices.IsTransparentProxy(proxy);
+        
+        Assert.True(isProxy);
+
+        var service = new TestService();
+        isProxy = RemotingServices.IsTransparentProxy(service);
+        
+        Assert.False(isProxy);
+    }
+
+    [Fact]
+    public void Marshal_should_register_a_service_instance()
+    {
+        var testService = new TestService();
+
+        using var server = new RemotingServer();
+        server.Start();
+        
+        string serviceName =
+            RemotingServices.Marshal(testService, "test", typeof(ITestService), server.UniqueServerInstanceName);
+
+        var registeredServiceInstance = server.ServiceRegistry.GetService(serviceName);
+
+        Assert.Same(testService, registeredServiceInstance);
+        Assert.True(registeredServiceInstance is ITestService);
+    }
+
+    [Fact]
+    public void Connect_should_create_a_proxy_for_a_remote_service()
+    {
+        var testService = 
+            new TestService 
+            {
+                TestMethodFake = arg => 
+                    arg
+            };
+
+        using var server = 
+            new RemotingServer(new ServerConfig
+            {
+                NetworkPort = 9199, 
+                IsDefault = true
+            });
+        
+        RemotingServices.Marshal(testService, "test", typeof(ITestService));
+        server.Start();
+
+        var clientThread = new Thread(() =>
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            new RemotingClient(new ClientConfig {ServerPort = 9199, MessageEncryption = false, IsDefault = true});
             
-            clientThread.Start();
-            clientThread.Join();
-        }
+            var proxy = 
+                RemotingServices.Connect(
+                    typeof(ITestService),
+                    "test",
+                    string.Empty);
+            
+            Assert.True(RemotingServices.IsTransparentProxy(proxy));
+
+            object result = ((ITestService) proxy).TestMethod(1);
+            
+            RemotingClient.DefaultRemotingClient.Dispose();
+            
+            Assert.Equal(1, Convert.ToInt32(result));
+        });
+        
+        clientThread.Start();
+        clientThread.Join();
     }
 }

--- a/CoreRemoting.Tests/ReturnAsProxyTests.cs
+++ b/CoreRemoting.Tests/ReturnAsProxyTests.cs
@@ -5,52 +5,51 @@ using CoreRemoting.ClassicRemotingApi;
 using CoreRemoting.Tests.Tools;
 using Xunit.Abstractions;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class ReturnAsProxyTests : IClassFixture<ServerFixture>
 {
-    [Collection("CoreRemoting")]
-    public class ReturnAsProxyTests : IClassFixture<ServerFixture>
+    private ServerFixture _serverFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public ReturnAsProxyTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
     {
-        private ServerFixture _serverFixture;
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public ReturnAsProxyTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
+        _serverFixture = serverFixture;
+        _testOutputHelper = testOutputHelper;
+        _serverFixture.Start();
+    }
+    
+    [Fact]
+    public void Call_on_Proxy_should_be_invoked_on_remote_service()
+    {
+        void ClientAction()
         {
-            _serverFixture = serverFixture;
-            _testOutputHelper = testOutputHelper;
-            _serverFixture.Start();
-        }
-        
-        [Fact]
-        public void Call_on_Proxy_should_be_invoked_on_remote_service()
-        {
-            void ClientAction()
+            try
             {
-                try
+                using var client = new RemotingClient(new ClientConfig()
                 {
-                    using var client = new RemotingClient(new ClientConfig()
-                    {
-                        ConnectionTimeout = 0, 
-                        MessageEncryption = false,
-                        ServerPort = _serverFixture.Server.Config.NetworkPort
-                    });
+                    ConnectionTimeout = 0, 
+                    MessageEncryption = false,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort
+                });
 
-                    client.Connect();
+                client.Connect();
 
-                    var factoryServiceProxy = client.CreateProxy<IFactoryService>();
-                    var testServiceProxy = factoryServiceProxy.GetTestService();
+                var factoryServiceProxy = client.CreateProxy<IFactoryService>();
+                var testServiceProxy = factoryServiceProxy.GetTestService();
 
-                    Assert.True(RemotingServices.IsTransparentProxy(testServiceProxy));
-                }
-                catch (Exception e)
-                {
-                    _testOutputHelper.WriteLine(e.ToString());
-                    throw;
-                }
+                Assert.True(RemotingServices.IsTransparentProxy(testServiceProxy));
             }
-
-            var clientThread = new Thread(ClientAction);
-            clientThread.Start();
-            clientThread.Join();
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
         }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
     }
 }

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -13,395 +13,796 @@ using CoreRemoting.Tests.Tools;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class RpcTests : IClassFixture<ServerFixture>
 {
-    [Collection("CoreRemoting")]
-    public class RpcTests : IClassFixture<ServerFixture>
+    private readonly ServerFixture _serverFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+    private bool _remoteServiceCalled;
+
+    protected virtual IServerChannel ServerChannel => null;
+
+    protected virtual IClientChannel ClientChannel => null;
+
+    public RpcTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
     {
-        private readonly ServerFixture _serverFixture;
-        private readonly ITestOutputHelper _testOutputHelper;
-        private bool _remoteServiceCalled;
+        _serverFixture = serverFixture;
+        _testOutputHelper = testOutputHelper;
 
-        protected virtual IServerChannel ServerChannel => null;
-
-        protected virtual IClientChannel ClientChannel => null;
-
-        public RpcTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
+        _serverFixture.TestService.TestMethodFake = arg =>
         {
-            _serverFixture = serverFixture;
-            _testOutputHelper = testOutputHelper;
+            _remoteServiceCalled = true;
+            return arg;
+        };
 
-            _serverFixture.TestService.TestMethodFake = arg =>
-            {
-                _remoteServiceCalled = true;
-                return arg;
-            };
+        _serverFixture.Start(ServerChannel);
+    }
 
-            _serverFixture.Start(ServerChannel);
-        }
+    [Fact]
+    public void ValidationSyncContext_is_installed()
+    {
+        using var ctx = ValidationSyncContext.Install();
 
-        [Fact]
-        public void ValidationSyncContext_is_installed()
-        {
-            using var ctx = ValidationSyncContext.Install();
+        Assert.IsType<ValidationSyncContext>(SynchronizationContext.Current);
+    }
 
-            Assert.IsType<ValidationSyncContext>(SynchronizationContext.Current);
-        }
-
-        [Fact]
-        public void Call_on_Proxy_should_be_invoked_on_remote_service()
-        {
-            void ClientAction()
-            {
-                using var ctx = ValidationSyncContext.Install();
-
-                try
-                {
-                    var stopWatch = new Stopwatch();
-                    stopWatch.Start();
-
-                    using var client = new RemotingClient(new ClientConfig()
-                    {
-                        ConnectionTimeout = 0,
-                        MessageEncryption = false,
-                        Channel = ClientChannel,
-                        ServerPort = _serverFixture.Server.Config.NetworkPort,
-                    });
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    client.Connect();
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    var proxy = client.CreateProxy<ITestService>();
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    var result = proxy.TestMethod("test");
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    var result2 = proxy.TestMethod("test");
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-
-                    Assert.Equal("test", result);
-                    Assert.Equal("test", result2);
-
-                    proxy.MethodWithOutParameter(out int methodCallCount);
-
-                    Assert.Equal(1, methodCallCount);
-                }
-                catch (Exception e)
-                {
-                    _testOutputHelper.WriteLine(e.ToString());
-                    throw;
-                }
-            }
-
-            var clientThread = new Thread(ClientAction);
-            clientThread.Start();
-            clientThread.Join();
-
-            Assert.True(_remoteServiceCalled);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
-        }
-
-        [Fact]
-        public void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
-        {
-            _serverFixture.Server.Config.MessageEncryption = true;
-
-            void ClientAction()
-            {
-                using var ctx = ValidationSyncContext.Install();
-
-                try
-                {
-                    var stopWatch = new Stopwatch();
-                    stopWatch.Start();
-
-                    using var client = new RemotingClient(new ClientConfig()
-                    {
-                        ConnectionTimeout = 0,
-                        Channel = ClientChannel,
-                        ServerPort = _serverFixture.Server.Config.NetworkPort,
-                        MessageEncryption = true,
-                    });
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    client.Connect();
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    var proxy = client.CreateProxy<ITestService>();
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    var result = proxy.TestMethod("test");
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-                    stopWatch.Reset();
-                    stopWatch.Start();
-
-                    var result2 = proxy.TestMethod("test");
-
-                    stopWatch.Stop();
-                    _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-
-                    Assert.Equal("test", result);
-                    Assert.Equal("test", result2);
-                }
-                catch (Exception e)
-                {
-                    _testOutputHelper.WriteLine(e.ToString());
-                    throw;
-                }
-            }
-
-            var clientThread = new Thread(ClientAction);
-            clientThread.Start();
-            clientThread.Join();
-
-            _serverFixture.Server.Config.MessageEncryption = false;
-
-            Assert.True(_remoteServiceCalled);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
-        }
-
-        [Fact]
-        public void Delegate_invoked_on_server_should_callback_client()
-        {
-            string argumentFromServer = null;
-
-            void ClientAction()
-            {
-                using var ctx = ValidationSyncContext.Install();
-
-                try
-                {
-                    using var client = new RemotingClient(
-                        new ClientConfig()
-                        {
-                            ConnectionTimeout = 0,
-                            Channel = ClientChannel,
-                            MessageEncryption = false,
-                            ServerPort = _serverFixture.Server.Config.NetworkPort,
-                        });
-
-                    client.Connect();
-
-                    var proxy = client.CreateProxy<ITestService>();
-                    proxy.TestMethodWithDelegateArg(arg => argumentFromServer = arg);
-                }
-                catch (Exception e)
-                {
-                    _testOutputHelper.WriteLine(e.ToString());
-                    throw;
-                }
-            }
-
-            var clientThread = new Thread(ClientAction);
-            clientThread.Start();
-            clientThread.Join();
-
-            Assert.Equal("test", argumentFromServer);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
-        }
-
-        [Fact]
-        public void Events_should_work_remotely()
+    [Fact]
+    public void Call_on_Proxy_should_be_invoked_on_remote_service()
+    {
+        void ClientAction()
         {
             using var ctx = ValidationSyncContext.Install();
 
-            var serviceEventCalled = false;
-            var customDelegateEventCalled = false;
+            try
+            {
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
 
-            using var client = new RemotingClient(
-                new ClientConfig()
+                using var client = new RemotingClient(new ClientConfig()
                 {
                     ConnectionTimeout = 0,
-                    SendTimeout = 0,
+                    MessageEncryption = false,
+                    Channel = ClientChannel,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                });
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                client.Connect();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var proxy = client.CreateProxy<ITestService>();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result2 = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+
+                Assert.Equal("test", result);
+                Assert.Equal("test", result2);
+
+                proxy.MethodWithOutParameter(out int methodCallCount);
+
+                Assert.Equal(1, methodCallCount);
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        Assert.True(_remoteServiceCalled);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
+    {
+        _serverFixture.Server.Config.MessageEncryption = true;
+
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
+
+                using var client = new RemotingClient(new ClientConfig()
+                {
+                    ConnectionTimeout = 0,
+                    Channel = ClientChannel,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                    MessageEncryption = true,
+                });
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                client.Connect();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var proxy = client.CreateProxy<ITestService>();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result2 = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+
+                Assert.Equal("test", result);
+                Assert.Equal("test", result2);
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        _serverFixture.Server.Config.MessageEncryption = false;
+
+        Assert.True(_remoteServiceCalled);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Delegate_invoked_on_server_should_callback_client()
+    {
+        string argumentFromServer = null;
+
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                using var client = new RemotingClient(
+                    new ClientConfig()
+                    {
+                        ConnectionTimeout = 0,
+                        Channel = ClientChannel,
+                        MessageEncryption = false,
+                        ServerPort = _serverFixture.Server.Config.NetworkPort,
+                    });
+
+                client.Connect();
+
+                var proxy = client.CreateProxy<ITestService>();
+                proxy.TestMethodWithDelegateArg(arg => argumentFromServer = arg);
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        Assert.Equal("test", argumentFromServer);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Events_should_work_remotely()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        var serviceEventCalled = false;
+        var customDelegateEventCalled = false;
+
+        using var client = new RemotingClient(
+            new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<ITestService>();
+
+        var serviceEventResetEvent = new ManualResetEventSlim(initialState: false);
+        var customDelegateEventResetEvent = new ManualResetEventSlim(initialState: false);
+
+        proxy.ServiceEvent += () =>
+        {
+            serviceEventCalled = true;
+            serviceEventResetEvent.Set();
+        };
+
+        proxy.CustomDelegateEvent += _ =>
+        {
+            customDelegateEventCalled = true;
+            customDelegateEventResetEvent.Set();
+        };
+
+        proxy.FireServiceEvent();
+        proxy.FireCustomDelegateEvent();
+
+        serviceEventResetEvent.Wait(1000);
+        customDelegateEventResetEvent.Wait(1000);
+
+        Assert.True(serviceEventCalled);
+        Assert.True(customDelegateEventCalled);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void External_types_should_work_as_remote_service_parameters()
+    {
+        DataClass parameterValue = null;
+
+        _serverFixture.TestService.TestExternalTypeParameterFake = arg =>
+        {
+            _remoteServiceCalled = true;
+            parameterValue = arg;
+        };
+
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                using var client = new RemotingClient(new ClientConfig()
+                {
+                    ConnectionTimeout = 0,
                     Channel = ClientChannel,
                     MessageEncryption = false,
                     ServerPort = _serverFixture.Server.Config.NetworkPort,
                 });
 
-            client.Connect();
+                client.Connect();
 
-            var proxy = client.CreateProxy<ITestService>();
+                var proxy = client.CreateProxy<ITestService>();
+                proxy.TestExternalTypeParameter(new DataClass() { Value = 42 });
 
-            var serviceEventResetEvent = new ManualResetEventSlim(initialState: false);
-            var customDelegateEventResetEvent = new ManualResetEventSlim(initialState: false);
-
-            proxy.ServiceEvent += () =>
+                Assert.Equal(42, parameterValue.Value);
+            }
+            catch (Exception e)
             {
-                serviceEventCalled = true;
-                serviceEventResetEvent.Set();
-            };
-
-            proxy.CustomDelegateEvent += _ =>
-            {
-                customDelegateEventCalled = true;
-                customDelegateEventResetEvent.Set();
-            };
-
-            proxy.FireServiceEvent();
-            proxy.FireCustomDelegateEvent();
-
-            serviceEventResetEvent.Wait(1000);
-            customDelegateEventResetEvent.Wait(1000);
-
-            Assert.True(serviceEventCalled);
-            Assert.True(customDelegateEventCalled);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
         }
 
-        [Fact]
-        public void External_types_should_work_as_remote_service_parameters()
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        Assert.True(_remoteServiceCalled);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Generic_methods_should_be_called_correctly()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
         {
-            DataClass parameterValue = null;
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
 
-            _serverFixture.TestService.TestExternalTypeParameterFake = arg =>
+        client.Connect();
+        var proxy = client.CreateProxy<IGenericEchoService>();
+
+        var result = proxy.Echo("Yay");
+
+        Assert.Equal("Yay", result);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Inherited_methods_should_be_called_correctly()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        var result = proxy.BaseMethod();
+
+        Assert.True(result);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Enum_arguments_should_be_passed_correctly()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<IEnumTestService>();
+
+        var resultFirst = proxy.Echo(TestEnum.First);
+        var resultSecond = proxy.Echo(TestEnum.Second);
+
+        Assert.Equal(TestEnum.First, resultFirst);
+        Assert.Equal(TestEnum.Second, resultSecond);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Missing_method_throws_RemoteInvocationException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
+
+        // simulate MissingMethodException
+        var mb = new CustomMessageBuilder
+        {
+            ProcessMethodCallMessage = m =>
             {
-                _remoteServiceCalled = true;
-                parameterValue = arg;
-            };
-
-            void ClientAction()
-            {
-                using var ctx = ValidationSyncContext.Install();
-
-                try
+                if (m.MethodName == "TestMethod")
                 {
-                    using var client = new RemotingClient(new ClientConfig()
-                    {
-                        ConnectionTimeout = 0,
-                        Channel = ClientChannel,
-                        MessageEncryption = false,
-                        ServerPort = _serverFixture.Server.Config.NetworkPort,
-                    });
-
-                    client.Connect();
-
-                    var proxy = client.CreateProxy<ITestService>();
-                    proxy.TestExternalTypeParameter(new DataClass() { Value = 42 });
-
-                    Assert.Equal(42, parameterValue.Value);
-                }
-                catch (Exception e)
-                {
-                    _testOutputHelper.WriteLine(e.ToString());
-                    throw;
+                    m.MethodName = "Missing Method";
                 }
             }
+        };
 
-            var clientThread = new Thread(ClientAction);
-            clientThread.Start();
-            clientThread.Join();
+        client.MethodCallMessageBuilder = mb;
+        client.Connect();
 
-            Assert.True(_remoteServiceCalled);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
-        }
+        var proxy = client.CreateProxy<ITestService>();
+        var ex = Assert.Throws<RemoteInvocationException>(() => proxy.TestMethod(null));
 
-        [Fact]
-        public void Generic_methods_should_be_called_correctly()
+        // a localized message similar to "Method 'Missing method' not found"
+        Assert.NotNull(ex);
+        Assert.Contains("Missing Method", ex.Message);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Missing_service_throws_RemoteInvocationException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
         {
-            using var ctx = ValidationSyncContext.Install();
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
 
+        client.Connect();
+
+        var proxy = client.CreateProxy<IDisposable>();
+        var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Dispose());
+
+        // a localized message similar to "Service 'System.IDisposable' is not registered"
+        Assert.NotNull(ex);
+        Assert.Contains("IDisposable", ex.Message);
+        Assert.Equal(0, _serverFixture.ServerErrorCount);
+    }
+
+    [Fact]
+    public void Error_method_throws_Exception()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
             using var client = new RemotingClient(new ClientConfig()
             {
-                ConnectionTimeout = 0,
-                Channel = ClientChannel,
-                MessageEncryption = false,
-                ServerPort = _serverFixture.Server.Config.NetworkPort,
-            });
-
-            client.Connect();
-            var proxy = client.CreateProxy<IGenericEchoService>();
-
-            var result = proxy.Echo("Yay");
-
-            Assert.Equal("Yay", result);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
-        }
-
-        [Fact]
-        public void Inherited_methods_should_be_called_correctly()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
-            using var client = new RemotingClient(new ClientConfig()
-            {
-                ConnectionTimeout = 0,
-                Channel = ClientChannel,
-                MessageEncryption = false,
-                ServerPort = _serverFixture.Server.Config.NetworkPort,
-            });
-
-            client.Connect();
-            var proxy = client.CreateProxy<ITestService>();
-
-            var result = proxy.BaseMethod();
-
-            Assert.True(result);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
-        }
-
-        [Fact]
-        public void Enum_arguments_should_be_passed_correctly()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
-            using var client = new RemotingClient(new ClientConfig()
-            {
-                ConnectionTimeout = 0,
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
                 Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort
             });
 
             client.Connect();
-            var proxy = client.CreateProxy<IEnumTestService>();
 
-            var resultFirst = proxy.Echo(TestEnum.First);
-            var resultSecond = proxy.Echo(TestEnum.Second);
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                proxy.Error(nameof(Error_method_throws_Exception)))
+                    .GetInnermostException();
 
-            Assert.Equal(TestEnum.First, resultFirst);
-            Assert.Equal(TestEnum.Second, resultSecond);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
+            Assert.NotNull(ex);
+            Assert.Equal(nameof(Error_method_throws_Exception), ex.Message);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+    public async Task ErrorAsync_method_throws_Exception()
+    {
+        // using var ctx = ValidationSyncContext.Install(); // fails?
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = (await Assert.ThrowsAsync<RemoteInvocationException>(async () =>
+            {
+                await proxy.ErrorAsync(nameof(ErrorAsync_method_throws_Exception)).ConfigureAwait(false);
+            })
+            .ConfigureAwait(false)).GetInnermostException();
+
+            Assert.NotNull(ex); 
+            Assert.Equal(nameof(ErrorAsync_method_throws_Exception), ex.Message);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void NonSerializableError_method_throws_Exception()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                proxy.NonSerializableError("Hello", "Serializable", "World"))
+                    .GetInnermostException();
+
+            Assert.NotNull(ex);
+            Assert.IsType<SerializableException>(ex);
+
+            if (ex is SerializableException sx)
+            {
+                Assert.Equal("NonSerializable", sx.SourceTypeName);
+                Assert.Equal("Hello", ex.Message);
+                Assert.Equal("Serializable", ex.Data["Serializable"]);
+                Assert.Equal("World", ex.Data["World"]);
+                Assert.NotNull(ex.StackTrace);
+            }
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void AfterCall_event_handler_can_translate_exceptions_to_improve_diagnostics()
+    {
+        // replace cryptic database error report with a user-friendly error message
+        void AfterCall(object sender, ServerRpcContext ctx)
+        {
+            var errorMsg = ctx.Exception?.Message ?? string.Empty;
+            if (errorMsg.StartsWith("23503:"))
+                ctx.Exception = new Exception("Deleting clients is not allowed.",
+                    ctx.Exception);
         }
 
-        [Fact]
-        public void Missing_method_throws_RemoteInvocationException()
-        {
-            using var ctx = ValidationSyncContext.Install();
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.AfterCall += AfterCall;
 
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var dbError = "23503: delete from table 'clients' violates " +
+                "foreign key constraint 'order_client_fk' on table 'orders'";
+
+            // simulate a database error on the server-side
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = Assert.Throws<Exception>(() => proxy.Error(dbError));
+
+            Assert.NotNull(ex);
+            Assert.Equal("Deleting clients is not allowed.", ex.Message);
+            Assert.NotNull(ex.InnerException);
+            Assert.Equal(dbError, ex.InnerException.Message);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+            _serverFixture.Server.AfterCall -= AfterCall;
+        }
+    }
+
+    [Fact]
+    public void Failing_component_constructor_throws_RemoteInvocationException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 3,
+            InvocationTimeout = 3,
+            SendTimeout = 3,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<IFailingService>();
+        var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Hello());
+
+        Assert.NotNull(ex);
+        Assert.Contains("FailingService", ex.Message);
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+    public async Task Disposed_client_subscription_doesnt_break_other_clients()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        async Task Roundtrip(bool encryption)
+        {
+            var oldEncryption = _serverFixture.Server.Config.MessageEncryption;
+            _serverFixture.Server.Config.MessageEncryption = encryption;
+
+            try
+            {
+                RemotingClient CreateClient() => new RemotingClient(new ClientConfig()
+                {
+                    Channel = ClientChannel,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                    MessageEncryption = encryption,
+                });
+
+                using var client1 = CreateClient();
+                using var client2 = CreateClient();
+
+                client1.Connect();
+                client2.Connect();
+
+                var proxy1 = client1.CreateProxy<ITestService>();
+                var fired1 = new TaskCompletionSource<bool>();
+                proxy1.ServiceEvent += () => fired1.TrySetResult(true);
+
+                var proxy2 = client2.CreateProxy<ITestService>();
+                var fired2 = new TaskCompletionSource<bool>();
+                proxy2.ServiceEvent += () => fired2.TrySetResult(true);
+
+                // early disposal, proxy1 subscription isn't canceled
+                client1.Disconnect();
+
+                proxy2.FireServiceEvent();
+                Assert.True(await fired2.Task.ConfigureAwait(false));
+                Assert.True(fired2.Task.IsCompleted);
+                Assert.False(fired1.Task.IsCompleted);
+            }
+            finally
+            {
+                _serverFixture.Server.Config.MessageEncryption = oldEncryption;
+
+                // reset the error counter for other tests
+                _serverFixture.ServerErrorCount = 0;
+            }
+        }
+
+        // works!
+        await Roundtrip(encryption: false).ConfigureAwait(false);
+
+        // fails!
+        await Roundtrip(encryption: true).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void DataTable_roundtrip_works_issue60()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        var dt = new DataTable();
+        dt.TableName = "Issue60";
+        dt.Columns.Add("CODE");
+        dt.Rows.Add(dt.NewRow());
+        dt.AcceptChanges();
+
+        var dt2 = proxy.TestDt(dt, 1);
+        Assert.NotNull(dt2);
+    }
+
+    [Fact]
+    public void Large_messages_are_sent_and_received()
+    {
+        // max payload size, in bytes
+        var maxSize = 2 * 1024 * 1024 + 1;
+
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        // shouldn't throw exceptions
+        Roundtrip("Payload", maxSize);
+        Roundtrip(new byte[] { 1, 2, 3, 4, 5 }, maxSize);
+        Roundtrip(new int[] { 12345, 67890 }, maxSize);
+
+        void Roundtrip<T>(T payload, int maxSize) where T : class
+        {
+            var lastSize = 0;
+            try
+            {
+                while (true)
+                {
+                    // a -> aa -> aaaa ...
+                    var dup = proxy.Duplicate(payload);
+                    if (dup.size >= maxSize)
+                        break;
+
+                    // save the size for error reporting
+                    lastSize = dup.size;
+                    payload = dup.duplicate;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to handle " +
+                    $"payload larger than {lastSize}: {ex.Message}", ex);
+            }
+        }
+    }
+
+    [Fact]
+    public void BeforeCall_and_AfterCall_events_are_triggered_on_success()
+    {
+        var beforeCallFired = 0;
+        void BeforeCall(object sender, ServerRpcContext e) =>
+            Interlocked.Increment(ref beforeCallFired);
+
+        var afterCallFired = 0;
+        void AfterCall(object sender, ServerRpcContext e) =>
+            Interlocked.Increment(ref afterCallFired);
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeforeCall += BeforeCall;
+        _serverFixture.Server.AfterCall += AfterCall;
+
+        try
+        {
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
@@ -409,38 +810,45 @@ namespace CoreRemoting.Tests
                 SendTimeout = 0,
                 Channel = ClientChannel,
                 MessageEncryption = false,
-                ServerPort = _serverFixture.Server.Config.NetworkPort
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
 
-            // simulate MissingMethodException
-            var mb = new CustomMessageBuilder
-            {
-                ProcessMethodCallMessage = m =>
-                {
-                    if (m.MethodName == "TestMethod")
-                    {
-                        m.MethodName = "Missing Method";
-                    }
-                }
-            };
-
-            client.MethodCallMessageBuilder = mb;
             client.Connect();
 
+            // test one-way method
             var proxy = client.CreateProxy<ITestService>();
-            var ex = Assert.Throws<RemoteInvocationException>(() => proxy.TestMethod(null));
+            proxy.OneWayMethod();
 
-            // a localized message similar to "Method 'Missing method' not found"
-            Assert.NotNull(ex);
-            Assert.Contains("Missing Method", ex.Message);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
+            // test normal method
+            Assert.Equal("Hello", proxy.Echo("Hello"));
+
+            Assert.Equal(2, beforeCallFired);
+            Assert.Equal(2, afterCallFired);
         }
-
-        [Fact]
-        public void Missing_service_throws_RemoteInvocationException()
+        finally
         {
-            using var ctx = ValidationSyncContext.Install();
+            _serverFixture.Server.AfterCall -= AfterCall;
+            _serverFixture.Server.BeforeCall -= BeforeCall;
+        }
+    }
 
+    [Fact]
+    public void BeforeCall_and_AfterCall_events_are_triggered_on_failures()
+    {
+        var beforeCallFired = 0;
+        void BeforeCall(object sender, ServerRpcContext e) =>
+            Interlocked.Increment(ref beforeCallFired);
+
+        var afterCallFired = 0;
+        void AfterCall(object sender, ServerRpcContext e) =>
+            Interlocked.Increment(ref afterCallFired);
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeforeCall += BeforeCall;
+        _serverFixture.Server.AfterCall += AfterCall;
+
+        try
+        {
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
@@ -448,193 +856,105 @@ namespace CoreRemoting.Tests
                 SendTimeout = 0,
                 Channel = ClientChannel,
                 MessageEncryption = false,
-                ServerPort = _serverFixture.Server.Config.NetworkPort
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
 
             client.Connect();
 
-            var proxy = client.CreateProxy<IDisposable>();
-            var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Dispose());
+            // test failing method
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Throws<RemoteInvocationException>(() => proxy.Error("Bang"));
 
-            // a localized message similar to "Service 'System.IDisposable' is not registered"
-            Assert.NotNull(ex);
-            Assert.Contains("IDisposable", ex.Message);
-            Assert.Equal(0, _serverFixture.ServerErrorCount);
+            Assert.Equal(1, beforeCallFired);
+            Assert.Equal(1, afterCallFired);
         }
-
-        [Fact]
-        public void Error_method_throws_Exception()
+        finally
         {
-            using var ctx = ValidationSyncContext.Install();
+            _serverFixture.Server.AfterCall -= AfterCall;
+            _serverFixture.Server.BeforeCall -= BeforeCall;
+        }
+    }
 
-            try
+    [Fact]
+    public void BeginCall_event_handler_can_intercept_and_cancel_method_calls()
+    {
+        var counter = 0;
+
+        void InterceptMethodCalls(object sender, ServerRpcContext e)
+        {
+            Interlocked.Increment(ref counter);
+
+            // swap Echo and Reverse methods
+            e.MethodCallMessage.MethodName = e.MethodCallMessage.MethodName switch
             {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 5,
-                    InvocationTimeout = 5,
-                    SendTimeout = 5,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort
-                });
+                "Echo" => "Reverse",
+                "Reverse" => "Echo",
+                var others => others
+            };
 
-                client.Connect();
-
-                var proxy = client.CreateProxy<ITestService>();
-                var ex = Assert.Throws<RemoteInvocationException>(() =>
-                    proxy.Error(nameof(Error_method_throws_Exception)))
-                        .GetInnermostException();
-
-                Assert.NotNull(ex);
-                Assert.Equal(nameof(Error_method_throws_Exception), ex.Message);
-            }
-            finally
+            // disable IHobbitService
+            if (e.MethodCallMessage.ServiceName.Contains("IHobbitService"))
             {
-                // reset the error counter for other tests
-                _serverFixture.ServerErrorCount = 0;
+                e.Cancel = true;
             }
         }
 
-        [Fact]
-        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-        public async Task ErrorAsync_method_throws_Exception()
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeginCall += InterceptMethodCalls;
+
+        try
         {
-            // using var ctx = ValidationSyncContext.Install(); // fails?
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 5,
-                    InvocationTimeout = 5,
-                    SendTimeout = 5,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort
-                });
-
-                client.Connect();
-
-                var proxy = client.CreateProxy<ITestService>();
-                var ex = (await Assert.ThrowsAsync<RemoteInvocationException>(async () =>
-                {
-                    await proxy.ErrorAsync(nameof(ErrorAsync_method_throws_Exception)).ConfigureAwait(false);
-                })
-                .ConfigureAwait(false)).GetInnermostException();
-
-                Assert.NotNull(ex); 
-                Assert.Equal(nameof(ErrorAsync_method_throws_Exception), ex.Message);
-            }
-            finally
-            {
-                // reset the error counter for other tests
-                _serverFixture.ServerErrorCount = 0;
-            }
-        }
-
-        [Fact]
-        public void NonSerializableError_method_throws_Exception()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 5,
-                    InvocationTimeout = 5,
-                    SendTimeout = 5,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort
-                });
-
-                client.Connect();
-
-                var proxy = client.CreateProxy<ITestService>();
-                var ex = Assert.Throws<RemoteInvocationException>(() =>
-                    proxy.NonSerializableError("Hello", "Serializable", "World"))
-                        .GetInnermostException();
-
-                Assert.NotNull(ex);
-                Assert.IsType<SerializableException>(ex);
-
-                if (ex is SerializableException sx)
-                {
-                    Assert.Equal("NonSerializable", sx.SourceTypeName);
-                    Assert.Equal("Hello", ex.Message);
-                    Assert.Equal("Serializable", ex.Data["Serializable"]);
-                    Assert.Equal("World", ex.Data["World"]);
-                    Assert.NotNull(ex.StackTrace);
-                }
-            }
-            finally
-            {
-                // reset the error counter for other tests
-                _serverFixture.ServerErrorCount = 0;
-            }
-        }
-
-        [Fact]
-        public void AfterCall_event_handler_can_translate_exceptions_to_improve_diagnostics()
-        {
-            // replace cryptic database error report with a user-friendly error message
-            void AfterCall(object sender, ServerRpcContext ctx)
-            {
-                var errorMsg = ctx.Exception?.Message ?? string.Empty;
-                if (errorMsg.StartsWith("23503:"))
-                    ctx.Exception = new Exception("Deleting clients is not allowed.",
-                        ctx.Exception);
-            }
-
-            using var ctx = ValidationSyncContext.Install();
-            _serverFixture.Server.AfterCall += AfterCall;
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 5,
-                    InvocationTimeout = 5,
-                    SendTimeout = 5,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort
-                });
-
-                client.Connect();
-
-                var dbError = "23503: delete from table 'clients' violates " +
-                    "foreign key constraint 'order_client_fk' on table 'orders'";
-
-                // simulate a database error on the server-side
-                var proxy = client.CreateProxy<ITestService>();
-                var ex = Assert.Throws<Exception>(() => proxy.Error(dbError));
-
-                Assert.NotNull(ex);
-                Assert.Equal("Deleting clients is not allowed.", ex.Message);
-                Assert.NotNull(ex.InnerException);
-                Assert.Equal(dbError, ex.InnerException.Message);
-            }
-            finally
-            {
-                // reset the error counter for other tests
-                _serverFixture.ServerErrorCount = 0;
-                _serverFixture.Server.AfterCall -= AfterCall;
-            }
-        }
-
-        [Fact]
-        public void Failing_component_constructor_throws_RemoteInvocationException()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
             using var client = new RemotingClient(new ClientConfig()
             {
-                ConnectionTimeout = 3,
-                InvocationTimeout = 3,
-                SendTimeout = 3,
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            // try swapped methods
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("321", proxy.Echo("123"));
+            Assert.Equal("Hello", proxy.Reverse("Hello"));
+
+            // try disabled service
+            var hobbit = client.CreateProxy<IHobbitService>();
+            Assert.Throws<RemoteInvocationException>(() =>
+                hobbit.QueryHobbits(h => h.LastName != ""));
+
+            // check interception counter
+            Assert.Equal(3, counter);
+        }
+        finally
+        {
+            _serverFixture.Server.BeginCall -= InterceptMethodCalls;
+        }
+    }
+
+    [Fact]
+    public void Authentication_is_taken_into_account_and_RejectCall_event_is_fired()
+    {
+        var rejectedMethod = string.Empty;
+        void RejectCall(object sender, ServerRpcContext e) =>
+            rejectedMethod = e.MethodCallMessage.MethodName;
+
+        var server = _serverFixture.Server;
+        server.RejectCall += RejectCall;
+        server.Config.AuthenticationRequired = true;
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
                 Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
@@ -643,75 +963,36 @@ namespace CoreRemoting.Tests
             client.Connect();
 
             var proxy = client.CreateProxy<IFailingService>();
-            var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Hello());
+            var ex = Assert.Throws<RemoteInvocationException>(proxy.Hello);
 
-            Assert.NotNull(ex);
-            Assert.Contains("FailingService", ex.Message);
+            // Session is not authenticated
+            Assert.Contains("authenticated", ex.Message);
+
+            // Method call was rejected
+            Assert.Equal("Hello", rejectedMethod);
         }
-
-        [Fact]
-        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-        public async Task Disposed_client_subscription_doesnt_break_other_clients()
+        finally
         {
-            using var ctx = ValidationSyncContext.Install();
-
-            async Task Roundtrip(bool encryption)
-            {
-                var oldEncryption = _serverFixture.Server.Config.MessageEncryption;
-                _serverFixture.Server.Config.MessageEncryption = encryption;
-
-                try
-                {
-                    RemotingClient CreateClient() => new RemotingClient(new ClientConfig()
-                    {
-                        Channel = ClientChannel,
-                        ServerPort = _serverFixture.Server.Config.NetworkPort,
-                        MessageEncryption = encryption,
-                    });
-
-                    using var client1 = CreateClient();
-                    using var client2 = CreateClient();
-
-                    client1.Connect();
-                    client2.Connect();
-
-                    var proxy1 = client1.CreateProxy<ITestService>();
-                    var fired1 = new TaskCompletionSource<bool>();
-                    proxy1.ServiceEvent += () => fired1.TrySetResult(true);
-
-                    var proxy2 = client2.CreateProxy<ITestService>();
-                    var fired2 = new TaskCompletionSource<bool>();
-                    proxy2.ServiceEvent += () => fired2.TrySetResult(true);
-
-                    // early disposal, proxy1 subscription isn't canceled
-                    client1.Disconnect();
-
-                    proxy2.FireServiceEvent();
-                    Assert.True(await fired2.Task.ConfigureAwait(false));
-                    Assert.True(fired2.Task.IsCompleted);
-                    Assert.False(fired1.Task.IsCompleted);
-                }
-                finally
-                {
-                    _serverFixture.Server.Config.MessageEncryption = oldEncryption;
-
-                    // reset the error counter for other tests
-                    _serverFixture.ServerErrorCount = 0;
-                }
-            }
-
-            // works!
-            await Roundtrip(encryption: false).ConfigureAwait(false);
-
-            // fails!
-            await Roundtrip(encryption: true).ConfigureAwait(false);
+            server.Config.AuthenticationRequired = false;
+            server.RejectCall -= RejectCall;
         }
+    }
 
-        [Fact]
-        public void DataTable_roundtrip_works_issue60()
+    [Fact]
+    public void Authentication_handler_has_access_to_the_current_session()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
         {
-            using var ctx = ValidationSyncContext.Install();
+            AuthenticateFake = c => RemotingSession.Current != null
+        };
 
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
@@ -720,29 +1001,83 @@ namespace CoreRemoting.Tests
                 Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new()],
             });
 
             client.Connect();
+
             var proxy = client.CreateProxy<ITestService>();
-
-            var dt = new DataTable();
-            dt.TableName = "Issue60";
-            dt.Columns.Add("CODE");
-            dt.Rows.Add(dt.NewRow());
-            dt.AcceptChanges();
-
-            var dt2 = proxy.TestDt(dt, 1);
-            Assert.NotNull(dt2);
+            Assert.Equal("123", proxy.Reverse("321"));
         }
-
-        [Fact]
-        public void Large_messages_are_sent_and_received()
+        finally
         {
-            // max payload size, in bytes
-            var maxSize = 2 * 1024 * 1024 + 1;
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+        }
+    }
 
-            using var ctx = ValidationSyncContext.Install();
+    [Fact]
+    public void Broken_auhentication_handler_doesnt_break_the_server()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
+        {
+            AuthenticateFake = c => throw new Exception("Broken")
+        };
 
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 3,
+                InvocationTimeout = 3,
+                SendTimeout = 3,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new()],
+            });
+
+            var ex = Assert.Throws<SecurityException>(client.Connect);
+
+            Assert.Contains("auth", ex.Message.ToLower());
+            Assert.Contains("failed", ex.Message);
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void Authentication_handler_can_check_client_address()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
+        {
+            AuthenticateFake = c =>
+            {
+                var address = RemotingSession.Current?.ClientAddress ??
+                    throw new ArgumentNullException("ClientAddress");
+
+                // allow only localhost connections
+                return address.Contains("127.0.0.1") || // ipv4
+                    address.Contains("[::1]"); // ipv6
+            }
+        };
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
@@ -751,486 +1086,150 @@ namespace CoreRemoting.Tests
                 Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new Credential()],
             });
 
             client.Connect();
+
             var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("123", proxy.Reverse("321"));
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+        }
+    }
 
-            // shouldn't throw exceptions
-            Roundtrip("Payload", maxSize);
-            Roundtrip(new byte[] { 1, 2, 3, 4, 5 }, maxSize);
-            Roundtrip(new int[] { 12345, 67890 }, maxSize);
+    [Fact]
+    public void ServerComponent_can_track_client_network_address()
+    {
+        using var ctx = ValidationSyncContext.Install();
 
-            void Roundtrip<T>(T payload, int maxSize) where T : class
-            {
-                var lastSize = 0;
-                try
-                {
-                    while (true)
-                    {
-                        // a -> aa -> aaaa ...
-                        var dup = proxy.Duplicate(payload);
-                        if (dup.size >= maxSize)
-                            break;
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            Channel = ClientChannel,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
 
-                        // save the size for error reporting
-                        lastSize = dup.size;
-                        payload = dup.duplicate;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidOperationException($"Failed to handle " +
-                        $"payload larger than {lastSize}: {ex.Message}", ex);
-                }
-            }
+        client.Connect();
+
+        var proxy = client.CreateProxy<ISessionAwareService>();
+
+        // what's my address as seen by remote server?
+        Assert.NotNull(proxy.ClientAddress);
+    }
+
+    [Fact]
+    public void Logon_and_logoff_events_are_triggered()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        void CheckSession(string operation)
+        {
+            var rs = RemotingSession.Current;
+            Assert.NotNull(rs);
+            Assert.True(rs?.IsAuthenticated);
+            Assert.NotNull(rs?.ClientAddress);
+            Assert.NotNull(rs?.Identity);
+            Console.WriteLine($"Client {rs.Identity.Name} from {rs.ClientAddress} is {operation}");
         }
 
-        [Fact]
-        public void BeforeCall_and_AfterCall_events_are_triggered_on_success()
+        var logon = false;
+        void Logon(object sender, EventArgs _)
         {
-            var beforeCallFired = 0;
-            void BeforeCall(object sender, ServerRpcContext e) =>
-                Interlocked.Increment(ref beforeCallFired);
-
-            var afterCallFired = 0;
-            void AfterCall(object sender, ServerRpcContext e) =>
-                Interlocked.Increment(ref afterCallFired);
-
-            using var ctx = ValidationSyncContext.Install();
-            _serverFixture.Server.BeforeCall += BeforeCall;
-            _serverFixture.Server.AfterCall += AfterCall;
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                });
-
-                client.Connect();
-
-                // test one-way method
-                var proxy = client.CreateProxy<ITestService>();
-                proxy.OneWayMethod();
-
-                // test normal method
-                Assert.Equal("Hello", proxy.Echo("Hello"));
-
-                Assert.Equal(2, beforeCallFired);
-                Assert.Equal(2, afterCallFired);
-            }
-            finally
-            {
-                _serverFixture.Server.AfterCall -= AfterCall;
-                _serverFixture.Server.BeforeCall -= BeforeCall;
-            }
+            logon = true;
+            CheckSession("logged on");
         }
 
-        [Fact]
-        public void BeforeCall_and_AfterCall_events_are_triggered_on_failures()
+        var logoff = false;
+        void Logoff(object sender, EventArgs _)
         {
-            var beforeCallFired = 0;
-            void BeforeCall(object sender, ServerRpcContext e) =>
-                Interlocked.Increment(ref beforeCallFired);
-
-            var afterCallFired = 0;
-            void AfterCall(object sender, ServerRpcContext e) =>
-                Interlocked.Increment(ref afterCallFired);
-
-            using var ctx = ValidationSyncContext.Install();
-            _serverFixture.Server.BeforeCall += BeforeCall;
-            _serverFixture.Server.AfterCall += AfterCall;
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                });
-
-                client.Connect();
-
-                // test failing method
-                var proxy = client.CreateProxy<ITestService>();
-                Assert.Throws<RemoteInvocationException>(() => proxy.Error("Bang"));
-
-                Assert.Equal(1, beforeCallFired);
-                Assert.Equal(1, afterCallFired);
-            }
-            finally
-            {
-                _serverFixture.Server.AfterCall -= AfterCall;
-                _serverFixture.Server.BeforeCall -= BeforeCall;
-            }
+            logoff = true;
+            CheckSession("logged off");
         }
 
-        [Fact]
-        public void BeginCall_event_handler_can_intercept_and_cancel_method_calls()
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationProvider = new FakeAuthProvider();
+
+        server.Logon += Logon;
+        server.Logoff += Logoff;
+        server.Config.AuthenticationRequired = true;
+
+        try
         {
-            var counter = 0;
-
-            void InterceptMethodCalls(object sender, ServerRpcContext e)
-            {
-                Interlocked.Increment(ref counter);
-
-                // swap Echo and Reverse methods
-                e.MethodCallMessage.MethodName = e.MethodCallMessage.MethodName switch
-                {
-                    "Echo" => "Reverse",
-                    "Reverse" => "Echo",
-                    var others => others
-                };
-
-                // disable IHobbitService
-                if (e.MethodCallMessage.ServiceName.Contains("IHobbitService"))
-                {
-                    e.Cancel = true;
-                }
-            }
-
-            using var ctx = ValidationSyncContext.Install();
-            _serverFixture.Server.BeginCall += InterceptMethodCalls;
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                });
-
-                client.Connect();
-
-                // try swapped methods
-                var proxy = client.CreateProxy<ITestService>();
-                Assert.Equal("321", proxy.Echo("123"));
-                Assert.Equal("Hello", proxy.Reverse("Hello"));
-
-                // try disabled service
-                var hobbit = client.CreateProxy<IHobbitService>();
-                Assert.Throws<RemoteInvocationException>(() =>
-                    hobbit.QueryHobbits(h => h.LastName != ""));
-
-                // check interception counter
-                Assert.Equal(3, counter);
-            }
-            finally
-            {
-                _serverFixture.Server.BeginCall -= InterceptMethodCalls;
-            }
-        }
-
-        [Fact]
-        public void Authentication_is_taken_into_account_and_RejectCall_event_is_fired()
-        {
-            var rejectedMethod = string.Empty;
-            void RejectCall(object sender, ServerRpcContext e) =>
-                rejectedMethod = e.MethodCallMessage.MethodName;
-
-            var server = _serverFixture.Server;
-            server.RejectCall += RejectCall;
-            server.Config.AuthenticationRequired = true;
-
-            using var ctx = ValidationSyncContext.Install();
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                });
-
-                client.Connect();
-
-                var proxy = client.CreateProxy<IFailingService>();
-                var ex = Assert.Throws<RemoteInvocationException>(proxy.Hello);
-
-                // Session is not authenticated
-                Assert.Contains("authenticated", ex.Message);
-
-                // Method call was rejected
-                Assert.Equal("Hello", rejectedMethod);
-            }
-            finally
-            {
-                server.Config.AuthenticationRequired = false;
-                server.RejectCall -= RejectCall;
-            }
-        }
-
-        [Fact]
-        public void Authentication_handler_has_access_to_the_current_session()
-        {
-            var server = _serverFixture.Server;
-            var authProvider = server.Config.AuthenticationProvider;
-            server.Config.AuthenticationRequired = true;
-            server.Config.AuthenticationProvider = new FakeAuthProvider
-            {
-                AuthenticateFake = c => RemotingSession.Current != null
-            };
-
-            using var ctx = ValidationSyncContext.Install();
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                    Credentials = [new()],
-                });
-
-                client.Connect();
-
-                var proxy = client.CreateProxy<ITestService>();
-                Assert.Equal("123", proxy.Reverse("321"));
-            }
-            finally
-            {
-                server.Config.AuthenticationProvider = authProvider;
-                server.Config.AuthenticationRequired = false;
-            }
-        }
-
-        [Fact]
-        public void Broken_auhentication_handler_doesnt_break_the_server()
-        {
-            var server = _serverFixture.Server;
-            var authProvider = server.Config.AuthenticationProvider;
-            server.Config.AuthenticationRequired = true;
-            server.Config.AuthenticationProvider = new FakeAuthProvider
-            {
-                AuthenticateFake = c => throw new Exception("Broken")
-            };
-
-            using var ctx = ValidationSyncContext.Install();
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 3,
-                    InvocationTimeout = 3,
-                    SendTimeout = 3,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                    Credentials = [new()],
-                });
-
-                var ex = Assert.Throws<SecurityException>(client.Connect);
-
-                Assert.Contains("auth", ex.Message.ToLower());
-                Assert.Contains("failed", ex.Message);
-            }
-            finally
-            {
-                server.Config.AuthenticationProvider = authProvider;
-                server.Config.AuthenticationRequired = false;
-                _serverFixture.ServerErrorCount = 0;
-            }
-        }
-
-        [Fact]
-        public void Authentication_handler_can_check_client_address()
-        {
-            var server = _serverFixture.Server;
-            var authProvider = server.Config.AuthenticationProvider;
-            server.Config.AuthenticationRequired = true;
-            server.Config.AuthenticationProvider = new FakeAuthProvider
-            {
-                AuthenticateFake = c =>
-                {
-                    var address = RemotingSession.Current?.ClientAddress ??
-                        throw new ArgumentNullException("ClientAddress");
-
-                    // allow only localhost connections
-                    return address.Contains("127.0.0.1") || // ipv4
-                        address.Contains("[::1]"); // ipv6
-                }
-            };
-
-            using var ctx = ValidationSyncContext.Install();
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                    Credentials = [new Credential()],
-                });
-
-                client.Connect();
-
-                var proxy = client.CreateProxy<ITestService>();
-                Assert.Equal("123", proxy.Reverse("321"));
-            }
-            finally
-            {
-                server.Config.AuthenticationProvider = authProvider;
-                server.Config.AuthenticationRequired = false;
-            }
-        }
-
-        [Fact]
-        public void ServerComponent_can_track_client_network_address()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
             using var client = new RemotingClient(new ClientConfig()
             {
                 ConnectionTimeout = 0,
                 InvocationTimeout = 0,
                 SendTimeout = 0,
-                MessageEncryption = false,
                 Channel = ClientChannel,
+                MessageEncryption = false,
+                Credentials = [new()],
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
             });
 
             client.Connect();
 
-            var proxy = client.CreateProxy<ISessionAwareService>();
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("Hello", proxy.Echo("Hello"));
 
-            // what's my address as seen by remote server?
-            Assert.NotNull(proxy.ClientAddress);
+            client.Disconnect();
+
+            Assert.True(logon);
+            Assert.True(logoff);
         }
-
-        [Fact]
-        public void Logon_and_logoff_events_are_triggered()
+        finally
         {
-            using var ctx = ValidationSyncContext.Install();
-
-            void CheckSession(string operation)
-            {
-                var rs = RemotingSession.Current;
-                Assert.NotNull(rs);
-                Assert.True(rs?.IsAuthenticated);
-                Assert.NotNull(rs?.ClientAddress);
-                Assert.NotNull(rs?.Identity);
-                Console.WriteLine($"Client {rs.Identity.Name} from {rs.ClientAddress} is {operation}");
-            }
-
-            var logon = false;
-            void Logon(object sender, EventArgs _)
-            {
-                logon = true;
-                CheckSession("logged on");
-            }
-
-            var logoff = false;
-            void Logoff(object sender, EventArgs _)
-            {
-                logoff = true;
-                CheckSession("logged off");
-            }
-
-            var server = _serverFixture.Server;
-            var authProvider = server.Config.AuthenticationProvider;
-            server.Config.AuthenticationProvider = new FakeAuthProvider();
-
-            server.Logon += Logon;
-            server.Logoff += Logoff;
-            server.Config.AuthenticationRequired = true;
-
-            try
-            {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    Credentials = [new()],
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                });
-
-                client.Connect();
-
-                var proxy = client.CreateProxy<ITestService>();
-                Assert.Equal("Hello", proxy.Echo("Hello"));
-
-                client.Disconnect();
-
-                Assert.True(logon);
-                Assert.True(logoff);
-            }
-            finally
-            {
-                server.Config.AuthenticationProvider = authProvider;
-                server.Config.AuthenticationRequired = false;
-                server.Logoff -= Logoff;
-                server.Logon -= Logon;
-            }
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+            server.Logoff -= Logoff;
+            server.Logon -= Logon;
         }
+    }
 
-        [Fact]
-        public void BeginCall_event_handler_can_bypass_authentication_for_chosen_method()
+    [Fact]
+    public void BeginCall_event_handler_can_bypass_authentication_for_chosen_method()
+    {
+        void BypassAuthorizationForEcho(object sender, ServerRpcContext e) =>
+            e.AuthenticationRequired =
+                e.MethodCallMessage.MethodName != "Echo";
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.Config.AuthenticationRequired = true;
+        _serverFixture.Server.BeginCall += BypassAuthorizationForEcho;
+
+        try
         {
-            void BypassAuthorizationForEcho(object sender, ServerRpcContext e) =>
-                e.AuthenticationRequired =
-                    e.MethodCallMessage.MethodName != "Echo";
-
-            using var ctx = ValidationSyncContext.Install();
-            _serverFixture.Server.Config.AuthenticationRequired = true;
-            _serverFixture.Server.BeginCall += BypassAuthorizationForEcho;
-
-            try
+            using var client = new RemotingClient(new ClientConfig()
             {
-                using var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    InvocationTimeout = 0,
-                    SendTimeout = 0,
-                    Channel = ClientChannel,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort,
-                });
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
 
-                client.Connect();
+            client.Connect();
 
-                // try allowed method "Echo"
-                var proxy = client.CreateProxy<ITestService>();
-                Assert.Equal("This method is allowed", proxy.Echo("This method is allowed"));
+            // try allowed method "Echo"
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("This method is allowed", proxy.Echo("This method is allowed"));
 
-                // try disallowed method "Reverse"
-                var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Reverse("This method is not allowed"));
-                Assert.Contains("auth", ex.Message);
-            }
-            finally
-            {
-                _serverFixture.Server.BeginCall -= BypassAuthorizationForEcho;
-                _serverFixture.Server.Config.AuthenticationRequired = false;
-            }
+            // try disallowed method "Reverse"
+            var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Reverse("This method is not allowed"));
+            Assert.Contains("auth", ex.Message);
+        }
+        finally
+        {
+            _serverFixture.Server.BeginCall -= BypassAuthorizationForEcho;
+            _serverFixture.Server.Config.AuthenticationRequired = false;
         }
     }
 }

--- a/CoreRemoting.Tests/RpcTests_Websockets.cs
+++ b/CoreRemoting.Tests/RpcTests_Websockets.cs
@@ -3,16 +3,15 @@ using CoreRemoting.Channels.Websocket;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class RpcTests_Websockets : RpcTests
 {
-    public class RpcTests_Websockets : RpcTests
+    protected override IServerChannel ServerChannel => new WebsocketServerChannel();
+
+    protected override IClientChannel ClientChannel => new WebsocketClientChannel();
+
+    public RpcTests_Websockets(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
     {
-        protected override IServerChannel ServerChannel => new WebsocketServerChannel();
-
-        protected override IClientChannel ClientChannel => new WebsocketClientChannel();
-
-        public RpcTests_Websockets(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
-        {
-        }
     }
 }

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -4,195 +4,222 @@ using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreRemoting.Authentication;
 using CoreRemoting.Tests.Tools;
 using CoreRemoting.Toolbox;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+[SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+[SuppressMessage("ReSharper", "CoVariantArrayConversion")]
+public class SessionTests : IClassFixture<ServerFixture>
 {
-    [Collection("CoreRemoting")]
-    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
-    [SuppressMessage("ReSharper", "CoVariantArrayConversion")]
-    public class SessionTests : IClassFixture<ServerFixture>
+    private readonly ServerFixture _serverFixture;
+
+    public SessionTests(ServerFixture serverFixture)
     {
-        private readonly ServerFixture _serverFixture;
+        _serverFixture = serverFixture;
+        _serverFixture.Start();
+    }
+    
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+    public async Task Client_Connect_should_create_new_session_AND_Disconnect_should_close_session()
+    {
+        using var ctx = ValidationSyncContext.Install();
 
-        public SessionTests(ServerFixture serverFixture)
+        var clientStarted1 = new TaskCompletionSource();
+        var clientStarted2 = new TaskCompletionSource();
+        var clientStopSignal = new TaskCompletionSource();
+
+        async Task ClientTask(TaskCompletionSource connected)
         {
-            _serverFixture = serverFixture;
-            _serverFixture.Start();
-        }
-        
-        [Fact]
-        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-        public async Task Client_Connect_should_create_new_session_AND_Disconnect_should_close_session()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
-            var clientStarted1 = new TaskCompletionSource();
-            var clientStarted2 = new TaskCompletionSource();
-            var clientStopSignal = new TaskCompletionSource();
-
-            async Task ClientTask(TaskCompletionSource connected)
+            var client = new RemotingClient(new ClientConfig()
             {
-                var client = new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    MessageEncryption = false,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort
-                });
+                ConnectionTimeout = 0,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
 
-                Assert.False(client.HasSession);
-                client.Connect();
-
-                connected.TrySetResult();
-                Assert.True(client.HasSession);
-
-                await clientStopSignal.Task.ConfigureAwait(false);
-                client.Dispose();
-            }
-
-            // There should be no sessions, before both clients connected
-            Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
-
-            // Start two clients to create two sessions
-            var client1 = ClientTask(clientStarted1);
-            var client2 = ClientTask(clientStarted2);
-
-            // Wait for connection of both clients
-            await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(1).ConfigureAwait(false);
-
-            Assert.Equal(2, _serverFixture.Server.SessionRepository.Sessions.Count());
-
-            clientStopSignal.TrySetResult();
-
-            await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(1).ConfigureAwait(false);
-
-            // There should be no sessions left, after both clients disconnected
-            Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
-        }
-
-        [Fact]
-        public void Client_Connect_should_throw_exception_on_invalid_auth_credentials()
-        {
-            using var ctx = ValidationSyncContext.Install();
-
-            var serverConfig =
-                new ServerConfig()
-                {
-                    UniqueServerInstanceName = "AuthServer",
-                    IsDefault = false,
-                    MessageEncryption = false,
-                    NetworkPort = 9095,
-                    AuthenticationRequired = true,
-                    AuthenticationProvider = new FakeAuthProvider()
-                    {
-                        AuthenticateFake = credentials => credentials[1].Value == "secret"
-                    }
-                };
-            
-            var server = new RemotingServer(serverConfig);
-            server.Start();
-
-            try
-            {
-                var clientAction = new Action<string, bool>((password, shouldThrow) =>
-                {
-                    using var client = 
-                        new RemotingClient(new ClientConfig()
-                        {
-                            ConnectionTimeout = 0,
-                            ServerPort = server.Config.NetworkPort,
-                            MessageEncryption = false,
-                            Credentials =
-                            [
-                                new() { Name = "User", Value = "tester" },
-                                new() { Name = "Password", Value = password }
-                            ]
-                        });
-                
-                    if (shouldThrow)
-                        Assert.Throws<SecurityException>(() => client.Connect());
-                    else
-                        client.Connect();
-                });
-
-                var clientThread1 = new Thread(() => clientAction("wrong", true));
-                clientThread1.Start();
-                clientThread1.Join();
-            
-                var clientThread2 = new Thread(() => clientAction("secret", false));
-                clientThread2.Start();
-                clientThread2.Join();
-
-                Assert.Equal(0, _serverFixture.ServerErrorCount);
-            }
-            finally
-            {
-                server.Stop();
-            }
-        }
-
-        [Fact]
-        public void RemotingSession_Dispose_should_disconnect_client()
-        {
-            _serverFixture.TestService.TestMethodFake = _ =>
-            {
-                RemotingSession.Current.Close();
-                return null;
-            };
-
-            using var ctx = ValidationSyncContext.Install();
-
-            var client =
-                new RemotingClient(new ClientConfig()
-                {
-                    ConnectionTimeout = 0,
-                    MessageEncryption = false,
-                    SendTimeout = 0,
-                    ServerPort = _serverFixture.Server.Config.NetworkPort
-                });
-
-            var waitForDisconnect = new ManualResetEventSlim(initialState: false);
-
-            client.AfterDisconnect += () =>
-            {
-                waitForDisconnect.Set();
-            };
-            
+            Assert.False(client.HasSession);
             client.Connect();
-            var proxy = client.CreateProxy<ITestService>();
 
-            proxy.TestMethod(null);
+            connected.TrySetResult();
+            Assert.True(client.HasSession);
 
-            waitForDisconnect.Wait();
-            Assert.False(client.IsConnected);
-            
+            await clientStopSignal.Task.ConfigureAwait(false);
             client.Dispose();
         }
 
-        [Fact]
-        public void RemotingSession_should_be_accessible_to_the_component_constructor()
-        {
-            using var ctx = ValidationSyncContext.Install();
+        // There should be no sessions, before both clients connected
+        Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
 
-            using var client = new RemotingClient(new ClientConfig()
+        // Start two clients to create two sessions
+        var client1 = ClientTask(clientStarted1);
+        var client2 = ClientTask(clientStarted2);
+
+        // Wait for connection of both clients
+        await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(1).ConfigureAwait(false);
+
+        Assert.Equal(2, _serverFixture.Server.SessionRepository.Sessions.Count());
+
+        clientStopSignal.TrySetResult();
+
+        await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(1).ConfigureAwait(false);
+
+        // There should be no sessions left, after both clients disconnected
+        Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
+    }
+
+    [Fact]
+    public void Client_Connect_should_throw_exception_on_invalid_auth_credentials()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        var serverConfig =
+            new ServerConfig()
             {
-                ConnectionTimeout = 0,
-                InvocationTimeout = 0,
-                SendTimeout = 0,
+                UniqueServerInstanceName = "AuthServer",
+                IsDefault = false,
                 MessageEncryption = false,
-                ServerPort = _serverFixture.Server.Config.NetworkPort,
+                NetworkPort = 9095,
+                AuthenticationRequired = true,
+                AuthenticationProvider = new FakeAuthProvider()
+                {
+                    AuthenticateFake = credentials => credentials[1].Value == "secret"
+                }
+            };
+        
+        var server = new RemotingServer(serverConfig);
+        server.Start();
+
+        try
+        {
+            var clientAction = new Action<string, bool>((password, shouldThrow) =>
+            {
+                using var client = 
+                    new RemotingClient(new ClientConfig()
+                    {
+                        ConnectionTimeout = 0,
+                        ServerPort = server.Config.NetworkPort,
+                        MessageEncryption = false,
+                        Credentials =
+                        [
+                            new() { Name = "User", Value = "tester" },
+                            new() { Name = "Password", Value = password }
+                        ]
+                    });
+            
+                if (shouldThrow)
+                    Assert.Throws<SecurityException>(() => client.Connect());
+                else
+                    client.Connect();
             });
 
-            client.Connect();
+            var clientThread1 = new Thread(() => clientAction("wrong", true));
+            clientThread1.Start();
+            clientThread1.Join();
+        
+            var clientThread2 = new Thread(() => clientAction("secret", false));
+            clientThread2.Start();
+            clientThread2.Join();
 
-            // RemotingSession.Current should be accessible to the component constructor
-            var proxy = client.CreateProxy<ISessionAwareService>();
-
-            // RemotingSession should be the same as in the constructor
-            Assert.True(proxy.HasSameSessionInstance);
+            Assert.Equal(0, _serverFixture.ServerErrorCount);
         }
+        finally
+        {
+            server.Stop();
+        }
+    }
+
+    [Fact]
+    public void RemotingSession_Dispose_should_disconnect_client()
+    {
+        _serverFixture.TestService.TestMethodFake = _ =>
+        {
+            RemotingSession.Current.Close();
+            return null;
+        };
+
+        using var ctx = ValidationSyncContext.Install();
+
+        var client =
+            new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                MessageEncryption = false,
+                SendTimeout = 0,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+        var waitForDisconnect = new ManualResetEventSlim(initialState: false);
+
+        client.AfterDisconnect += () =>
+        {
+            waitForDisconnect.Set();
+        };
+        
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        proxy.TestMethod(null);
+
+        waitForDisconnect.Wait();
+        Assert.False(client.IsConnected);
+        
+        client.Dispose();
+    }
+
+    [Fact]
+    public void RemotingSession_should_be_accessible_to_the_component_constructor()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        // RemotingSession.Current should be accessible to the component constructor
+        var proxy = client.CreateProxy<ISessionAwareService>();
+
+        // RemotingSession should be the same as in the constructor
+        Assert.True(proxy.HasSameSessionInstance);
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+    public async Task CloseSession_method_should_close_session_gracefully_issue55()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        var disconnected = new TaskCompletionSource<bool>();
+        client.Connect();
+        client.AfterDisconnect += () => disconnected.TrySetResult(true);
+
+        // RemotingSession.Current should be accessible to the component constructor
+        var proxy = client.CreateProxy<ISessionAwareService>();
+
+        // CloseSession shouldn't throw exceptions
+        proxy.CloseSession();
+
+        // Disconnection event should occur
+        await disconnected.Task.Timeout(1).ConfigureAwait(false);
     }
 }

--- a/CoreRemoting.Tests/SignatureTests.cs
+++ b/CoreRemoting.Tests/SignatureTests.cs
@@ -2,33 +2,32 @@ using System.Text;
 using CoreRemoting.Encryption;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class SignatureTests
 {
-    public class SignatureTests
+    [Fact]
+    public void VerifySignature_should_return_true_if_signature_is_valid()
     {
-        [Fact]
-        public void VerifySignature_should_return_true_if_signature_is_valid()
-        {
-            int keySize = 4096;
-            var keyPair = new RsaKeyPair(keySize);
+        int keySize = 4096;
+        var keyPair = new RsaKeyPair(keySize);
 
-            var data = Encoding.UTF8.GetBytes("Test");
+        var data = Encoding.UTF8.GetBytes("Test");
 
-            var signature =
-                RsaSignature.CreateSignature(
-                    keySize: keySize,
-                    sendersPrivateKeyBlob: keyPair.PrivateKey,
-                    rawData: data);
+        var signature =
+            RsaSignature.CreateSignature(
+                keySize: keySize,
+                sendersPrivateKeyBlob: keyPair.PrivateKey,
+                rawData: data);
 
-            var result =
-                RsaSignature.VerifySignature(
-                    keySize: keySize,
-                    sendersPublicKeyBlob: keyPair.PublicKey,
-                    rawData: data,
-                    signature: signature);
-            
-            Assert.Equal(512, signature.Length);
-            Assert.True(result);
-        }
+        var result =
+            RsaSignature.VerifySignature(
+                keySize: keySize,
+                sendersPublicKeyBlob: keyPair.PublicKey,
+                rawData: data,
+                signature: signature);
+        
+        Assert.Equal(512, signature.Length);
+        Assert.True(result);
     }
 }

--- a/CoreRemoting.Tests/Tools/ISessionAwareService.cs
+++ b/CoreRemoting.Tests/Tools/ISessionAwareService.cs
@@ -1,4 +1,7 @@
-﻿namespace CoreRemoting.Tests.Tools
+﻿using System.Threading.Tasks;
+using System;
+
+namespace CoreRemoting.Tests.Tools
 {
     public interface ISessionAwareService
     {
@@ -6,6 +9,8 @@
 
         string ClientAddress { get; }
 
-        void CloseSession();
+        Task Wait(double seconds);
+
+        Task CloseSession(double seconds);
     }
 }

--- a/CoreRemoting.Tests/Tools/ISessionAwareService.cs
+++ b/CoreRemoting.Tests/Tools/ISessionAwareService.cs
@@ -5,5 +5,7 @@
         bool HasSameSessionInstance { get; }
 
         string ClientAddress { get; }
+
+        void CloseSession();
     }
 }

--- a/CoreRemoting.Tests/Tools/SessionAwareService.cs
+++ b/CoreRemoting.Tests/Tools/SessionAwareService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace CoreRemoting.Tests.Tools
 {
@@ -22,5 +23,11 @@ namespace CoreRemoting.Tests.Tools
 
         public string ClientAddress =>
             CurrentSession.ClientAddress;
+
+        public void CloseSession()
+        {
+            RemotingSession.Current.Close();
+            Thread.Sleep(TimeSpan.FromSeconds(0.8));
+        }
     }
 }

--- a/CoreRemoting.Tests/Tools/SessionAwareService.cs
+++ b/CoreRemoting.Tests/Tools/SessionAwareService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace CoreRemoting.Tests.Tools
 {
@@ -24,10 +25,13 @@ namespace CoreRemoting.Tests.Tools
         public string ClientAddress =>
             CurrentSession.ClientAddress;
 
-        public void CloseSession()
+        public async Task Wait(double seconds) =>
+            await Task.Delay(TimeSpan.FromSeconds(seconds));
+
+        public async Task CloseSession(double seconds)
         {
             RemotingSession.Current.Close();
-            Thread.Sleep(TimeSpan.FromSeconds(0.8));
+            await Wait(seconds);
         }
     }
 }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -46,8 +46,7 @@ namespace CoreRemoting
         private byte[] _serverPublicKeyBlob;
 
         // ReSharper disable once InconsistentNaming
-        private static readonly ConcurrentDictionary<string, IRemotingClient> _clientInstances =
-            new ConcurrentDictionary<string, IRemotingClient>();
+        private static readonly ConcurrentDictionary<string, IRemotingClient> _clientInstances = new();
 
         private static WeakReference<IRemotingClient> _defaultRemotingClientRef;
 
@@ -144,7 +143,7 @@ namespace CoreRemoting
         /// <summary>
         /// Gets the proxy generator instance.
         /// </summary>
-        private static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
+        private static readonly ProxyGenerator ProxyGenerator = new();
 
         /// <summary>
         /// Gets a utility object for building remoting messages.

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -424,7 +424,7 @@ namespace CoreRemoting
                 _server.Serializer
                     .Deserialize<MethodCallMessage>(decryptedRawMessage);
 
-            ServerRpcContext serverRpcContext =
+            var serverRpcContext =
                 new ServerRpcContext
                 {
                     UniqueCallKey =


### PR DESCRIPTION
Closing the current session shouldn't throw exceptions during the current RPC call:

```cs
public void CloseSession()
{
    RemotingSession.Current.Close();
}
```

RPC for `CloseSession` should be executed without exceptions, with Disconnect event after. 

Furthermore, `CloseSession` should wait until all pending RPC results are sent back to the client within the specified timeout.