### PR TITLE
Implemented the AsyncLock, see issue #143

### DIFF
--- a/CoreRemoting.Tests/AsyncLockTests.cs
+++ b/CoreRemoting.Tests/AsyncLockTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
+using Xunit;
+using Xunit.Sdk;
+
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class AsyncLockTests
+{
+    private AsyncLock Lock { get; } = new();
+
+    [Fact]
+    public async Task AsyncLock_is_awaitable()
+    {
+        using (await Lock)
+            await Task.Delay(1);
+
+        using (await Lock)
+            await Task.Delay(2);
+
+        using (await Lock)
+            await Task.Delay(3);
+    }
+
+    private async Task RunSharedResourceTest(bool useLock)
+    {
+        var sharedResource = 0;
+        var taskCount = 1000;
+        var start = new TaskCompletionSource<bool>();
+        var threads = new ConcurrentDictionary<int, bool>();
+
+        async Task Add(int value)
+        {
+            threads[Environment.CurrentManagedThreadId] = await start.Task;
+
+            async Task<IDisposable> OptionalLock() =>
+                useLock ? await Lock : null;
+
+            // access shared resource
+            using (await OptionalLock())
+            {
+                var prevValue = sharedResource;
+                await Task.Yield();
+                sharedResource = prevValue + value;
+            }
+        }
+
+        // spawn concurrent tasks
+        var tasks = Enumerable
+            .Range(1, taskCount)
+            .Select(i => Task.Run(() => Add(i)));
+
+        // start all tasks at once
+        start.TrySetResult(true);
+        await Task.WhenAll(tasks);
+
+        // debugging
+        Console.WriteLine($"Shared resource test: use lock = {useLock}");
+        Console.WriteLine($"Shared resource test: thread count = {threads.Count}");
+        Console.WriteLine($"Shared resource test: result = {sharedResource}");
+
+        // check if there were many threads involved
+        Assert.True(threads.Count > 1);
+
+        // validate the calculation: 1 + 2 + ... + taskCount
+        Assert.Equal((taskCount + 1) * taskCount / 2, sharedResource);
+    }
+
+    [Fact]
+    public async Task AsyncLock_protects_shared_resource_from_concurrent_access()
+    {
+        await RunSharedResourceTest(useLock: true);
+    }
+
+    [Fact]
+    public async Task Missing_AsyncLock_doesnt_protect_shared_resource_from_concurrent_access()
+    {
+        await Assert.ThrowsAsync<EqualException>(async () =>
+            await RunSharedResourceTest(useLock: false));
+    }
+}

--- a/CoreRemoting/Toolbox/AsyncLock.cs
+++ b/CoreRemoting/Toolbox/AsyncLock.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Runtime.CompilerServices;
+
+namespace CoreRemoting.Toolbox;
+
+/// <summary>
+/// Awaitable async locking synchronization primitive.
+/// </summary>
+public class AsyncLock
+{
+    private SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+    /// <summary>
+    /// Locks asynchronously, by awaiting the lock object itself.
+    /// </summary>
+    public TaskAwaiter<IDisposable> GetAwaiter()
+    {
+        async Task<IDisposable> LockAsync()
+        {
+            await Semaphore.WaitAsync();
+            return Disposable.Create(() => Semaphore.Release());
+        }
+
+        return LockAsync().GetAwaiter();
+    }
+}


### PR DESCRIPTION
Usage example:

```csharp
var asyncLock = new AsyncLock();
...
using (await asyncLock)
{
    await Task.Delay(10);
}
```

Demonstrating the protected access to the shared variable:

```csharp
var sharedResource = 0;
...
using (await asyncLock)
{
    var prevValue = sharedResource;
    await Task.Yield();
    sharedResource = prevValue + value;
}
```

Github Action test runner logs demonstrate the difference:

![image](https://github.com/user-attachments/assets/5ae796bf-384c-43ef-8083-6737e751f69f)