### PR TITLE
Enable windows-latest conditionally

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: ${{ !contains(github.event.head_commit.message, 'windows') && 'windows-latest' }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - windows-latest
         exclude:
           - os: ${{ !contains(github.event.head_commit.message, 'windows') && 'windows-latest' }}
 


### PR DESCRIPTION
Looks like windows runner is pretty slow compared to linux runner.
To include windows-latest platform, ensure that commit message contains 'windows'.