### PR TITLE
Fixed RPC hangup when connection is lost in TcpClientChannel

### DIFF
--- a/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
+++ b/CoreRemoting/Channels/Tcp/TcpClientChannel.cs
@@ -144,7 +144,9 @@ public class TcpClientChannel : IClientChannel, IRawMessageTransport
     {
         try
         {
-            return await _tcpClient.SendAsync(rawMessage).ConfigureAwait(false);
+            if (await _tcpClient.SendAsync(rawMessage).ConfigureAwait(false))
+                return true;
+            throw new NetworkException("Channel disconnected");
         }
         catch (Exception ex)
         {

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -329,8 +329,16 @@ namespace CoreRemoting
 
                 _goodbyeCompletedEvent.Reset();
 
-                await _channel.RawMessageTransport.SendMessageAsync(rawData)
-                    .ConfigureAwait(false);
+                try
+                {
+                    await _channel.RawMessageTransport.SendMessageAsync(rawData)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                    // TODO: dispatch the exception
+                }
 
                 await _goodbyeCompletedEvent.WaitAsync().Expire(10)
                     .ConfigureAwait(false);


### PR DESCRIPTION
When the connection is already terminated, RPC waits for the result indefinitely if SendTimeout = 0 at sendTask.Wait, but the result will never come, because _tcpClient.SendAsync returns false if there is no connection, and this value is not used. Therefore, we throw an exception to abort RPC immediately.