### PR TITLE
Fixed _tcpClient leak when SendAsync has errors

### DIFF
--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -178,7 +178,7 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
                 _tcpClient.Dispose();
                 _tcpClient = null;
             }
-            catch (Exception e)
+            catch
             {
                 // ignored
             }

--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -136,16 +136,18 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     /// <param name="rawMessage">Raw message data</param>
     public async Task<bool> SendMessageAsync(byte[] rawMessage)
     {
-        if (_tcpClient != null)
+        try
         {
-            if (await _tcpClient.SendAsync(rawMessage).ConfigureAwait(false))
-                return true;
-            if (!_tcpClient.Connected)
-                _tcpClient = null;
+            return await _tcpClient.SendAsync(rawMessage).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                            new NetworkException(ex.Message, ex);
+
+            ErrorOccured?.Invoke(ex.Message, LastException);
             return false;
         }
-        else
-            throw new NetworkException("Channel disconnected");
     }
 
     /// <summary>


### PR DESCRIPTION
If the _tcpClient variable is set to null, without calling _tcpClient.Dispose() before that, the connection remains active and causes the server ThreadPool to be consumed.