### PR TITLE
Fix "rpc_result" and "session_closed" race condition

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,8 @@ jobs:
           - windows-latest
         exclude:
           - os: ${{ !contains(github.event.head_commit.message, 'windows') && 'windows-latest' }}
+        include:
+          - os: ${{ github.event.pull_request && 'windows-latest' }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/CoreRemoting.Tests/AsyncReaderWriterLockTests.cs
+++ b/CoreRemoting.Tests/AsyncReaderWriterLockTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
+using Xunit;
+
+namespace CoreRemoting.Tests;
+
+[Collection("CoreRemoting")]
+public class AsyncReaderWriterLockTests
+{
+    private AsyncReaderWriterLock AsyncLock { get; } = new();
+
+    [Fact]
+    public async Task AsyncReaderWriterLock_can_enter_and_exit()
+    {
+        var myLock = new AsyncReaderWriterLock();
+
+        await myLock.EnterReadLock();
+        await myLock.ExitReadLock();
+
+        await myLock.EnterWriteLock();
+        await myLock.ExitWriteLock();
+    }
+
+    [Fact]
+    public async Task AsyncReaderWriterLock_simple_multithreaded_test()
+    {
+        var readers = 0;
+        var writers = 0;
+        var readerThreads = new ConcurrentDictionary<int, int>();
+        var writerThreads = new ConcurrentDictionary<int, int>();
+
+        async Task SimulateRead(int ms)
+        {
+            readerThreads[Environment.CurrentManagedThreadId] = 0;
+            await AsyncLock.EnterReadLock();
+
+            try
+            {
+                // in a reader's critical section, there are no writers
+                Assert.Equal(0, writers);
+                Assert.True(readers >= 0);
+
+                Interlocked.Increment(ref readers);
+                await Task.Delay(ms);
+                Interlocked.Decrement(ref readers);
+            }
+            finally
+            {
+                await AsyncLock.ExitReadLock();
+            }
+        }
+
+        async Task SimulateWrite(int ms)
+        {
+            writerThreads[Environment.CurrentManagedThreadId] = 0;
+            await AsyncLock.EnterWriteLock();
+
+            try
+            {
+                // in a writer's critical section, there are no readers or writers
+                Assert.Equal(0, readers);
+                Assert.Equal(0, writers);
+
+                Interlocked.Increment(ref writers);
+                await Task.Delay(ms);
+                Interlocked.Decrement(ref writers);
+            }
+            finally
+            {
+                await AsyncLock.ExitWriteLock();
+            }
+        }
+
+        const int minDelay = 10;
+        const int maxDelay = 100;
+        const int count = maxDelay - minDelay;
+
+        // exclusive writers should take ~seconds,
+        // parallel readers should take less than seconds
+        // so all tasks should end within ~seconds * 2 or less
+        var seconds = (minDelay + maxDelay) / 2 * count / 1000;
+
+        var readTasks = Enumerable.Range(minDelay, count).Select(SimulateRead);
+        var writeTasks = Enumerable.Range(minDelay, count).Select(SimulateWrite);
+
+        await Task.WhenAll(readTasks.Concat(writeTasks)).Timeout(seconds * 2 + 1);
+
+        // check if it was actually parallelized
+        Assert.True(readerThreads.Count > 0);
+        Assert.True(writerThreads.Count > 0);
+    }
+
+    [Fact]
+    public async Task AsyncReaderWriterLock_doesnt_fail_the_LoadTest()
+    {
+        // This load test is taken from the AsyncReaderWriterLockSlim unit test suite, but without the sync part:
+        // https://github.com/osexpert/AsyncReaderWriterLockSlim/blob/master/AsyncReaderWriterLockSlim.UnitTests/AsyncReaderWriterLockSlimTests.cs#L332
+        var myLock = new AsyncReaderWriterLock();
+
+        var lockCountSyncRoot = new AsyncLock();
+        var readLockCount = 0;
+        var writeLockCount = 0;
+        var incorrectLockCount = false;
+
+        void checkLockCount()
+        {
+            Debug.WriteLine($"ReadLocks = {readLockCount}, WriteLocks = {writeLockCount}");
+
+            bool countIsCorrect = readLockCount == 0 && writeLockCount == 0 ||
+                    readLockCount > 0 && writeLockCount == 0 ||
+                    readLockCount == 0 && writeLockCount == 1;
+
+            if (!countIsCorrect)
+                Volatile.Write(ref incorrectLockCount, true);
+        }
+
+        bool cancel = false;
+
+        var tasks = new Task[20];
+
+        var masterRandom = new Random();
+
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            var random = new Random(masterRandom.Next());
+            tasks[i] = Task.Run(async () =>
+            {
+                while (!Volatile.Read(ref cancel))
+                {
+                    bool isRead = random.Next(10) < 7;
+                    if (isRead)
+                        await myLock.EnterReadLock();
+                    else
+                        await myLock.EnterWriteLock();
+
+                    lock (lockCountSyncRoot)
+                    {
+                        if (isRead)
+                            readLockCount++;
+                        else
+                            writeLockCount++;
+
+                        checkLockCount();
+                    }
+
+                    // Simulate work.
+                    await Task.Delay(10);
+
+                    using (await lockCountSyncRoot)
+                    {
+                        if (isRead)
+                        {
+                            await myLock.ExitReadLock();
+                            readLockCount--;
+                        }
+                        else
+                        {
+                            await myLock.ExitWriteLock();
+                            writeLockCount--;
+                        }
+
+                        checkLockCount();
+                    }
+                }
+            });
+        }
+
+        // Run for 5 seconds, then stop the tasks and threads.
+        Thread.Sleep(5000);
+
+        Volatile.Write(ref cancel, true);
+
+        await Task.WhenAll(tasks).Timeout(1);
+
+        Assert.False(incorrectLockCount);
+    }
+}

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -10,7 +10,6 @@
     <!-- Exclude the unnecessary tests to save Github Actions time -->
     <!-- WatsonTcp is the default channel, WebSocketSharp is optional, Quic is .net9 only -->
     <ItemGroup>
-      <Compile Remove="DisposableTests.Async.cs" />
       <Compile Remove="RpcTests_Quic.cs" />
       <Compile Remove="RpcTests_WatsonTcp.cs" />
       <Compile Remove="RpcTests_WebsocketSharp.cs" />

--- a/CoreRemoting.Tests/DisposableTests.Async.cs
+++ b/CoreRemoting.Tests/DisposableTests.Async.cs
@@ -2,42 +2,63 @@ using CoreRemoting.Toolbox;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+partial class DisposableTests
 {
-    partial class DisposableTests
+    [Fact]
+    public async Task AsyncDisposable_executes_action_on_DisposeAsync()
     {
-        [Fact]
-        public async Task AsyncDisposable_executes_action_on_DisposeAsync()
+        var disposed = false;
+
+        async Task DisposeTask()
         {
-            var disposed = false;
-
-            async Task DisposeTask()
-            {
-                await Task.Yield();
-                disposed = true;
-            }
-
-            await using (Disposable.Create(DisposeTask))
-                Assert.False(disposed);
-
-            Assert.True(disposed);
+            await Task.Yield();
+            disposed = true;
         }
 
-        [Fact]
-        public async Task AsyncTaskDisposable_executes_action_on_DisposeAsync()
+        await using (Disposable.Create(DisposeTask))
+            Assert.False(disposed);
+
+        Assert.True(disposed);
+    }
+
+    [Fact]
+    public async Task AsyncTaskDisposable_executes_action_on_DisposeAsync()
+    {
+        var disposed = false;
+
+        async ValueTask DisposeAsync()
         {
-            var disposed = false;
-
-            async ValueTask DisposeAsync()
-            {
-                await Task.Yield();
-                disposed = true;
-            }
-
-            await using (Disposable.Create(DisposeAsync))
-                Assert.False(disposed);
-
-            Assert.True(disposed);
+            await Task.Yield();
+            disposed = true;
         }
+
+        await using (Disposable.Create(DisposeAsync))
+            Assert.False(disposed);
+
+        Assert.True(disposed);
+    }
+
+    [Fact]
+    public async Task Disposable_combines_async_disposables()
+    {
+        var count = 0;
+        Task AsyncDispose() =>
+            Task.FromResult(count++);
+
+        void Dispose() =>
+            count++;
+
+        var d1 = Disposable.Create(AsyncDispose);
+        var d2 = Disposable.Create(AsyncDispose);
+        var d3 = Disposable.Create(Dispose);
+        var d4 = Disposable.Create(AsyncDispose);
+        var d5 = Disposable.Create(Dispose);
+
+        await using (Disposable.Create(d1, d2, d3, d4, d5))
+            Assert.Equal(0, count);
+
+        Assert.Equal(5, count);
     }
 }

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -826,6 +827,7 @@ public class RpcTests : IClassFixture<ServerFixture>
     }
 
     [Fact]
+    [SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "<Pending>")]
     public void Large_messages_are_sent_and_received()
     {
         // max payload size, in bytes
@@ -859,13 +861,13 @@ public class RpcTests : IClassFixture<ServerFixture>
                 while (true)
                 {
                     // a -> aa -> aaaa ...
-                    var dup = proxy.Duplicate(payload);
-                    if (dup.size >= maxSize)
+                    var (dup, size) = proxy.Duplicate(payload);
+                    if (size >= maxSize)
                         break;
 
                     // save the size for error reporting
-                    lastSize = dup.size;
-                    payload = dup.duplicate;
+                    lastSize = size;
+                    payload = dup;
                 }
             }
             catch (Exception ex)

--- a/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
+++ b/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
@@ -10,7 +10,7 @@ namespace CoreRemoting.Channels.Websocket;
 /// <summary>
 /// Abstract web socket transport for reading and writing messages.
 /// </summary>
-public abstract class WebSocketTransport : IRawMessageTransport
+public abstract class WebSocketTransport : IRawMessageTransport, IDisposable
 {
     /// <summary>
     /// Handshake cookies: message encryption flag.
@@ -74,6 +74,13 @@ public abstract class WebSocketTransport : IRawMessageTransport
     private AsyncLock ReceiveLock { get; } = new();
 
     private AsyncLock SendLock { get; } = new();
+
+    /// <inheritdoc/>
+    public virtual void Dispose()
+    {
+        ReceiveLock.Dispose();
+        SendLock.Dispose();
+    }
 
     /// <summary>
     /// Reads the incoming websocket messages

--- a/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
@@ -100,7 +100,7 @@ public class WebsocketClientChannel : WebSocketTransport, IClientChannel
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public override void Dispose()
     {
         if (ClientWebSocket == null)
             return;
@@ -111,5 +111,7 @@ public class WebsocketClientChannel : WebSocketTransport, IClientChannel
 
         ClientWebSocket.Dispose();
         ClientWebSocket = null;
+
+        base.Dispose();
     }
 }

--- a/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
@@ -64,8 +64,10 @@ public class WebsocketServerConnection : WebSocketTransport, IDisposable
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public override void Dispose()
     {
         WebSocket.Dispose();
+
+        base.Dispose();
     }
 }

--- a/CoreRemoting/CoreRemoting.csproj
+++ b/CoreRemoting/CoreRemoting.csproj
@@ -66,8 +66,4 @@
       <Protobuf Include="**/*.proto" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Compile Remove="Toolbox\Disposable.Async.cs" />
-    </ItemGroup>
-
 </Project>

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -591,7 +591,7 @@ namespace CoreRemoting
                 _delegateRegistry.GetDelegateByHandlerKey(delegateInvocationMessage.HandlerKey);
 
             // Invoke local delegate with arguments from remote caller
-            localDelegate.DynamicInvoke(delegateInvocationMessage.DelegateArguments);
+            localDelegate.OneWayDynamicInvoke(delegateInvocationMessage.DelegateArguments);
         }
 
         /// <summary>

--- a/CoreRemoting/Toolbox/AsyncLock.cs
+++ b/CoreRemoting/Toolbox/AsyncLock.cs
@@ -10,9 +10,12 @@ using ConfiguredAwaiter = ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwa
 /// <summary>
 /// Awaitable async locking synchronization primitive.
 /// </summary>
-public class AsyncLock
+public class AsyncLock : IDisposable
 {
     private SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+    /// <inheritdoc/>
+    public void Dispose() => Semaphore.Dispose();
 
     /// <summary>
     /// Locks asynchronously, by awaiting the lock object itself.

--- a/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
+++ b/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Toolbox;
+
+/// <summary>
+/// Simple async readers/writers lock.
+/// </summary>
+/// <remarks>
+/// Based on Michel Raynal's pseudocode using two mutexes and a counter:
+/// https://en.wikipedia.org/wiki/Readers–writer_lock#Using_two_mutexes
+/// </remarks>
+public class AsyncReaderWriterLock
+{
+    private volatile int blockingReaders = 0;
+
+    private AsyncLock ReadersLock { get; } = new();
+
+    private AsyncLock WritersLock { get; } = new();
+
+    private IDisposable ReleaseWritersLock { get; set; }
+
+    /// <summary>
+    /// Enter the lock in read mode.
+    /// </summary>
+    public async Task EnterReadLock()
+    {
+        using (await ReadersLock)
+        {
+            if (Interlocked.Increment(ref blockingReaders) == 1)
+            {
+                ReleaseWritersLock = await WritersLock;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reduces the recursion count in read mode and exits read mode if counter is zero.
+    /// </summary>
+    public async Task ExitReadLock()
+    {
+        using (await ReadersLock)
+        {
+            if (Interlocked.Decrement(ref blockingReaders) == 0)
+            {
+                ReleaseWritersLock?.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enter the lock in write mode.
+    /// </summary>
+    public async Task EnterWriteLock()
+    {
+        ReleaseWritersLock = await WritersLock;
+    }
+
+    /// <summary>
+    /// Releases the lock from write mode.
+    /// </summary>
+    public Task ExitWriteLock()
+    {
+        ReleaseWritersLock?.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
+++ b/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
@@ -87,7 +87,9 @@ public class AsyncReaderWriterLock : IDisposable
     /// </summary>
     internal async Task<IAsyncDisposable> ReadLock()
     {
-        await EnterReadLock();
+        await EnterReadLock()
+            .ConfigureAwait(false);
+
         return Disposable.Create(ExitReadLock);
     }
 
@@ -96,7 +98,9 @@ public class AsyncReaderWriterLock : IDisposable
     /// </summary>
     internal async Task<IAsyncDisposable> WriteLock()
     {
-        await EnterWriteLock();
+        await EnterWriteLock()
+            .ConfigureAwait(false);
+
         return Disposable.Create(ExitWriteLock);
     }
 }

--- a/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
+++ b/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
@@ -65,4 +65,22 @@ public class AsyncReaderWriterLock
         ReleaseWritersLock?.Dispose();
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Enters the lock in the read mode in an async-disposable way.
+    /// </summary>
+    internal async Task<IAsyncDisposable> ReadLock()
+    {
+        await EnterReadLock();
+        return Disposable.Create(ExitReadLock);
+    }
+
+    /// <summary>
+    /// Enters the lock in the write mode in an async-disposable way.
+    /// </summary>
+    internal async Task<IAsyncDisposable> WriteLock()
+    {
+        await EnterWriteLock();
+        return Disposable.Create(ExitWriteLock);
+    }
 }


### PR DESCRIPTION
My approach is to use a reader/writer lock so there are multiple concurrent tasks handling **rpc_result** messages and single exclusive task processing **session_closed** message.

Built-in ``ReaderWriterLockSlim`` is not compatible with async/await pattern, just like `lock` statement. To avoid introducing new dependencies for the sake of a single synchronization primitive, I implemented one myself using two locks and a counter. Here is the pseudocode from Michel Raynal's book [Concurrent Programming: Algorithms, Principles, and Foundations](https://books.google.ru/books?id=0a1AAAAAQBAJ&hl=ru):

![image](https://github.com/user-attachments/assets/28870045-0578-487a-9268-2f9571cf2131)

This simple RW-lock doesn't have reader → writer upgrade and TryEnterXxxLock methods, but I don't seem to need these anyway. I've added a few unit tests for the async lock, as well as the load test based on MIT-licensed [AsyncReaderWriterLockSlimTests.LoadTest](https://github.com/osexpert/AsyncReaderWriterLockSlim/blob/master/AsyncReaderWriterLockSlim.UnitTests/AsyncReaderWriterLockSlimTests.cs) method.

Also, I've added a disposable wrappers for the reader/writer locks, to avoid try/finally clutter, i.e.:

```csharp
using var myLock = new AsyncReaderWriterLock();
...

// multiple concurrent readers
await using (await myLock.ReadLock())
{
    await ReadFromMyResource(...);
}

// single exclusive writer is like
await using (await myLock.WriteLock())
{
    await WriteToMyResource(...);
}
```