### PR TITLE
Replaced single _syncObject with a few granular lock objects

### DIFF
--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -36,11 +36,10 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
         _tcpClient = new WatsonTcpClient(client.Config.ServerHostName, client.Config.ServerPort);
         _tcpClient.Settings.NoDelay = true;
 
-        _handshakeMetadata =
-            new Dictionary<string, object>
-            {
-                { "MessageEncryption", client.MessageEncryption }
-            };
+        _handshakeMetadata = new()
+        {
+            { "MessageEncryption", client.MessageEncryption }
+        };
 
         if (client.MessageEncryption)
             _handshakeMetadata.Add("ShakeHands", Convert.ToBase64String(client.PublicKey));
@@ -156,8 +155,6 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     /// <summary>
     /// Disconnect and free manages resources.
     /// </summary>
-    public void Dispose()
-    {
+    public void Dispose() =>
         DisconnectAsync().JustWait();
-    }
 }


### PR DESCRIPTION
Added back `await` channel.DisconnectAsync().

- `_activeCallsLock` protects _activeCalls
- `_channelLock` protects the transport channel
- `_sessionLock` protects _sessionId which is a Guid, a structure too large for atomic reads/writes