### PR TITLE
Update WatsonTcp dependency to v6.0.9, close #121.

### DIFF
--- a/CoreRemoting.Tests/DicTests.cs
+++ b/CoreRemoting.Tests/DicTests.cs
@@ -158,7 +158,7 @@ public class DicTests
         var t = new ConcurrentDictionary<int, int>();
 
         void RegisterCurrentThread() =>
-            t.TryAdd(Thread.CurrentThread.ManagedThreadId, 0);
+            t.TryAdd(Environment.CurrentManagedThreadId, 0);
 
         void RegisterService()
         {

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -517,6 +517,8 @@ public class RpcTests : IClassFixture<ServerFixture>
         // a localized message similar to "Method 'Missing method' not found"
         Assert.NotNull(ex);
         Assert.Contains("Missing Method", ex.Message);
+
+        Console.WriteLine(_serverFixture.LastServerError);
         Assert.Equal(0, _serverFixture.ServerErrorCount);
     }
 

--- a/CoreRemoting.Tests/ServerFixture.cs
+++ b/CoreRemoting.Tests/ServerFixture.cs
@@ -11,6 +11,8 @@ public class ServerFixture : IDisposable
 {
     public int ServerErrorCount;
 
+    public Exception LastServerError;
+
     public ServerFixture()
     {
         TestService = new TestService();
@@ -98,8 +100,9 @@ public class ServerFixture : IDisposable
             ServerConfig.Channel = channel;
 
         Server = new RemotingServer(ServerConfig);
-        Server.Error += (_, _) =>
+        Server.Error += (s, ex) =>
         {
+            LastServerError = ex;
             ServerErrorCount++;
         };
 

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -195,7 +195,6 @@ public class SessionTests : IClassFixture<ServerFixture>
     }
 
     [Fact]
-    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
     public async Task CloseSession_method_should_close_session_gracefully_issue55()
     {
         using var client = new RemotingClient(new ClientConfig()

--- a/CoreRemoting/CoreRemoting.csproj
+++ b/CoreRemoting/CoreRemoting.csproj
@@ -59,7 +59,7 @@
       <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
       <PackageReference Include="System.Security.Cryptography.OpenSsl" Version="5.0.0" />
       <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
-      <PackageReference Include="WatsonTcp" Version="6.0.8" />
+      <PackageReference Include="WatsonTcp" Version="6.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/CoreRemoting/RemoteDelegates/EventStub.cs
+++ b/CoreRemoting/RemoteDelegates/EventStub.cs
@@ -277,7 +277,7 @@ public class EventStub
             set { TypedDelegate = (T)(object)value; }
         }
 
-        private object syncRoot = new object();
+        private object syncRoot = new();
 
         public void AddHandler(Delegate handler)
         {
@@ -396,9 +396,8 @@ public class EventStub
         foreach (var d in handler.GetInvocationList())
         {
             // check if it's a delegate holder
-            if (d.Target is IDelegateHolder)
+            if (d.Target is IDelegateHolder holder)
             {
-                var holder = (IDelegateHolder)d.Target;
                 count += holder.HandlerCount;
                 continue;
             }

--- a/CoreRemoting/RemotingServer.cs
+++ b/CoreRemoting/RemotingServer.cs
@@ -25,8 +25,7 @@ namespace CoreRemoting
         private readonly string _uniqueServerInstanceName;
 
         // ReSharper disable once InconsistentNaming
-        private static readonly ConcurrentDictionary<string, IRemotingServer> _serverInstances =
-            new ConcurrentDictionary<string, IRemotingServer>();
+        private static readonly ConcurrentDictionary<string, IRemotingServer> _serverInstances = new();
 
         private static WeakReference<IRemotingServer> _defaultRemotingServerRef;
 

--- a/CoreRemoting/ServiceProxy.cs
+++ b/CoreRemoting/ServiceProxy.cs
@@ -261,8 +261,9 @@ namespace CoreRemoting
                 argumentType is
                 {
                     IsGenericType: true,
-                    BaseType: { IsGenericType: true }
-                } && argumentType.BaseType.GetGenericTypeDefinition() == typeof(Expression<>);
+                    BaseType.IsGenericType: true
+                }
+                && argumentType.BaseType.GetGenericTypeDefinition() == typeof(Expression<>);
 
             if (!isLinqExpression)
             {


### PR DESCRIPTION
Brings back support for .NET Standard 2.0 platform.