### PR TITLE
Customizable service proxies

### DIFF
--- a/CoreRemoting.Tests/Tools/CustomProxyBuilder.cs
+++ b/CoreRemoting.Tests/Tools/CustomProxyBuilder.cs
@@ -1,0 +1,44 @@
+﻿namespace CoreRemoting.Tests.Tools;
+
+/// <summary>
+/// Custom proxy builder for unit tests.
+/// </summary>
+public class CustomProxyBuilder : RemotingProxyBuilder
+{
+    /// <summary>
+    /// Intercepts <see cref="IGenericEchoService"/> calls.
+    /// </summary>
+    private class GenericEchoInterceptor : IGenericEchoService
+    {
+        public GenericEchoInterceptor(IGenericEchoService svc)
+        {
+            Svc = svc;
+        }
+
+        public IGenericEchoService Svc { get; }
+
+        public T Echo<T>(T value)
+        {
+            var result = Svc.Echo(value);
+            if (value is string v)
+            {
+                v = "[" + v + "]";
+                return (T)(object)v;
+            }
+
+            return result;
+        }
+    }
+
+    public override T CreateProxy<T>(RemotingClient remotingClient, string serviceName = "")
+    {
+        var proxy = base.CreateProxy<T>(remotingClient, serviceName);
+        if (typeof(T) != typeof(IGenericEchoService))
+        {
+            return proxy;
+        }
+
+        var result = new GenericEchoInterceptor(proxy as IGenericEchoService);
+        return (T)(object)result;
+    }
+}

--- a/CoreRemoting/ClientConfig.cs
+++ b/CoreRemoting/ClientConfig.cs
@@ -89,5 +89,10 @@ namespace CoreRemoting
         /// Gets or set whether this is the default client.
         /// </summary>
         public bool IsDefault { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets an utility class to create remoting proxies.
+        /// </summary>
+        public RemotingProxyBuilder ProxyBuilder { get; set; }
     }
 }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -770,12 +770,9 @@ namespace CoreRemoting
         /// <returns>Proxy object</returns>
         public object CreateProxy(Type serviceInterfaceType, string serviceName = "")
         {
-            var serviceProxyType = typeof(ServiceProxy<>).MakeGenericType(serviceInterfaceType);
-            var serviceProxy = Activator.CreateInstance(serviceProxyType, this, serviceName);
-
-            return ProxyGenerator.CreateInterfaceProxyWithoutTarget(
-                interfaceToProxy: serviceInterfaceType,
-                interceptor: (IInterceptor)serviceProxy);
+            var createMethodInfo = new Func<string, int>(CreateProxy<int>).Method.GetGenericMethodDefinition();
+            var createProxyFunc = createMethodInfo.MakeGenericMethod([serviceInterfaceType]);
+            return createProxyFunc.Invoke(this, [serviceName]);
         }
 
         /// <summary>

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -83,6 +83,7 @@ namespace CoreRemoting
 
             Serializer = config.Serializer ?? new BsonSerializerAdapter();
             MessageEncryption = config.MessageEncryption;
+            ProxyBuilder = config.ProxyBuilder ?? new RemotingProxyBuilder();
 
             _config = config;
 
@@ -141,9 +142,9 @@ namespace CoreRemoting
         #region Properties
 
         /// <summary>
-        /// Gets the proxy generator instance.
+        /// Gets or sets an utility class to create remoting proxies.
         /// </summary>
-        private static readonly ProxyGenerator ProxyGenerator = new();
+        internal RemotingProxyBuilder ProxyBuilder { get; set; }
 
         /// <summary>
         /// Gets a utility object for building remoting messages.
@@ -753,14 +754,8 @@ namespace CoreRemoting
         /// <typeparam name="T">Type of the shared interface of the remote service</typeparam>
         /// <param name="serviceName">Unique name of the remote service</param>
         /// <returns>Proxy object</returns>
-        public T CreateProxy<T>(string serviceName = "")
-        {
-            return (T) ProxyGenerator.CreateInterfaceProxyWithoutTarget(
-                interfaceToProxy: typeof(T),
-                interceptor: new ServiceProxy<T>(
-                    client: this,
-                    serviceName: serviceName));
-        }
+        public T CreateProxy<T>(string serviceName = "") =>
+            ProxyBuilder.CreateProxy<T>(this, serviceName);
 
         /// <summary>
         /// Creates a proxy object to provide access to a remote service.

--- a/CoreRemoting/RemotingProxyBuilder.cs
+++ b/CoreRemoting/RemotingProxyBuilder.cs
@@ -1,0 +1,30 @@
+﻿using Castle.DynamicProxy;
+
+namespace CoreRemoting;
+
+/// <summary>
+/// Default remoting proxy builder implementation.
+/// </summary>
+public class RemotingProxyBuilder
+{
+    /// <summary>
+    /// Gets the proxy generator instance.
+    /// </summary>
+    protected static readonly ProxyGenerator ProxyGenerator = new();
+
+    /// <summary>
+    /// Creates a proxy object to provide access to a remote service.
+    /// </summary>
+    /// <typeparam name="T">Type of the shared interface of the remote service</typeparam>
+    /// <param name="remotingClient"><see cref="IRemotingClient"/> instance to make remote calls</param>
+    /// <param name="serviceName">Unique name of the remote service</param>
+    /// <returns>Proxy object</returns>
+    public virtual T CreateProxy<T>(RemotingClient remotingClient, string serviceName = "")
+    {
+        return (T)ProxyGenerator.CreateInterfaceProxyWithoutTarget(
+            interfaceToProxy: typeof(T),
+            interceptor: new ServiceProxy<T>(
+                client: remotingClient,
+                serviceName: serviceName));
+    }
+}

--- a/CoreRemoting/RemotingProxyBuilder.cs
+++ b/CoreRemoting/RemotingProxyBuilder.cs
@@ -19,12 +19,10 @@ public class RemotingProxyBuilder
     /// <param name="remotingClient"><see cref="IRemotingClient"/> instance to make remote calls</param>
     /// <param name="serviceName">Unique name of the remote service</param>
     /// <returns>Proxy object</returns>
-    public virtual T CreateProxy<T>(RemotingClient remotingClient, string serviceName = "")
-    {
-        return (T)ProxyGenerator.CreateInterfaceProxyWithoutTarget(
+    public virtual T CreateProxy<T>(RemotingClient remotingClient, string serviceName = "") =>
+        (T)ProxyGenerator.CreateInterfaceProxyWithoutTarget(
             interfaceToProxy: typeof(T),
             interceptor: new ServiceProxy<T>(
                 client: remotingClient,
                 serviceName: serviceName));
-    }
 }


### PR DESCRIPTION
Certain features of Zyan Framework, such as call interceptors 
and InterLINQ queries require extensibility points in `ServiceProxy`.

This PR adds the ability to specify custom proxy builder in the `ClientConfig`,
which can use custom descendant of `ServiceProxy` to create proxies, i.e.:

```csharp
var config = new ClientConfig
{
    ProxyBuilder = new CustomProxyBuilder(),
    ...
};

var client = new RemotingClient(config);

...

public class CustomProxyBuilder : RemotingProxyBuilder
{
   public override T CreateProxy<T>(RemotingClient remotingClient, string serviceName = "") =>
        (T)ProxyGenerator.CreateInterfaceProxyWithoutTarget(
            interfaceToProxy: typeof(T),
            interceptor: new CustomServiceProxy<T>(
                client: remotingClient,
                serviceName: serviceName));
}

public class CustomServiceProxy<T> : ServiceProxy<T>
{
   ...
   protected override void Intercept(IInvocation invocation)
   {
       ...
   }
}
```