### PR TITLE
Added IoC container stress test

### DIFF
--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -45,6 +45,13 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Compile Remove="RpcTests_Websockets.cs" />
+      <Compile Include="RpcTests_Websockets.cs">
+        <DependentUpon>RpcTests.cs</DependentUpon>
+      </Compile>
+    </ItemGroup>
+    
+    <ItemGroup>
       <None Update="TestConfig.xml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>

--- a/CoreRemoting.Tests/DicTests.cs
+++ b/CoreRemoting.Tests/DicTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreRemoting.DependencyInjection;
+using CoreRemoting.Tests.Tools;
+using Xunit;
+
+namespace CoreRemoting.Tests
+{
+    public class DicTests
+    {
+        public virtual IDependencyInjectionContainer Container =>
+            new CastleWindsorDependencyInjectionContainer();
+
+        [Fact]
+        public void Registered_service_is_resolved()
+        {
+            var c = Container;
+            c.RegisterService<ITestService, TestService>(
+                ServiceLifetime.SingleCall, "1");
+
+            var svc = c.GetService<ITestService>("1");
+            Assert.NotNull(svc);
+            Assert.IsType<TestService>(svc);
+        }
+
+        [Fact]
+        public void Registered_factory_is_resolved()
+        {
+            var c = Container;
+            c.RegisterService<ITestService>(
+                () => new TestService(), ServiceLifetime.SingleCall, "2");
+
+            var svc = c.GetService<ITestService>("2");
+            Assert.NotNull(svc);
+            Assert.IsType<TestService>(svc);
+        }
+
+        [Fact]
+        [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+        public async Task Register_multiple_services_thread_safety()
+        {
+            var c = Container;
+            var t = new HashSet<int>();
+
+            void RegisterService()
+            {
+                t.Add(Thread.CurrentThread.ManagedThreadId);
+                c.RegisterService<ITestService, TestService>(
+                    ServiceLifetime.SingleCall, Guid.NewGuid().ToString());
+            }
+
+            void RegisterFactory()
+            {
+                t.Add(Thread.CurrentThread.ManagedThreadId);
+                c.RegisterService<ITestService>(() => new TestService(),
+                    ServiceLifetime.SingleCall, Guid.NewGuid().ToString());
+            }
+
+            var tasks = new List<Task>();
+            for (var i = 0; i < 500; i++)
+            {
+                tasks.Add(Task.Run(RegisterService));
+                tasks.Add(Task.Run(RegisterFactory));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // check if all registrations are there
+            var regs = c.GetServiceRegistrations();
+            Assert.NotNull(regs);
+            Assert.Equal(1000, regs.Count());
+
+            // check if we actually used many threads
+            Console.WriteLine($"Registration threads: {t.Count}");
+            Assert.True(t.Count > 1);
+        }
+    }
+}

--- a/CoreRemoting/CoreRemoting.csproj
+++ b/CoreRemoting/CoreRemoting.csproj
@@ -69,5 +69,5 @@
     <ItemGroup>
       <Compile Remove="Toolbox\Disposable.Async.cs" />
     </ItemGroup>
-    
+
 </Project>

--- a/CoreRemoting/DependencyInjection/IDependencyInjectionContainer.cs
+++ b/CoreRemoting/DependencyInjection/IDependencyInjectionContainer.cs
@@ -37,7 +37,7 @@ namespace CoreRemoting.DependencyInjection
             string serviceName = "",
             bool asHiddenSystemService = false)
             where TServiceInterface : class
-            where  TServiceImpl : class, TServiceInterface;
+            where TServiceImpl : class, TServiceInterface;
 
         /// <summary>
         /// Registers a service.


### PR DESCRIPTION
The idea is to run lots of registrations in parallel and check if nothing is lost and no errors are thrown.
If this test fails, then the container needs additional machinery to ensure thread safety.

UPD. Screenshot from Visual Studio test runner shows there are 14 threads:

![image](https://github.com/user-attachments/assets/3af3c899-4027-4433-9382-f45d181b8efc)
