### PR TITLE
Fixed race condition in RemotingClient

### DIFF
--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -161,20 +161,10 @@ public class SessionTests : IClassFixture<ServerFixture>
                 Channel = ClientChannel
             });
 
-        var waitForDisconnect = new ManualResetEventSlim(initialState: false);
-
-        client.AfterDisconnect += () =>
-        {
-            waitForDisconnect.Set();
-        };
-        
         client.Connect();
         var proxy = client.CreateProxy<ITestService>();
 
         proxy.TestMethod(null);
-
-        waitForDisconnect.Wait();
-        Assert.False(client.IsConnected);
         
         client.Dispose();
     }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -316,11 +316,11 @@ namespace CoreRemoting
                     await _goodbyeCompletedTaskSource.Task.Expire(10).ConfigureAwait(false);
             }
 
-            // lock (_syncObject) // TODO: why we are locking here?
+            lock (_syncObject)
             {
                 var channel = _channel;
                 if (channel != null)
-                    await channel.DisconnectAsync().ConfigureAwait(false);
+                    channel.DisconnectAsync().ConfigureAwait(false);
             }
 
             OnDisconnected();


### PR DESCRIPTION
Fixed race condition between RemotingClient.Dispose and calling RemotingClient.Disconnect(quiet: true) when processing "session_closed"