### PR TITLE
Client delegate invocation don't need a lock

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,9 +19,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         exclude:
-          - os: ${{ !contains(github.event.head_commit.message, 'windows') && 'windows-latest' }}
-        include:
-          - os: ${{ github.event.pull_request && 'windows-latest' }}
+          - os: ${{ !contains(github.event.head_commit.message, 'windows') && !github.event.pull_request && 'windows-latest' }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -468,7 +468,7 @@ namespace CoreRemoting
                     await ProcessRpcResultMessage(message);
                     break;
                 case "invoke":
-                    await ProcessRemoteDelegateInvocationMessage(message);
+                    ProcessRemoteDelegateInvocationMessage(message);
                     break;
                 case "goodbye":
                     await ProcessGoodbyeMessage(message);
@@ -596,10 +596,8 @@ namespace CoreRemoting
         /// Processes a remote delegate invocation message from server.
         /// </summary>
         /// <param name="message">Deserialized WireMessage that contains a RemoteDelegateInvocationMessage</param>
-        private async Task ProcessRemoteDelegateInvocationMessage(WireMessage message)
+        private void ProcessRemoteDelegateInvocationMessage(WireMessage message)
         {
-            await using var rpcLock = await _rpcMessageLock.ReadLock();
-
             if (_goodbyeCompletedTaskSource.Task.IsCompleted)
                 return;
 


### PR DESCRIPTION
Also, trying to fix the github action workflow yml file.