### PR TITLE
Fix possible leak of ClientRpcContext

### DIFF
--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -789,6 +789,9 @@ namespace CoreRemoting
 
             if (_rawMessageTransport.LastException != null)
             {
+                using (await _activeCallsLock)
+                    _activeCalls.Remove(clientRpcContext.UniqueCallKey);
+                
                 clientRpcContext.Dispose();
                 throw _rawMessageTransport.LastException;
             }


### PR DESCRIPTION
clientRpcContext disposed but not removed from _activeCalls dictionary