### PR TITLE
Do not hang for 10 seconds in Dispose

### DIFF
--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -467,6 +467,7 @@ namespace CoreRemoting
                     _goodbyeCompletedTaskSource.TrySetResult(true);
                     break;
                 case "session_closed":
+                    _goodbyeCompletedTaskSource.TrySetResult(true);
                     Disconnect(quiet: true);
                     break;
                 default:


### PR DESCRIPTION
if RemotingClient.Dospose() called right after Session close on server side. Hang was at waiting for _goodbyeCompletedTaskSource