### PR TITLE
Refactoring: Unreachable code removed

### DIFF
--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -741,15 +741,7 @@ namespace CoreRemoting
 
             using (await _activeCallsLock)
             {
-                if (_activeCalls.ContainsKey(clientRpcContext.UniqueCallKey))
-                {
-                    clientRpcContext.Dispose();
-                    throw new ApplicationException("Duplicate unique call key.");
-                }
-                else
-                {
-                    _activeCalls.Add(clientRpcContext.UniqueCallKey, clientRpcContext);
-                }
+                _activeCalls.Add(clientRpcContext.UniqueCallKey, clientRpcContext);
             }
 
             var wireMessage =


### PR DESCRIPTION
clientRpcContext. UniqueCallKey in this case is equal to the new Guid, which is never repeated, so checking for a duplicate key value in _activeCalls is meaningless.