### PR TITLE
Simplify tcp channel handshake sequence

### DIFF
--- a/CoreRemoting.Tests/AsyncLockTests.cs
+++ b/CoreRemoting.Tests/AsyncLockTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using CoreRemoting.Tests.Tools;
 using CoreRemoting.Toolbox;
 using Xunit;
 using Xunit.Sdk;
@@ -14,16 +16,22 @@ public class AsyncLockTests
     private AsyncLock Lock { get; } = new();
 
     [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
     public async Task AsyncLock_is_awaitable()
     {
-        using (await Lock)
-            await Task.Delay(1);
+        using var ctx = ValidationSyncContext.Install();
 
         using (await Lock)
-            await Task.Delay(2);
+            await Task.Delay(1)
+                .ConfigureAwait(false);
 
         using (await Lock)
-            await Task.Delay(3);
+            await Task.Delay(2)
+                .ConfigureAwait(false);
+
+        using (await Lock)
+            await Task.Delay(3)
+                .ConfigureAwait(false);
     }
 
     private async Task RunSharedResourceTest(bool useLock)

--- a/CoreRemoting.Tests/DisposableTests.Sync.cs
+++ b/CoreRemoting.Tests/DisposableTests.Sync.cs
@@ -32,6 +32,31 @@ public partial class DisposableTests
     }
 
     [Fact]
+    public void Disposable_executes_function_on_Dispose()
+    {
+        var disposed = false;
+
+        bool Dispose() =>
+            disposed = true;
+
+        using (Disposable.Create(Dispose))
+            Assert.False(disposed);
+
+        Assert.True(disposed);
+    }
+
+    [Fact]
+    public void Disposable_ignores_nulls_function()
+    {
+        Func<int> dispose = null;
+
+        using (Disposable.Create(dispose))
+        {
+            // doesn't throw
+        }
+    }
+
+    [Fact]
     public void Disposable_combines_disposables()
     {
         var count = 0;

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -165,7 +165,6 @@ public class SessionTests : IClassFixture<ServerFixture>
         var proxy = client.CreateProxy<ITestService>();
 
         proxy.TestMethod(null);
-        
         client.Dispose();
     }
 

--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -61,6 +61,7 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
         _tcpClient.Events.ServerDisconnected += OnDisconnected;
         _tcpClient.Connect();
 
+        // note: we don't rely on the Connected event anymore
         await _tcpClient.SendAsync([0], _handshakeMetadata);
     }
 

--- a/CoreRemoting/Toolbox/AsyncLock.cs
+++ b/CoreRemoting/Toolbox/AsyncLock.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 
 namespace CoreRemoting.Toolbox;
 
+using ConfiguredAwaiter = ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwaiter;
+
 /// <summary>
 /// Awaitable async locking synchronization primitive.
 /// </summary>
@@ -15,14 +17,18 @@ public class AsyncLock
     /// <summary>
     /// Locks asynchronously, by awaiting the lock object itself.
     /// </summary>
-    public TaskAwaiter<IDisposable> GetAwaiter()
+    public ConfiguredAwaiter GetAwaiter()
     {
         async Task<IDisposable> LockAsync()
         {
-            await Semaphore.WaitAsync();
-            return Disposable.Create(() => Semaphore.Release());
+            await Semaphore.WaitAsync()
+                .ConfigureAwait(false);
+
+            return Disposable.Create(Semaphore.Release);
         }
 
-        return LockAsync().GetAwaiter();
+        return LockAsync()
+            .ConfigureAwait(false)
+                .GetAwaiter();
     }
 }

--- a/CoreRemoting/Toolbox/Disposable.Sync.cs
+++ b/CoreRemoting/Toolbox/Disposable.Sync.cs
@@ -20,6 +20,19 @@ namespace CoreRemoting.Toolbox
         public static IDisposable Create(Action disposeAction) =>
             new SyncDisposable(disposeAction);
 
+        private class SyncDisposable<T>(Func<T> disposeFunction) : IDisposable
+        {
+            void IDisposable.Dispose() =>
+                disposeFunction?.Invoke();
+        }
+
+        /// <summary>
+        /// Creates a disposable object.
+        /// </summary>
+        /// <param name="disposeFunction">An action to invoke on disposal.</param>
+        public static IDisposable Create<T>(Func<T> disposeFunction) =>
+            new SyncDisposable<T>(disposeFunction);
+
         private class ParamsDisposable(params IDisposable[] disposables) : IDisposable
         {
             void IDisposable.Dispose()


### PR DESCRIPTION
1. Make sure we don't depend on TcpServerChannel event order, see also:
    - #55 
    - #148
3. The original commit related to the frozen tcp handshake: 5ee3266dbc98b726282bff6c5b089de0d9cc75f1. 
4. Also, improved Disposable.Create and AsyncLock helper.