### PR TITLE
WebSocket methods thread-safety issues

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,8 +13,12 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
-    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     steps:
     - name: Checkout source

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -65,13 +65,13 @@ public class SessionTests : IClassFixture<ServerFixture>
         var client2 = ClientTask(clientStarted2);
 
         // Wait for connection of both clients
-        await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(1).ConfigureAwait(false);
+        await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(5).ConfigureAwait(false);
 
         Assert.Equal(2, _serverFixture.Server.SessionRepository.Sessions.Count());
 
         clientStopSignal.TrySetResult();
 
-        await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(1).ConfigureAwait(false);
+        await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(5).ConfigureAwait(false);
 
         // There should be no sessions left, after both clients disconnected
         Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);


### PR DESCRIPTION
1. Multiple **SendAsync** cannot be run in parallel, at least on Windows.
Also, multiple **ReceiveAsync** cannot be run in parallel, it seems to break the websocket state.
But **SendAsync** can run in parallel with **ReceiveAsync**.
2. This pull request also adds matrix strategy to run tests on both Linux and Windows.