### PR TITLE
Write exceptions for OneWay methods to the log

### DIFF
--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -485,7 +485,7 @@ namespace CoreRemoting
                 ((RemotingServer)_server).OnRejectCall(serverRpcContext);
 
                 if (oneWay)
-                    return;
+                    throw;
 
                 serializedResult =
                     _server.Serializer.Serialize(serverRpcContext.Exception);
@@ -565,7 +565,7 @@ namespace CoreRemoting
                     ((RemotingServer)_server).OnAfterCall(serverRpcContext);
 
                     if (oneWay)
-                        return;
+                        throw;
 
                     serializedResult =
                         _server.Serializer.Serialize(serverRpcContext.Exception);


### PR DESCRIPTION
If an exception occurred when calling the OneWay method, it was hidden, because the result was not used for such methods. Now the exception is written to the server log.