### PR TITLE
Fixed crash in KeepSessionAliveTimerOnElapsed due to an unhandled exception

### DIFF
--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -396,9 +396,17 @@ namespace CoreRemoting
                 return;
             }
 
-            // Send empty message to keep session alive
-            await _rawMessageTransport.SendMessageAsync([])
-                .ConfigureAwait(false);
+            try
+            {
+                // Send empty message to keep session alive
+                await _rawMessageTransport.SendMessageAsync([])
+                    .ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // ignored
+                // TODO: dispatch the exception
+            }
         }
 
         private byte[] SharedSecret()


### PR DESCRIPTION
when channel was disconnected