### PR TITLE
Fixed BSON deserialization for common .NET types

### DIFF
--- a/CoreRemoting.Tests/DataSetSerializationTests.cs
+++ b/CoreRemoting.Tests/DataSetSerializationTests.cs
@@ -1,5 +1,5 @@
 using System.Data;
-using CoreRemoting.Serialization.Bson.DataSetDiffGramSupport;
+using CoreRemoting.Serialization.Bson.Converters.DataSetDiffGramSupport;
 using Newtonsoft.Json;
 using Xunit;
 

--- a/CoreRemoting/Serialization/Bson/BsonSerializerConfig.cs
+++ b/CoreRemoting/Serialization/Bson/BsonSerializerConfig.cs
@@ -26,5 +26,10 @@ namespace CoreRemoting.Serialization.Bson
         /// Gets a list of JSON converters to customize BSON serialization.
         /// </summary>
         public List<JsonConverter> JsonConverters { get; }
+
+        /// <summary>
+        /// Gets or sets whether a set of common JSON converters should be added.
+        /// </summary>
+        public bool AddCommonJsonConverters { get; set; } = true;
     }
 }

--- a/CoreRemoting/Serialization/Bson/BsonTypeConversionRegistry.cs
+++ b/CoreRemoting/Serialization/Bson/BsonTypeConversionRegistry.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Numerics;
+using System.Text;
+
+namespace CoreRemoting.Serialization.Bson
+{
+    /// <summary>
+    /// Provides a registry for custom type conversions when deserializing BSON data.
+    /// </summary>
+    public static class BsonTypeConversionRegistry
+    {
+        private static readonly Dictionary<Type, Func<object, object>> _registry = CreateDefaultRegistry();
+
+        /// <summary>
+        /// Gets or sets the function used to convert a wrapped value to its expected type.
+        /// </summary>
+        /// <remarks>
+        /// This strategy is invoked when the actual type of the wrapped value differs from the expected type.
+        /// By default, it uses <see cref="Convert.ChangeType(object, Type)"/>, but it can be overridden
+        /// to provide custom conversion logic for edge cases or unsupported types.
+        /// </remarks>
+        public static Func<object, Type, object> DefaultTypeConversion { get; set; } = Convert.ChangeType;
+
+        /// <summary>
+        /// Attempts to retrieve a registered type conversion function for a specified type.
+        /// </summary>
+        /// <param name="type">Type to retrieve a conversion function</param>
+        /// <param name="converter">Contains the conversion function if found; otherwise null</param>
+        /// <returns><c>true</c> if a conversion function was found for the given type.</returns>
+        public static bool TryGetTypeConversion(Type type, out Func<object, object> converter)
+        {
+            return _registry.TryGetValue(type, out converter);
+        }
+
+        /// <summary>
+        /// Adds a new type conversion function or updates an existing one for a specified type.
+        /// </summary>
+        /// <param name="type">The target type to associate with the conversion function.</param>
+        /// <param name="converter">The conversion function that converts an object to the specified type.</param>
+        public static void AddOrUpdateTypeConversion(Type type, Func<object, object> converter)
+        {
+            _registry[type] = converter;
+        }
+
+        /// <summary>
+        /// Creates the default registry mapping common .NET types to corresponding converters.
+        /// </summary>
+        /// <returns>A dictionary of default type converters</returns>
+        private static Dictionary<Type, Func<object, object>> CreateDefaultRegistry()
+        {
+            return new Dictionary<Type, Func<object, object>>
+            {
+                { typeof(DateTimeOffset), value => ConvertToDateTimeOffset(value) },
+                { typeof(TimeSpan), value => TimeSpan.Parse(value.ToString()) },
+                { typeof(Uri), value => new Uri(value.ToString()) },
+                { typeof(CultureInfo), value => GetCultureInfo(value.ToString()) },
+                { typeof(RegionInfo), value => new RegionInfo(value.ToString()) },
+                { typeof(Version), value => new Version(value.ToString()) },
+                { typeof(BigInteger), value => ConvertToBigInteger(value) },
+                { typeof(IPAddress), value => IPAddress.Parse(value.ToString()) },
+                { Type.GetType("System.RuntimeType"), value => Type.GetType(value.ToString()) },
+            };
+        }
+
+        private static DateTimeOffset ConvertToDateTimeOffset(object value)
+        {
+            return value is DateTime dateTime
+                ? new DateTimeOffset(dateTime)
+                : DateTimeOffset.Parse(value.ToString());
+        }
+
+        private static CultureInfo GetCultureInfo(string value)
+        {
+            // InvariantCulture.Name = "(Default)" and cannot be retrieved through CultureInfo.GetCultureInfo
+            return value == "(Default)"
+                ? CultureInfo.InvariantCulture
+                : CultureInfo.GetCultureInfo(value);
+        }
+
+        private static BigInteger ConvertToBigInteger(object value)
+        {
+            return value is byte[] byteArray
+                ? new BigInteger(byteArray)
+                : BigInteger.Parse(value.ToString());
+        }
+    }
+}

--- a/CoreRemoting/Serialization/Bson/Converters/DataSetDiffGramSupport/DataSetDiffGramJsonConverter.cs
+++ b/CoreRemoting/Serialization/Bson/Converters/DataSetDiffGramSupport/DataSetDiffGramJsonConverter.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace CoreRemoting.Serialization.Bson.DataSetDiffGramSupport;
+namespace CoreRemoting.Serialization.Bson.Converters.DataSetDiffGramSupport;
 
 /// <summary>
 /// Converter to serialize and deserialize typed and untyped DataSets / DataTables.

--- a/CoreRemoting/Serialization/Bson/Converters/DataSetDiffGramSupport/SerializedDiffGram.cs
+++ b/CoreRemoting/Serialization/Bson/Converters/DataSetDiffGramSupport/SerializedDiffGram.cs
@@ -3,7 +3,7 @@ using System.Data;
 using System.IO;
 using System.Text;
 
-namespace CoreRemoting.Serialization.Bson.DataSetDiffGramSupport;
+namespace CoreRemoting.Serialization.Bson.Converters.DataSetDiffGramSupport;
 
 /// <summary>
 /// Representation of serialized DataSet/DataTable DiffGram.

--- a/CoreRemoting/Serialization/Bson/Converters/EncodingConverter.cs
+++ b/CoreRemoting/Serialization/Bson/Converters/EncodingConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace CoreRemoting.Serialization.Bson.Converters
+{
+    /// <summary>
+    /// Converter to serialize and deserialize Encoding instances.
+    /// </summary>
+    public class EncodingConverter : JsonConverter<Encoding>
+    {
+        /// <summary>
+        /// Reads an Encoding instance from JSON.
+        /// </summary>
+        /// <param name="reader">JSON reader</param>
+        /// <param name="objectType">Object type to be read</param>
+        /// <param name="existingValue">Existing value</param>
+        /// <param name="hasExistingValue">Has existing value</param>
+        /// <param name="serializer">JSON serializer</param>
+        /// <returns>Encoding instance</returns>
+        public override Encoding ReadJson(JsonReader reader, Type objectType, Encoding existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var encodingName = reader.Value?.ToString();
+            if (string.IsNullOrEmpty(encodingName))
+                return null;
+
+            return Encoding.GetEncoding(encodingName);
+        }
+
+        /// <summary>
+        /// Writes JSON for an Encoding instance.
+        /// </summary>
+        /// <param name="writer">JSON writer</param>
+        /// <param name="value">Encoding</param>
+        /// <param name="serializer">JSON serializer</param>
+        public override void WriteJson(JsonWriter writer, Encoding value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteValue(value.WebName); // IANA names should be compatible with Encoding.GetEncoding
+        }
+    }
+}

--- a/CoreRemoting/Serialization/Bson/Converters/IPAddressConverter.cs
+++ b/CoreRemoting/Serialization/Bson/Converters/IPAddressConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Net;
+using Newtonsoft.Json;
+
+namespace CoreRemoting.Serialization.Bson.Converters
+{
+    /// <summary>
+    /// Converter to serialize and deserialize IPAddress instances
+    /// </summary>
+    public class IPAddressConverter : JsonConverter<IPAddress>
+    {
+        /// <summary>
+        /// Reads an IPAddress instance from JSON.
+        /// </summary>
+        /// <param name="reader">JSON reader</param>
+        /// <param name="objectType">Object type to be read</param>
+        /// <param name="existingValue">Existing value</param>
+        /// <param name="hasExistingValue">Has existing value</param>
+        /// <param name="serializer">JSON serializer</param>
+        /// <returns>IPAddress instance</returns>
+        public override IPAddress ReadJson(JsonReader reader, Type objectType, IPAddress existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var addressString = reader.Value?.ToString();
+            if (string.IsNullOrEmpty(addressString))
+                return null;
+
+            return IPAddress.Parse(addressString);
+        }
+
+        /// <summary>
+        /// Writes JSON for an IPAddress instance.
+        /// </summary>
+        /// <param name="writer">JSON writer</param>
+        /// <param name="value">IPAddress</param>
+        /// <param name="serializer">JSON serializer</param>
+        public override void WriteJson(JsonWriter writer, IPAddress value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteValue(value.ToString());
+        }
+    }
+}

--- a/CoreRemoting/Serialization/Bson/Converters/IPEndPointConverter.cs
+++ b/CoreRemoting/Serialization/Bson/Converters/IPEndPointConverter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CoreRemoting.Serialization.Bson.Converters
+{
+    /// <summary>
+    /// Converter to serialize and deserialize IPEndPoint instances.
+    /// </summary>
+    public class IPEndPointConverter : JsonConverter<IPEndPoint>
+    {
+        /// <summary>
+        /// Reads an IPEndPoint instance from JSON.
+        /// </summary>
+        /// <param name="reader">JSON reader</param>
+        /// <param name="objectType">Object type to be read</param>
+        /// <param name="existingValue">Existing value</param>
+        /// <param name="hasExistingValue">Indicates if the existing value exists</param>
+        /// <param name="serializer">JSON serializer</param>
+        /// <returns>IPEndPoint instance</returns>
+        public override IPEndPoint ReadJson(JsonReader reader, Type objectType, IPEndPoint existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            // Read the JSON value as a JObject to extract both Address and Port
+            var jsonObject = JObject.Load(reader);
+            var address = jsonObject["Address"]?.ToObject<IPAddress>(serializer);
+            var port = jsonObject["Port"]?.ToObject<int>(serializer);
+
+            if (address == null || port == null)
+                throw new JsonSerializationException("Invalid IPEndPoint format.");
+
+            return new IPEndPoint(address, port.Value);
+        }
+
+        /// <summary>
+        /// Writes JSON for an IPEndPoint instance.
+        /// </summary>
+        /// <param name="writer">JSON writer</param>
+        /// <param name="value">IPEndPoint</param>
+        /// <param name="serializer">JSON serializer</param>
+        public override void WriteJson(JsonWriter writer, IPEndPoint value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            // Serialize IPEndPoint as a JSON object with "Address" and "Port" properties
+            writer.WriteStartObject();
+            writer.WritePropertyName("Address");
+            serializer.Serialize(writer, value.Address);
+            writer.WritePropertyName("Port");
+            serializer.Serialize(writer, value.Port);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/CoreRemoting/Serialization/Bson/Converters/RegionInfoConverter.cs
+++ b/CoreRemoting/Serialization/Bson/Converters/RegionInfoConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace CoreRemoting.Serialization.Bson.Converters
+{
+    /// <summary>
+    /// Converter to serialize and deserialize RegionInfo instances
+    /// </summary>
+    public class RegionInfoConverter : JsonConverter<RegionInfo>
+    {
+        /// <summary>
+        /// Reads a RegionInfo instance from JSON.
+        /// </summary>
+        /// <param name="reader">JSON reader</param>
+        /// <param name="objectType">Object type to be read</param>
+        /// <param name="existingValue">Existing value</param>
+        /// <param name="hasExistingValue">Has existing value</param>
+        /// <param name="serializer">JSON serializer</param>
+        /// <returns>RegionInfo instance</returns>
+        public override RegionInfo ReadJson(JsonReader reader, Type objectType, RegionInfo existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var regionName = reader.Value?.ToString();
+            if (string.IsNullOrEmpty(regionName))
+                return null;
+
+            return new RegionInfo(regionName);
+        }
+
+        /// <summary>
+        /// Writes JSON for a RegionInfo instance.
+        /// </summary>
+        /// <param name="writer">JSON writer</param>
+        /// <param name="value">RegionInfo</param>
+        /// <param name="serializer">JSON serializer</param>
+        public override void WriteJson(JsonWriter writer, RegionInfo value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteValue(value.Name);
+        }
+    }
+}


### PR DESCRIPTION
Adds `BsonTypeConversionRegistry` to allow registering custom enveloped type converters in a dictionary.
Adds a few JSON converters that are needed for some of the types. 

By default, fixes type conversion of the following types:
- `DateTimeOffset` 
- `TimeSpan`
- `Uri`
- `CultureInfo`
- `RegionInfo` (Requires a converter)
- `Version`
- `BigInteger`
- `Encoding` (Requires a converter and `typeof(Encoding).IsAssignableFrom(type)` because of its many subclasses)
- `IPAddress` (Requires a converter)
- `IPEndPoint` (Requires a converter and special `JObject` handling in `Envelope`)

Also adds an `AddCommonJsonConverters` boolean flag to `BsonSerializerConfig` to enable/disable the new converters (true by default).

See the modified test in BsonSerializationTests.cs for a demonstration.