### PR TITLE
Using IAsyncDisposable in the transport channels

### DIFF
--- a/CoreRemoting.Channels.Quic/QuicClientChannel.cs
+++ b/CoreRemoting.Channels.Quic/QuicClientChannel.cs
@@ -187,19 +187,17 @@ public class QuicClientChannel : IClientChannel, IRawMessageTransport
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (Connection == null)
             return;
 
         if (IsConnected)
-            DisconnectAsync()
-                .JustWait();
+            await DisconnectAsync()
+                .ConfigureAwait(false);
 
-        Connection.DisposeAsync()
-            .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+        await Connection.DisposeAsync()
+            .ConfigureAwait(false);
         Connection = null;
 
         // clean up readers/writers

--- a/CoreRemoting.Channels.Quic/QuicServerChannel.cs
+++ b/CoreRemoting.Channels.Quic/QuicServerChannel.cs
@@ -73,7 +73,8 @@ public class QuicServerChannel : IServerChannel
                 {
                     new SslApplicationProtocol(QuicClientChannel.ProtocolName)
                 },
-            });
+            })
+            .ConfigureAwait(false);
 
             // accept incoming connections
             IsListening = true;
@@ -81,8 +82,12 @@ public class QuicServerChannel : IServerChannel
             {
                 try
                 {
-                    var connection = await Listener.AcceptConnectionAsync();
-                    var stream = await connection.AcceptInboundStreamAsync();
+                    var connection = await Listener.AcceptConnectionAsync()
+                        .ConfigureAwait(false);
+
+                    var stream = await connection.AcceptInboundStreamAsync()
+                        .ConfigureAwait(false);
+
                     var session = new QuicServerConnection(connection, stream, Server);
                     var sessionId = session.StartListening();
                     Connections[sessionId] = session;

--- a/CoreRemoting.Channels.Quic/QuicServerChannel.cs
+++ b/CoreRemoting.Channels.Quic/QuicServerChannel.cs
@@ -111,9 +111,10 @@ public class QuicServerChannel : IServerChannel
     }
 
     /// <inheritdoc/>
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         StopListening();
         Listener = null;
+        return default;
     }
 }

--- a/CoreRemoting.Channels.WebsocketSharp/WebsocketSharpClientChannel.cs
+++ b/CoreRemoting.Channels.WebsocketSharp/WebsocketSharpClientChannel.cs
@@ -131,9 +131,9 @@ namespace CoreRemoting.Channels.WebsocketSharp
         /// <summary>
         /// Disconnect and free manages resources.
         /// </summary>
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            DisconnectAsync().JustWait();
+            await DisconnectAsync();
             _webSocket = null;
         }
 

--- a/CoreRemoting.Channels.WebsocketSharp/WebsocketSharpServerChannel.cs
+++ b/CoreRemoting.Channels.WebsocketSharp/WebsocketSharpServerChannel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using WebSocketSharp.Server;
 
 namespace CoreRemoting.Channels.WebsocketSharp
@@ -60,11 +61,12 @@ namespace CoreRemoting.Channels.WebsocketSharp
         /// <summary>
         /// Stops listening and frees managed resources.
         /// </summary>
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
             StopListening();
             _webSocketServer = null;
             _server = null;
+            return default;
         }
     }
 }

--- a/CoreRemoting.Tests/AsyncLockTests.cs
+++ b/CoreRemoting.Tests/AsyncLockTests.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreRemoting.Tests.Tools;
-using CoreRemoting.Toolbox;
+using CoreRemoting.Threading;
 using Xunit;
 using Xunit.Sdk;
 

--- a/CoreRemoting.Tests/AsyncReaderWriterLockTests.cs
+++ b/CoreRemoting.Tests/AsyncReaderWriterLockTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreRemoting.Tests.Tools;
+using CoreRemoting.Threading;
 using CoreRemoting.Toolbox;
 using Xunit;
 using Inv = System.InvalidOperationException;

--- a/CoreRemoting.Tests/AsyncReaderWriterLockTests.cs
+++ b/CoreRemoting.Tests/AsyncReaderWriterLockTests.cs
@@ -37,13 +37,13 @@ public class AsyncReaderWriterLockTests
         using var ctx = ValidationSyncContext.Install();
         using var myLock = new AsyncReaderWriterLock();
 
-        await using (await myLock.ReadLock())
+        await using (await myLock.Read)
         {
             await Task.Delay(0)
                 .ConfigureAwait(false);
         }
 
-        await using (await myLock.WriteLock())
+        await using (await myLock.Write)
         {
             await Task.Delay(0)
                 .ConfigureAwait(false);
@@ -59,7 +59,7 @@ public class AsyncReaderWriterLockTests
         await Assert.ThrowsAsync<Inv>(myLock.ExitReadLock);
         await Assert.ThrowsAsync<Inv>(myLock.ExitWriteLock);
 
-        var readLock = await myLock.ReadLock();
+        var readLock = await myLock.Read;
         await readLock.DisposeAsync();
 
         await Assert.ThrowsAsync<Inv>(myLock.ExitReadLock);
@@ -146,7 +146,7 @@ public class AsyncReaderWriterLockTests
         {
             readerThreads[Environment.CurrentManagedThreadId] = 0;
 
-            await using (await AsyncLock.ReadLock())
+            await using (await AsyncLock.Read)
             {
                 // in a reader's critical section, there are no writers
                 Assert.Equal(0, writers);
@@ -162,7 +162,7 @@ public class AsyncReaderWriterLockTests
         {
             writerThreads[Environment.CurrentManagedThreadId] = 0;
 
-            await using (await AsyncLock.WriteLock())
+            await using (await AsyncLock.Write)
             {
                 // in a writer's critical section, there are no readers or writers
                 Assert.Equal(0, readers);

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="DryIoc.MefAttributedModel.dll" Version="7.0.2" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />

--- a/CoreRemoting.Tests/EventStubTests.cs
+++ b/CoreRemoting.Tests/EventStubTests.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreRemoting.RemoteDelegates;
-using CoreRemoting.Tests.Tools;
+using CoreRemoting.Threading;
 using CoreRemoting.Toolbox;
 using Xunit;
 

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -11,6 +10,7 @@ using CoreRemoting.Channels;
 using CoreRemoting.Serialization;
 using CoreRemoting.Tests.ExternalTypes;
 using CoreRemoting.Tests.Tools;
+using CoreRemoting.Threading;
 using CoreRemoting.Toolbox;
 using Xunit;
 using Xunit.Abstractions;

--- a/CoreRemoting.Tests/Threading/AsyncCountdownEventUnitTests.cs
+++ b/CoreRemoting.Tests/Threading/AsyncCountdownEventUnitTests.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Threading.Tasks;
+using CoreRemoting.Threading;
+using Xunit;
+
+namespace CoreRemoting.Tests.Threading;
+
+/// <summary>
+/// Unit tests based on Nito.AsyncEx unit tests for the AsyncCountdownEvent class by Stephen Cleary:
+/// https://github.com/StephenCleary/AsyncEx/blob/master/test/AsyncEx.Coordination.UnitTests/AsyncCountdownEventUnitTests.cs
+/// </summary>
+public class AsyncCountdownEventUnitTests
+{
+    [Fact]
+    public async Task WaitAsync_Unset_IsNotCompleted()
+    {
+        var ce = new AsyncCountdownEvent(1);
+        var task = ce.WaitAsync();
+
+        Assert.Equal(1, ce.CurrentCount);
+        Assert.False(task.IsCompleted);
+
+        ce.Signal();
+        await task;
+    }
+
+    [Fact]
+    public void WaitAsync_Set_IsCompleted()
+    {
+        var ce = new AsyncCountdownEvent(0);
+        var task = ce.WaitAsync();
+
+        Assert.Equal(0, ce.CurrentCount);
+        Assert.True(task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task AddCount_IncrementsCount()
+    {
+        var ce = new AsyncCountdownEvent(1);
+        var task = ce.WaitAsync();
+        Assert.Equal(1, ce.CurrentCount);
+        Assert.False(task.IsCompleted);
+
+        ce.AddCount();
+
+        Assert.Equal(2, ce.CurrentCount);
+        Assert.False(task.IsCompleted);
+
+        ce.Signal(2);
+        await task;
+    }
+
+    [Fact]
+    public async Task Signal_Nonzero_IsNotCompleted()
+    {
+        var ce = new AsyncCountdownEvent(2);
+        var task = ce.WaitAsync();
+        Assert.False(task.IsCompleted);
+
+        ce.Signal();
+
+        Assert.Equal(1, ce.CurrentCount);
+        Assert.False(task.IsCompleted);
+
+        ce.Signal();
+        await task;
+    }
+
+    [Fact]
+    public void Signal_Zero_SynchronouslyCompletesWaitTask()
+    {
+        var ce = new AsyncCountdownEvent(1);
+        var task = ce.WaitAsync();
+        Assert.False(task.IsCompleted);
+
+        ce.Signal();
+
+        Assert.Equal(0, ce.CurrentCount);
+        Assert.True(task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Signal_AfterSet_CountsNegativeAndResetsTask()
+    {
+        var ce = new AsyncCountdownEvent(0);
+        var originalTask = ce.WaitAsync();
+
+        ce.Signal();
+
+        var newTask = ce.WaitAsync();
+        Assert.Equal(-1, ce.CurrentCount);
+        Assert.NotSame(originalTask, newTask);
+
+        ce.AddCount();
+        await newTask;
+    }
+
+    [Fact]
+    public async Task AddCount_AfterSet_CountsPositiveAndResetsTask()
+    {
+        var ce = new AsyncCountdownEvent(0);
+        var originalTask = ce.WaitAsync();
+
+        ce.AddCount();
+        var newTask = ce.WaitAsync();
+
+        Assert.Equal(1, ce.CurrentCount);
+        Assert.NotSame(originalTask, newTask);
+
+        ce.Signal();
+        await newTask;
+    }
+
+    [Fact]
+    public async Task Signal_PastZero_PulsesTask()
+    {
+        var ce = new AsyncCountdownEvent(1);
+        var originalTask = ce.WaitAsync();
+
+        ce.Signal(2);
+        await originalTask;
+        var newTask = ce.WaitAsync();
+
+        Assert.Equal(-1, ce.CurrentCount);
+        Assert.NotSame(originalTask, newTask);
+
+        ce.AddCount();
+        await newTask;
+    }
+
+    [Fact]
+    public async Task AddCount_PastZero_PulsesTask()
+    {
+        var ce = new AsyncCountdownEvent(-1);
+        var originalTask = ce.WaitAsync();
+
+        ce.AddCount(2);
+        await originalTask;
+        var newTask = ce.WaitAsync();
+
+        Assert.Equal(1, ce.CurrentCount);
+        Assert.NotSame(originalTask, newTask);
+
+        ce.Signal();
+        await newTask;
+    }
+
+    [Fact]
+    public void AddCount_Overflow_ThrowsException()
+    {
+        var ce = new AsyncCountdownEvent(long.MaxValue);
+        Assert.Throws<OverflowException>(() => ce.AddCount());
+    }
+
+    [Fact]
+    public void Signal_Underflow_ThrowsException()
+    {
+        var ce = new AsyncCountdownEvent(long.MinValue);
+        Assert.Throws<OverflowException>(() => ce.Signal());
+    }
+}

--- a/CoreRemoting.Tests/Threading/AsyncLockTests.cs
+++ b/CoreRemoting.Tests/Threading/AsyncLockTests.cs
@@ -8,7 +8,7 @@ using CoreRemoting.Threading;
 using Xunit;
 using Xunit.Sdk;
 
-namespace CoreRemoting.Tests;
+namespace CoreRemoting.Tests.Threading;
 
 [Collection("CoreRemoting")]
 public class AsyncLockTests

--- a/CoreRemoting.Tests/Threading/AsyncManualResetEventTests.cs
+++ b/CoreRemoting.Tests/Threading/AsyncManualResetEventTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace CoreRemoting.Tests.Threading;
 
 /// <summary>
-/// Unit tests based on Nito.AsyncEx unit tests for the AsyncManualResetEvent class:
+/// Unit tests based on Nito.AsyncEx unit tests for the AsyncManualResetEvent class by Stephen Cleary:
 /// https://github.com/StephenCleary/AsyncEx/blob/master/test/AsyncEx.Coordination.UnitTests/AsyncManualResetEventUnitTests.cs
 /// </summary>
 public class AsyncManualResetEventTests

--- a/CoreRemoting.Tests/Threading/AsyncManualResetEventTests.cs
+++ b/CoreRemoting.Tests/Threading/AsyncManualResetEventTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading.Tasks;
+using CoreRemoting.Threading;
+using CoreRemoting.Toolbox;
+using Xunit;
+
+namespace CoreRemoting.Tests.Threading;
+
+/// <summary>
+/// Unit tests based on Nito.AsyncEx unit tests for the AsyncManualResetEvent class:
+/// https://github.com/StephenCleary/AsyncEx/blob/master/test/AsyncEx.Coordination.UnitTests/AsyncManualResetEventUnitTests.cs
+/// </summary>
+public class AsyncManualResetEventTests
+{
+    private async Task NeverCompletes(Task task, double sec = 0.5) =>
+        await Assert.ThrowsAsync<TimeoutException>(() => task.Timeout(sec));
+
+    [Fact]
+    public async Task WaitAsync_Unset_IsNotCompleted()
+    {
+        var mre = new AsyncManualResetEvent();
+
+        var task = mre.WaitAsync();
+
+        await NeverCompletes(mre.WaitAsync());
+    }
+
+    [Fact]
+    public void WaitAsync_AfterSet_IsCompleted()
+    {
+        var mre = new AsyncManualResetEvent();
+
+        mre.Set();
+        var task = mre.WaitAsync();
+
+        Assert.True(task.IsCompleted);
+    }
+
+    [Fact]
+    public void WaitAsync_Set_IsCompleted()
+    {
+        var mre = new AsyncManualResetEvent(true);
+
+        var task = mre.WaitAsync();
+
+        Assert.True(task.IsCompleted);
+    }
+
+    [Fact]
+    public void MultipleWaitAsync_AfterSet_IsCompleted()
+    {
+        var mre = new AsyncManualResetEvent();
+
+        mre.Set();
+        var task1 = mre.WaitAsync();
+        var task2 = mre.WaitAsync();
+
+        Assert.True(task1.IsCompleted);
+        Assert.True(task2.IsCompleted);
+    }
+
+    [Fact]
+    public void MultipleWaitAsync_Set_IsCompleted()
+    {
+        var mre = new AsyncManualResetEvent(true);
+
+        var task1 = mre.WaitAsync();
+        var task2 = mre.WaitAsync();
+
+        Assert.True(task1.IsCompleted);
+        Assert.True(task2.IsCompleted);
+    }
+
+    [Fact]
+    public async Task WaitAsync_AfterReset_IsNotCompleted()
+    {
+        var mre = new AsyncManualResetEvent();
+
+        mre.Set();
+        mre.Reset();
+        var task = mre.WaitAsync();
+
+        await NeverCompletes(task);
+    }
+}

--- a/CoreRemoting.Tests/Threading/AsyncReaderWriterLockTests.cs
+++ b/CoreRemoting.Tests/Threading/AsyncReaderWriterLockTests.cs
@@ -11,7 +11,7 @@ using CoreRemoting.Toolbox;
 using Xunit;
 using Inv = System.InvalidOperationException;
 
-namespace CoreRemoting.Tests;
+namespace CoreRemoting.Tests.Threading;
 
 [Collection("CoreRemoting")]
 public class AsyncReaderWriterLockTests

--- a/CoreRemoting/Channels/IClientChannel.cs
+++ b/CoreRemoting/Channels/IClientChannel.cs
@@ -6,7 +6,7 @@ namespace CoreRemoting.Channels
     /// <summary>
     /// Interface for CoreRemoting client side transport channel.
     /// </summary>
-    public interface IClientChannel : IDisposable
+    public interface IClientChannel : IAsyncDisposable
     {
         /// <summary>
         /// Initializes the channel.

--- a/CoreRemoting/Channels/IServerChannel.cs
+++ b/CoreRemoting/Channels/IServerChannel.cs
@@ -5,7 +5,7 @@ namespace CoreRemoting.Channels
     /// <summary>
     /// Interface for CoreRemoting server side transport channel.
     /// </summary>
-    public interface IServerChannel : IDisposable
+    public interface IServerChannel : IAsyncDisposable
     {
         /// <summary>
         /// Initializes the channel.

--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -156,6 +156,7 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     /// <summary>
     /// Disconnect and free manages resources.
     /// </summary>
-    public void Dispose() =>
-        DisconnectAsync().JustWait();
+    public async ValueTask DisposeAsync() =>
+        await DisconnectAsync()
+            .ConfigureAwait(false);
 }

--- a/CoreRemoting/Channels/Tcp/TcpServerChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpServerChannel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
+using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
 using WatsonTcp;
 
 namespace CoreRemoting.Channels.Tcp;
@@ -82,12 +83,14 @@ public class TcpServerChannel : IServerChannel
     /// <summary>
     /// Stops listening and frees managed resources.
     /// </summary>
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         if (_tcpServer != null)
         {
             _tcpServer.Dispose();
             _tcpServer = null;
         }
+
+        return default;
     }
 }

--- a/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
+++ b/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
@@ -10,7 +10,7 @@ namespace CoreRemoting.Channels.Websocket;
 /// <summary>
 /// Abstract web socket transport for reading and writing messages.
 /// </summary>
-public abstract class WebSocketTransport : IRawMessageTransport, IDisposable
+public abstract class WebSocketTransport : IRawMessageTransport, IAsyncDisposable
 {
     /// <summary>
     /// Handshake cookies: message encryption flag.
@@ -76,10 +76,11 @@ public abstract class WebSocketTransport : IRawMessageTransport, IDisposable
     private AsyncLock SendLock { get; } = new();
 
     /// <inheritdoc/>
-    public virtual void Dispose()
+    public virtual ValueTask DisposeAsync()
     {
         ReceiveLock.Dispose();
         SendLock.Dispose();
+        return default;
     }
 
     /// <summary>

--- a/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
+++ b/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
@@ -3,7 +3,7 @@ using System.Net.WebSockets;
 using CoreRemoting.IO;
 using System.Threading.Tasks;
 using System.Threading;
-using CoreRemoting.Toolbox;
+using CoreRemoting.Threading;
 
 namespace CoreRemoting.Channels.Websocket;
 

--- a/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
+++ b/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
@@ -10,7 +10,7 @@ namespace CoreRemoting.Channels.Websocket;
 /// <summary>
 /// Abstract web socket transport for reading and writing messages.
 /// </summary>
-public abstract class WebSocketTransport : IRawMessageTransport, IAsyncDisposable
+public abstract class WebsocketTransport : IRawMessageTransport, IAsyncDisposable
 {
     /// <summary>
     /// Handshake cookies: message encryption flag.

--- a/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
@@ -10,7 +10,7 @@ namespace CoreRemoting.Channels.Websocket;
 /// <summary>
 /// Client side websocket channel implementation based on System.Net.Websockets.
 /// </summary>
-public class WebsocketClientChannel : WebSocketTransport, IClientChannel
+public class WebsocketClientChannel : WebsocketTransport, IClientChannel
 {
     /// <summary>
     /// Gets or sets the URL this channel is connected to.

--- a/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
@@ -100,18 +100,19 @@ public class WebsocketClientChannel : WebSocketTransport, IClientChannel
     }
 
     /// <inheritdoc />
-    public override void Dispose()
+    public override async ValueTask DisposeAsync()
     {
         if (ClientWebSocket == null)
             return;
 
         if (IsConnected)
-            DisconnectAsync()
-                .JustWait();
+            await DisconnectAsync()
+                .ConfigureAwait(false);
 
         ClientWebSocket.Dispose();
         ClientWebSocket = null;
 
-        base.Dispose();
+        await base.DisposeAsync()
+            .ConfigureAwait(false);
     }
 }

--- a/CoreRemoting/Channels/Websocket/WebsocketServerChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketServerChannel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
 
 namespace CoreRemoting.Channels.Websocket;
 
@@ -82,12 +83,13 @@ public class WebsocketServerChannel : IServerChannel
     }
 
     /// <inheritdoc/>
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         StopListening();
         HttpListener = null;
 
         foreach (var conn in Connections.Values)
-            conn.Dispose();
+            await conn.DisposeAsync()
+                .ConfigureAwait(false);
     }
 }

--- a/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
@@ -7,7 +7,7 @@ namespace CoreRemoting.Channels.Websocket;
 /// <summary>
 /// Websocket connection.
 /// </summary>
-public class WebsocketServerConnection : WebSocketTransport, IAsyncDisposable
+public class WebsocketServerConnection : WebsocketTransport, IAsyncDisposable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="WebsocketServerConnection"/> class.

--- a/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Net.WebSockets;
+using System.Threading.Tasks;
 
 namespace CoreRemoting.Channels.Websocket;
 
 /// <summary>
 /// Websocket connection.
 /// </summary>
-public class WebsocketServerConnection : WebSocketTransport, IDisposable
+public class WebsocketServerConnection : WebSocketTransport, IAsyncDisposable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="WebsocketServerConnection"/> class.
@@ -64,10 +65,11 @@ public class WebsocketServerConnection : WebSocketTransport, IDisposable
     }
 
     /// <inheritdoc />
-    public override void Dispose()
+    public override async ValueTask DisposeAsync()
     {
         WebSocket.Dispose();
 
-        base.Dispose();
+        await base.DisposeAsync()
+            .ConfigureAwait(false);
     }
 }

--- a/CoreRemoting/ClassicRemotingApi/RemotingConfiguration.cs
+++ b/CoreRemoting/ClassicRemotingApi/RemotingConfiguration.cs
@@ -3,9 +3,11 @@ using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using CoreRemoting.Authentication;
 using CoreRemoting.ClassicRemotingApi.ConfigSection;
 using CoreRemoting.DependencyInjection;
+using CoreRemoting.Toolbox;
 
 namespace CoreRemoting.ClassicRemotingApi
 {
@@ -86,20 +88,34 @@ namespace CoreRemoting.ClassicRemotingApi
         /// Unregisters a CoreRemoting server.
         /// </summary>
         /// <param name="uniqueServerInstanceName">Unique name of the server instance</param>
-        public static void UnregisterServer(string uniqueServerInstanceName)
+        public static void UnregisterServer(string uniqueServerInstanceName) =>
+            UnregisterServerAsync(uniqueServerInstanceName).JustWait();
+
+        /// <summary>
+        /// Unregisters a CoreRemoting server asynchronously.
+        /// </summary>
+        /// <param name="uniqueServerInstanceName">Unique name of the server instance</param>
+        public static async Task UnregisterServerAsync(string uniqueServerInstanceName)
         {
             var server = RemotingServer.GetActiveServerInstance(uniqueServerInstanceName);
-            server?.Dispose();
+            await (server?.DisposeAsync() ?? default).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Unregisters a CoreRemoting client.
         /// </summary>
         /// <param name="uniqueClientInstanceName">Unique name of the client instance</param>
-        public static void UnregisterClient(string uniqueClientInstanceName)
+        public static void UnregisterClient(string uniqueClientInstanceName) =>
+            UnregisterClientAsync(uniqueClientInstanceName).JustWait();
+
+        /// <summary>
+        /// Unregisters a CoreRemoting client asynchronously.
+        /// </summary>
+        /// <param name="uniqueClientInstanceName">Unique name of the client instance</param>
+        public static async Task UnregisterClientAsync(string uniqueClientInstanceName)
         {
             var client = RemotingClient.GetActiveClientInstance(uniqueClientInstanceName);
-            client?.Dispose();
+            await (client?.DisposeAsync() ?? default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,13 +213,21 @@ namespace CoreRemoting.ClassicRemotingApi
         /// <summary>
         /// Shutdown all registered clients and servers.
         /// </summary>
-        public static void ShutdownAll()
+        public static void ShutdownAll() =>
+            ShutdownAllAsync().JustWait();
+
+        /// <summary>
+        /// Shutdown all registered clients and servers asynchronously.
+        /// </summary>
+        public static async Task ShutdownAllAsync()
         {
             foreach (var registeredClient in RegisteredClientInstances)
-                registeredClient.Dispose();
-            
+                await registeredClient.DisposeAsync()
+                    .ConfigureAwait(false);
+
             foreach (var registeredServer in RegisteredServerInstances)
-                registeredServer.Dispose();
+                await registeredServer.DisposeAsync()
+                    .ConfigureAwait(false);
         }
     }
 }

--- a/CoreRemoting/CoreRemoting.csproj
+++ b/CoreRemoting/CoreRemoting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <LangVersion>default</LangVersion>
@@ -46,6 +46,7 @@
 
     <ItemGroup>
       <PackageReference Include="Castle.Windsor" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />

--- a/CoreRemoting/IRemotingClient.cs
+++ b/CoreRemoting/IRemotingClient.cs
@@ -5,18 +5,18 @@ namespace CoreRemoting
     /// <summary>
     /// Interface of a CoreRemoting client.
     /// </summary>
-    public interface IRemotingClient : IDisposable
+    public interface IRemotingClient : IAsyncDisposable, IDisposable
     {
         /// <summary>
         /// Event: Fires after client was disconnected.
         /// </summary>
         event Action AfterDisconnect;
-        
+
         /// <summary>
         /// Gets the configuration settings used by the CoreRemoting client instance.
         /// </summary>
         ClientConfig Config { get; }
-        
+
         /// <summary>
         /// Gets the public key of this CoreRemoting client instance.
         /// </summary>

--- a/CoreRemoting/IRemotingServer.cs
+++ b/CoreRemoting/IRemotingServer.cs
@@ -9,7 +9,7 @@ namespace CoreRemoting
     /// <summary>
     /// Interface of a CoreRemoting server.
     /// </summary>
-    public interface IRemotingServer : IDisposable
+    public interface IRemotingServer : IAsyncDisposable, IDisposable
     {
         /// <summary>
         /// Event: Fires when an RPC call is prepared and can be canceled.

--- a/CoreRemoting/ISessionRepository.cs
+++ b/CoreRemoting/ISessionRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using CoreRemoting.Channels;
 
 namespace CoreRemoting
@@ -7,7 +8,7 @@ namespace CoreRemoting
     /// <summary>
     /// Interface to be implemented by CoreRemoting session repository classes.
     /// </summary>
-    public interface ISessionRepository : IDisposable
+    public interface ISessionRepository : IAsyncDisposable
     {
         /// <summary>
         /// Gets the key size for asymmetric encryption. Should be 3072 or better in 2021 ;)
@@ -44,6 +45,6 @@ namespace CoreRemoting
         /// Removes a specified session by its ID.
         /// </summary>
         /// <param name="sessionId">Session ID</param>
-        void RemoveSession(Guid sessionId);
+        Task RemoveSession(Guid sessionId);
     }
 }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -575,7 +575,7 @@ namespace CoreRemoting
         /// </summary>
         private async Task ProcessGoodbyeMessage(WireMessage message)
         {
-            await using var rpcLock = await _rpcMessageLock.WriteLock();
+            await using var rpcLock = await _rpcMessageLock.Write;
 
             _goodbyeCompletedTaskSource.TrySetResult(true);
         }
@@ -585,7 +585,7 @@ namespace CoreRemoting
         /// </summary>
         private async Task ProcessSessionClosedMessage(WireMessage message)
         {
-            await using var rpcLock = await _rpcMessageLock.WriteLock();
+            await using var rpcLock = await _rpcMessageLock.Write;
 
             _goodbyeCompletedTaskSource.TrySetResult(true);
 
@@ -627,7 +627,7 @@ namespace CoreRemoting
         /// <exception cref="KeyNotFoundException">Thrown, when the received result is of a unknown call</exception>
         private async Task ProcessRpcResultMessage(WireMessage message)
         {
-            await using var rpcLock = await _rpcMessageLock.ReadLock();
+            await using var rpcLock = await _rpcMessageLock.Read;
 
             if (_goodbyeCompletedTaskSource.Task.IsCompleted)
                 return;

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -19,6 +19,7 @@ using CoreRemoting.Serialization.Bson;
 using CoreRemoting.Toolbox;
 using CancellationTokenSource = System.Threading.CancellationTokenSource;
 using Timer = System.Timers.Timer;
+using CoreRemoting.Threading;
 
 namespace CoreRemoting
 {

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -852,13 +852,10 @@ namespace CoreRemoting
         /// <summary>
         /// Frees managed resources.
         /// </summary>
-        public void Dispose() =>
-            DisposeAsync().JustWait();
+        public void Dispose() => DisposeAsync().JustWait();
 
-        /// <summary>
-        /// TODO: consider implementing IDisposableAsync instead?
-        /// </summary>
-        private async Task DisposeAsync()
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
         {
             if (RemotingClient.DefaultRemotingClient == this)
                 RemotingClient.DefaultRemotingClient = null;
@@ -882,7 +879,9 @@ namespace CoreRemoting
             {
                 if (_channel != null)
                 {
-                    _channel.Dispose();
+                    await _channel.DisposeAsync()
+                        .ConfigureAwait(false);
+
                     _channel = null;
                 }
             }

--- a/CoreRemoting/RemotingServer.cs
+++ b/CoreRemoting/RemotingServer.cs
@@ -147,7 +147,7 @@ namespace CoreRemoting
         /// <summary>
         /// Gets the session repository to perform session management tasks.
         /// </summary>
-        public ISessionRepository SessionRepository { get; }
+        public ISessionRepository SessionRepository { get; private set; }
 
         /// <summary>
         /// Gets the channel used to do the raw network transport.
@@ -280,6 +280,14 @@ namespace CoreRemoting
                 RemotingServer.DefaultRemotingServer = null;
 
             _serverInstances.TryRemove(_config.UniqueServerInstanceName, out _);
+
+            if (SessionRepository != null)
+            {
+                await SessionRepository.DisposeAsync()
+                    .ConfigureAwait(false);
+
+                SessionRepository = null;
+            }
 
             if (Channel != null)
             {

--- a/CoreRemoting/RemotingServer.cs
+++ b/CoreRemoting/RemotingServer.cs
@@ -12,6 +12,8 @@ using CoreRemoting.Serialization;
 using CoreRemoting.Serialization.Bson;
 using ServiceLifetime = CoreRemoting.DependencyInjection.ServiceLifetime;
 using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
 
 namespace CoreRemoting
 {
@@ -269,7 +271,10 @@ namespace CoreRemoting
         /// <summary>
         /// Frees managed resources.
         /// </summary>
-        public void Dispose()
+        public void Dispose() => DisposeAsync().JustWait();
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
         {
             if (RemotingServer.DefaultRemotingServer == this)
                 RemotingServer.DefaultRemotingServer = null;
@@ -278,7 +283,9 @@ namespace CoreRemoting
 
             if (Channel != null)
             {
-                Channel.Dispose();
+                await Channel.DisposeAsync()
+                    .ConfigureAwait(false);
+
                 Channel = null;
             }
         }

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -801,7 +801,7 @@ namespace CoreRemoting
                 // TODO: make sure that the current RPC message result gets
                 // sent to the client and processed before the session is disposed
                 if (isRpcCall)
-                    await Task.Delay(100);
+                    await Task.Delay(300);
 
                 // disposes the current session
                 _server?.SessionRepository.RemoveSession(_sessionId);

--- a/CoreRemoting/SessionRepository.cs
+++ b/CoreRemoting/SessionRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Timers;
 using CoreRemoting.Channels;
 
@@ -124,10 +125,11 @@ namespace CoreRemoting
         /// Removes a specified session by its ID.
         /// </summary>
         /// <param name="sessionId">Session ID</param>
-        public void RemoveSession(Guid sessionId)
+        public async Task RemoveSession(Guid sessionId)
         {
             if (_sessions.TryRemove(sessionId, out var session))
-                session.Dispose();
+                await session.DisposeAsync()
+                    .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -138,7 +140,7 @@ namespace CoreRemoting
         /// <summary>
         /// Frees managed resources.
         /// </summary>
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (_inactiveSessionSweepTimer != null)
             {
@@ -150,7 +152,8 @@ namespace CoreRemoting
             while (_sessions.Count > 0)
             {
                 var sessionId = _sessions.First().Key;
-                RemoveSession(sessionId);
+                await RemoveSession(sessionId)
+                    .ConfigureAwait(false);
             }
         }
     }

--- a/CoreRemoting/Threading/AsyncCountdownEvent.cs
+++ b/CoreRemoting/Threading/AsyncCountdownEvent.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Threading;
+
+/// <summary>
+/// Awaitable counterpart of the CountdownEvent class.
+/// </summary>
+/// <remarks>
+/// Based on the work of Stephen Toub and Stephen Cleary:
+/// https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-3-asynccountdownevent/
+/// https://github.com/StephenCleary/AsyncEx/blob/master/src/Nito.AsyncEx.Coordination/AsyncCountdownEvent.cs
+/// </remarks>
+public class AsyncCountdownEvent
+{
+    private readonly AsyncManualResetEvent _mre;
+
+    private long _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncCountdownEvent"/> class.
+    /// </summary>
+    public AsyncCountdownEvent(long count = 0)
+    {
+        _mre = new AsyncManualResetEvent(count == 0);
+        _count = count;
+    }
+
+    /// <summary>
+    /// Performs the requested getter function within the critical section.
+    /// </summary>
+    /// <typeparam name="T">The type of the getter returned value.</typeparam>
+    private T Synced<T>(Func<T> getter)
+    {
+        lock (_mre)
+        {
+            return getter();
+        }
+    }
+
+    /// <summary>
+    /// Gets the current number of remaining signals before this event becomes set.
+    /// This member is seldom used; code using this member has a high possibility of race conditions.
+    /// </summary>
+    public long CurrentCount => Synced(() => _count);
+
+    /// <summary>
+    /// Waits for the count to reach zero.
+    /// </summary>
+    public Task WaitAsync() => _mre.WaitAsync();
+
+    /// <summary>
+    /// Attempts to modify the current count by the specified amount.
+    /// </summary>
+    /// <param name="delta">The amount to change the current count.</param>
+    private void ModifyCount(long delta)
+    {
+        if (delta == 0)
+            return;
+
+        lock (_mre)
+        {
+            var oldCount = _count;
+            checked
+            {
+                _count += delta;
+            }
+
+            if (oldCount == 0)
+            {
+                _mre.Reset();
+            }
+            else if (_count == 0)
+            {
+                _mre.Set();
+            }
+            else if ((oldCount < 0 && _count > 0) || (oldCount > 0 && _count < 0))
+            {
+                _mre.Set();
+                _mre.Reset();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds the specified value to the current count.
+    /// </summary>
+    /// <param name="addCount">The amount to change the current count.</param>
+    public void AddCount(long addCount = 1) =>
+        ModifyCount(addCount);
+
+    /// <summary>
+    /// Subtracts the specified value from the current count.
+    /// </summary>
+    /// <param name="signalCount">The amount to change the current count.</param>
+    public void Signal(long signalCount = 1) =>
+        ModifyCount(-signalCount);
+}

--- a/CoreRemoting/Threading/AsyncCountdownEvent.cs
+++ b/CoreRemoting/Threading/AsyncCountdownEvent.cs
@@ -20,10 +20,10 @@ public class AsyncCountdownEvent
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncCountdownEvent"/> class.
     /// </summary>
-    public AsyncCountdownEvent(long count = 0)
+    public AsyncCountdownEvent(long initialCount = 0)
     {
-        _mre = new AsyncManualResetEvent(count == 0);
-        _count = count;
+        _mre = new AsyncManualResetEvent(initialCount == 0);
+        _count = initialCount;
     }
 
     /// <summary>

--- a/CoreRemoting/Threading/AsyncCounter.cs
+++ b/CoreRemoting/Threading/AsyncCounter.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace CoreRemoting.Toolbox;
+namespace CoreRemoting.Threading;
 
 /// <summary>
 /// Threadsafe counter that can await for the given value.
@@ -51,6 +51,6 @@ public class AsyncCounter
     /// <summary>
     /// Increments the counter.
     /// </summary>
-    public static AsyncCounter operator ++ (AsyncCounter ac) =>
+    public static AsyncCounter operator ++(AsyncCounter ac) =>
         ac.Increment();
 }

--- a/CoreRemoting/Threading/AsyncLock.cs
+++ b/CoreRemoting/Threading/AsyncLock.cs
@@ -2,8 +2,9 @@
 using System.Threading.Tasks;
 using System.Threading;
 using System.Runtime.CompilerServices;
+using CoreRemoting.Toolbox;
 
-namespace CoreRemoting.Toolbox;
+namespace CoreRemoting.Threading;
 
 using ConfiguredAwaiter = ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwaiter;
 

--- a/CoreRemoting/Threading/AsyncManualResetEvent.cs
+++ b/CoreRemoting/Threading/AsyncManualResetEvent.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Threading;
+
+/// <summary>
+/// Awaitable counterpart of the ManualResetEvent class.
+/// </summary>
+/// <remarks>
+/// Based on the work of Stephen Toub and Stephen Cleary:
+/// https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-1-asyncmanualresetevent/
+/// https://github.com/StephenCleary/AsyncEx
+/// </remarks>
+public class AsyncManualResetEvent
+{
+    private readonly object syncObject = new();
+
+    private TaskCompletionSource<bool> tcs = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncManualResetEvent"/> class.
+    /// </summary>
+    public AsyncManualResetEvent(bool set = false)
+    {
+        if (set)
+        {
+            tcs.TrySetResult(true);
+        }
+    }
+
+    /// <summary>
+    /// Performs the requested getter function within the critical section.
+    /// </summary>
+    /// <typeparam name="T">The type of the getter returned value.</typeparam>
+    private T Synced<T>(Func<T> getter)
+    {
+        lock (syncObject)
+        {
+            return getter();
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the event is currently set.
+    /// </summary>
+    public bool IsSet => Synced(() => tcs.Task.IsCompleted);
+
+    /// <summary>
+    /// Waits for the event to be set.
+    /// </summary>
+    public Task WaitAsync() => Synced(() => tcs.Task);
+
+    /// <summary>
+    /// Sets the event. If it's already set, does nothing.
+    /// </summary>
+    public void Set() => Synced(() => tcs.TrySetResult(true));
+
+    /// <summary>
+    /// Resets the event. If it's already reset, does nothing.
+    /// </summary>
+    public void Reset() => Synced(() => tcs = IsSet ? new() : tcs);
+}

--- a/CoreRemoting/Threading/AsyncManualResetEvent.cs
+++ b/CoreRemoting/Threading/AsyncManualResetEvent.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace CoreRemoting.Threading;
@@ -12,13 +9,13 @@ namespace CoreRemoting.Threading;
 /// <remarks>
 /// Based on the work of Stephen Toub and Stephen Cleary:
 /// https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-1-asyncmanualresetevent/
-/// https://github.com/StephenCleary/AsyncEx
+/// https://github.com/StephenCleary/AsyncEx/blob/master/src/Nito.AsyncEx.Coordination/AsyncManualResetEvent.cs
 /// </remarks>
 public class AsyncManualResetEvent
 {
-    private readonly object syncObject = new();
+    private readonly object _syncObject = new();
 
-    private TaskCompletionSource<bool> tcs = new();
+    private TaskCompletionSource<bool> _tcs = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncManualResetEvent"/> class.
@@ -27,7 +24,7 @@ public class AsyncManualResetEvent
     {
         if (set)
         {
-            tcs.TrySetResult(true);
+            _tcs.TrySetResult(true);
         }
     }
 
@@ -37,7 +34,7 @@ public class AsyncManualResetEvent
     /// <typeparam name="T">The type of the getter returned value.</typeparam>
     private T Synced<T>(Func<T> getter)
     {
-        lock (syncObject)
+        lock (_syncObject)
         {
             return getter();
         }
@@ -46,20 +43,20 @@ public class AsyncManualResetEvent
     /// <summary>
     /// Gets a value indicating whether the event is currently set.
     /// </summary>
-    public bool IsSet => Synced(() => tcs.Task.IsCompleted);
+    public bool IsSet => Synced(() => _tcs.Task.IsCompleted);
 
     /// <summary>
     /// Waits for the event to be set.
     /// </summary>
-    public Task WaitAsync() => Synced(() => tcs.Task);
+    public Task WaitAsync() => Synced(() => _tcs.Task);
 
     /// <summary>
     /// Sets the event. If it's already set, does nothing.
     /// </summary>
-    public void Set() => Synced(() => tcs.TrySetResult(true));
+    public void Set() => Synced(() => _tcs.TrySetResult(true));
 
     /// <summary>
     /// Resets the event. If it's already reset, does nothing.
     /// </summary>
-    public void Reset() => Synced(() => tcs = IsSet ? new() : tcs);
+    public void Reset() => Synced(() => _tcs = IsSet ? new() : _tcs);
 }

--- a/CoreRemoting/Threading/AsyncReaderWriterLock.cs
+++ b/CoreRemoting/Threading/AsyncReaderWriterLock.cs
@@ -2,8 +2,9 @@
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
 
-namespace CoreRemoting.Toolbox;
+namespace CoreRemoting.Threading;
 
 using ConfiguredAwaitable = ConfiguredTaskAwaitable<IAsyncDisposable>;
 

--- a/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
+++ b/CoreRemoting/Toolbox/AsyncReaderWriterLock.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace CoreRemoting.Toolbox;
+
+using ConfiguredAwaitable = ConfiguredTaskAwaitable<IAsyncDisposable>;
 
 /// <summary>
 /// Simple async readers/writers lock.
@@ -85,7 +88,7 @@ public class AsyncReaderWriterLock : IDisposable
     /// <summary>
     /// Enters the lock in the read mode in an async-disposable way.
     /// </summary>
-    internal async Task<IAsyncDisposable> ReadLock()
+    private async Task<IAsyncDisposable> ReadLock()
     {
         await EnterReadLock()
             .ConfigureAwait(false);
@@ -94,13 +97,25 @@ public class AsyncReaderWriterLock : IDisposable
     }
 
     /// <summary>
+    /// Gets the awaitable async-disposable lock for the read mode.
+    /// </summary>
+    public ConfiguredAwaitable Read =>
+        ReadLock().ConfigureAwait(false);
+
+    /// <summary>
     /// Enters the lock in the write mode in an async-disposable way.
     /// </summary>
-    internal async Task<IAsyncDisposable> WriteLock()
+    private async Task<IAsyncDisposable> WriteLock()
     {
         await EnterWriteLock()
             .ConfigureAwait(false);
 
         return Disposable.Create(ExitWriteLock);
     }
+
+    /// <summary>
+    /// Gets the awaitable async-disposable lock for the write mode.
+    /// </summary>
+    public ConfiguredAwaitable Write =>
+        WriteLock().ConfigureAwait(false);
 }

--- a/CoreRemoting/Toolbox/Disposable.Async.cs
+++ b/CoreRemoting/Toolbox/Disposable.Async.cs
@@ -25,14 +25,14 @@ namespace CoreRemoting.Toolbox
         /// Creates an asynchronous disposable object.
         /// </summary>
         /// <param name="disposeAsync">An action to invoke on disposal.</param>
-        internal static IAsyncDisposable Create(Func<ValueTask> disposeAsync) =>
+        public static IAsyncDisposable Create(Func<ValueTask> disposeAsync) =>
             new AsyncDisposable(disposeAsync, null);
 
         /// <summary>
         /// Creates an asynchronous disposable object.
         /// </summary>
         /// <param name="disposeAsync">An action to invoke on disposal.</param>
-        internal static IAsyncDisposable Create(Func<Task> disposeAsync) =>
+        public static IAsyncDisposable Create(Func<Task> disposeAsync) =>
             new AsyncDisposable(null, disposeAsync);
 
         private class ParamsDisposableAsync(params object[] disposables) : IAsyncDisposable
@@ -52,7 +52,7 @@ namespace CoreRemoting.Toolbox
         /// Creates an asynchronous disposable object.
         /// </summary>
         /// <param name="disposables">Disposable items to dispose on disposal, both sync and async.</param>
-        internal static IAsyncDisposable Create(params object[] disposables) =>
+        public static IAsyncDisposable Create(params object[] disposables) =>
             new ParamsDisposableAsync(disposables);
     }
 }

--- a/Examples/HelloWorld/HelloWorld.Client/HelloWorld.Client.csproj
+++ b/Examples/HelloWorld/HelloWorld.Client/HelloWorld.Client.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Examples/HelloWorld/HelloWorld.Server/HelloWorld.Server.csproj
+++ b/Examples/HelloWorld/HelloWorld.Server/HelloWorld.Server.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Also, added IAsyncDisposable to RemotingClient, RemotingServer, RemotingSession and SessionRepository.

Keeping IDisposable in RemotingClient and RemotingServer for backwards compatibility.

Related issues: #153, #143, #107, #84, etc.
