### PR TITLE
Added Task.Expire extension method

### DIFF
--- a/CoreRemoting.Tests/TaskTests.cs
+++ b/CoreRemoting.Tests/TaskTests.cs
@@ -87,6 +87,13 @@ namespace CoreRemoting.Tests
         }
 
         [Fact]
+        public async Task Expire_method_returns_true_if_task_completed_and_false_if_task_exceeds_the_specified_timeout()
+        {
+            Assert.True(await Task.Delay(100).Expire(1));
+            Assert.False(await Task.Delay(1000).Expire(0.1));
+        }
+
+        [Fact]
         [SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "<Pending>")]
         public void JustWait_doesnt_wrap_the_exception_into_AggregateException()
         {

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -313,7 +313,7 @@ namespace CoreRemoting
                 //_goodbyeCompletedWaitHandle.Reset();
 
                 if (await _channel.RawMessageTransport.SendMessageAsync(rawData).ConfigureAwait(false))
-                    await _goodbyeCompletedTaskSource.Task.Timeout(10).ConfigureAwait(false);
+                    await _goodbyeCompletedTaskSource.Task.Expire(10).ConfigureAwait(false);
             }
 
             // lock (_syncObject) // TODO: why we are locking here?


### PR DESCRIPTION
Similar to Task.Timeout, but doesn't throw exceptions. Use it with caution! Examples:

```csharp
[Fact]
public async Task Expire_method_returns_true_if_task_completed_and_false_if_task_exceeds_the_specified_timeout()
{
    Assert.True(await Task.Delay(100).Expire(1));
    Assert.False(await Task.Delay(1000).Expire(0.1));
}
```