### PR TITLE
In-process NullChannel for unit testing

### DIFF
--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -66,6 +66,10 @@
       <Compile Include="RpcTests_Websockets.cs">
         <DependentUpon>RpcTests.cs</DependentUpon>
       </Compile>
+      <Compile Remove="RpcTests_NullChannel.cs" />
+      <Compile Include="RpcTests_NullChannel.cs">
+        <DependentUpon>RpcTests.cs</DependentUpon>
+      </Compile>
       <Compile Remove="SessionTests_Websockets.cs" />
       <Compile Include="SessionTests_Websockets.cs">
         <DependentUpon>SessionTests.cs</DependentUpon>

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -139,7 +139,7 @@ public class RpcTests : IClassFixture<ServerFixture>
     }
 
     [Fact]
-    public virtual void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
+    public void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
     {
         _serverFixture.Server.Config.MessageEncryption = true;
 
@@ -763,7 +763,7 @@ public class RpcTests : IClassFixture<ServerFixture>
 
     [Fact]
     [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-    public virtual async Task Disposed_client_subscription_doesnt_break_other_clients()
+    public async Task Disposed_client_subscription_doesnt_break_other_clients()
     {
         using var ctx = ValidationSyncContext.Install();
 

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -139,7 +139,7 @@ public class RpcTests : IClassFixture<ServerFixture>
     }
 
     [Fact]
-    public void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
+    public virtual void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
     {
         _serverFixture.Server.Config.MessageEncryption = true;
 
@@ -763,7 +763,7 @@ public class RpcTests : IClassFixture<ServerFixture>
 
     [Fact]
     [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-    public async Task Disposed_client_subscription_doesnt_break_other_clients()
+    public virtual async Task Disposed_client_subscription_doesnt_break_other_clients()
     {
         using var ctx = ValidationSyncContext.Install();
 

--- a/CoreRemoting.Tests/RpcTests_NullChannel.cs
+++ b/CoreRemoting.Tests/RpcTests_NullChannel.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CoreRemoting.Channels;
+using CoreRemoting.Channels.Null;
+using CoreRemoting.Toolbox;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreRemoting.Tests;
+
+public class RpcTests_NullChannel : RpcTests
+{
+    protected override IServerChannel ServerChannel => new NullServerChannel();
+
+    protected override IClientChannel ClientChannel => new NullClientChannel();
+
+    public RpcTests_NullChannel(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
+    {
+    }
+
+    [Fact]
+    public async Task NullMessageQueue_doesnt_have_messages()
+    {
+        var msgs = NullMessageQueue.ReceiveMessagesAsync("123", "123", "123");
+        var enumerator = msgs.GetAsyncEnumerator();
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
+        {
+            await enumerator.MoveNextAsync().AsTask().Timeout(0.5);
+        });
+    }
+
+    [Fact]
+    public async Task NullMessageQueue_can_have_messages()
+    {
+        NullMessageQueue.SendMessage("123", "123", "123", [1, 2, 3]);
+
+        var received = Array.Empty<byte>();
+        await foreach (var msg in NullMessageQueue.ReceiveMessagesAsync("123", "123", "123"))
+        {
+            received = msg.Message;
+        }
+
+        Assert.Equal(3, received.Length);
+    }
+
+    [Fact]
+    public async Task NullClientChannel_can_connect_to_NullServerChannel()
+    {
+        await using var client = new NullClientChannel();
+        await using var server = new NullServerChannel();
+
+        server.SetUrl("localhost", 1234);
+        client.SetUrl("localhost", 1234);
+
+        Assert.True(server.Connections.IsEmpty);
+        client.ReceiveMessage += message =>
+            Console.WriteLine($"Client message received: {string.Join("", message)}");
+
+        server.StartListening();
+        await client.ConnectAsync();
+
+        await Task.Delay(TimeSpan.FromSeconds(0.5));
+        Assert.False(server.Connections.IsEmpty);
+
+        var connection = server.Connections.First().Value;
+        connection.ReceiveMessage += message =>
+            Console.WriteLine($"Server message received: {string.Join("", message)}");
+
+        await client.SendMessageAsync([1, 2, 3, 4]);
+        await connection.SendMessageAsync([3, 2, 1, 0]);
+        await Task.Delay(TimeSpan.FromSeconds(0.5));
+    }
+
+    [Fact]
+    public async Task RemotingClient_can_connect_to_RemotingServer_using_NullChannel()
+    {
+        using var server = new RemotingServer(new ServerConfig
+        {
+            MessageEncryption = false,
+            Channel = ServerChannel,
+            NetworkPort = 1234,
+        });
+
+        using var client = new RemotingClient(new ClientConfig
+        {
+            ConnectionTimeout = 5,
+            MessageEncryption = false,
+            Channel = ClientChannel,
+            ServerPort = 1234,
+        });
+
+        server.Start();
+        await client.ConnectAsync();
+
+        await client.DisconnectAsync();
+        server.Stop();
+    }
+}

--- a/CoreRemoting.Tests/RpcTests_NullChannel.cs
+++ b/CoreRemoting.Tests/RpcTests_NullChannel.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreRemoting.Channels;
 using CoreRemoting.Channels.Null;
-using CoreRemoting.Tests.Tools;
 using CoreRemoting.Toolbox;
-using WatsonTcp;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -117,7 +114,8 @@ public class RpcTests_NullChannel : RpcTests
 
         Assert.True(server.Connections.IsEmpty);
         client.ReceiveMessage += message =>
-            Console.WriteLine($"Client message received: {string.Join("", serverMessage = message)}");
+            Console.WriteLine($"Client message received: {
+                string.Concat(serverMessage = message)}");
 
         server.StartListening();
         await client.ConnectAsync();
@@ -127,22 +125,16 @@ public class RpcTests_NullChannel : RpcTests
 
         var connection = server.Connections.First().Value;
         connection.ReceiveMessage += message =>
-            Console.WriteLine($"Server message received: {string.Join("", clientMessage = message)}");
+            Console.WriteLine($"Server message received: {
+                string.Concat(clientMessage = message)}");
 
         await client.SendMessageAsync([1, 2, 3, 4]);
         await connection.SendMessageAsync([3, 2, 1, 0]);
 
         await Task.Delay(TimeSpan.FromSeconds(0.5));
-        Assert.Equal("1, 2, 3, 4", string.Join(", ", clientMessage));
-        Assert.Equal("3, 2, 1, 0", string.Join(", ", serverMessage));
+        Assert.Equal("1234", string.Concat(clientMessage));
+        Assert.Equal("3210", string.Concat(serverMessage));
     }
-
-    // these tests are known to be broken
-    public override void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption() =>
-        Assert.Fail();
-
-    public override Task Disposed_client_subscription_doesnt_break_other_clients() =>
-        Task.Run(() => Assert.Fail());
 
     [Fact]
     public async Task RemotingClient_can_connect_to_RemotingServer_using_NullChannel()

--- a/CoreRemoting.Tests/RpcTests_NullChannel.cs
+++ b/CoreRemoting.Tests/RpcTests_NullChannel.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreRemoting.Channels;
 using CoreRemoting.Channels.Null;
+using CoreRemoting.Tests.Tools;
 using CoreRemoting.Toolbox;
+using WatsonTcp;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,6 +23,25 @@ public class RpcTests_NullChannel : RpcTests
     }
 
     [Fact]
+    public void NullMessageQueue_cannot_connect_when_no_listener_is_registered()
+    {
+        Assert.Throws<Exception>(() => NullMessageQueue.Connect("123"));
+    }
+
+    [Fact]
+    public void NullMessageQueue_connects_when_a_listener_is_registered()
+    {
+        // server endpoint
+        NullMessageQueue.StartListener("123");
+
+        // client endpoint
+        var client = NullMessageQueue.Connect("123");
+        Assert.NotNull(client);
+
+        NullMessageQueue.StopListener("123");
+    }
+
+    [Fact]
     public async Task NullMessageQueue_doesnt_have_messages()
     {
         var msgs = NullMessageQueue.ReceiveMessagesAsync("123", "123", "123");
@@ -33,15 +55,52 @@ public class RpcTests_NullChannel : RpcTests
     [Fact]
     public async Task NullMessageQueue_can_have_messages()
     {
-        NullMessageQueue.SendMessage("123", "123", "123", [1, 2, 3]);
+        NullMessageQueue.SendMessage("123", "123", [1, 2, 3]);
 
         var received = Array.Empty<byte>();
-        await foreach (var msg in NullMessageQueue.ReceiveMessagesAsync("123", "123", "123"))
+        await foreach (var msg in NullMessageQueue.ReceiveMessagesAsync(null, "123", "123"))
         {
             received = msg.Message;
         }
 
         Assert.Equal(3, received.Length);
+    }
+
+    [Fact]
+    public async Task NullMessageQueue_can_simulate_listen_connect_and_send_operations()
+    {
+        // no listener yet
+        var server = "server";
+        Assert.Throws<Exception>(() => NullMessageQueue.Connect(server));
+
+        // start the listener and connect successfully
+        NullMessageQueue.StartListener(server);
+        var client = NullMessageQueue.Connect(server);
+
+        // send two messages to the server
+        NullMessageQueue.SendMessage(client, server, [1, 2, 3], "First");
+        NullMessageQueue.SendMessage(client, server, [4, 5]);
+
+        // receive two messages from server
+        await foreach (var msg in NullMessageQueue.ReceiveMessagesAsync(null, client, server))
+        {
+            var expected = msg.Metadata.Any() ? "1, 2, 3" : "4, 5";
+            Assert.Equal(expected, string.Join(", ", msg.Message));
+        }
+
+        // no messages left
+        var msgs = NullMessageQueue.ReceiveMessagesAsync(null, client, server);
+        var enumerator = msgs.GetAsyncEnumerator();
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
+        {
+            await enumerator.MoveNextAsync().AsTask().Timeout(0.5);
+        });
+
+        // stop the listener
+        NullMessageQueue.StopListener("server");
+
+        // no listener anymore
+        Assert.Throws<Exception>(() => NullMessageQueue.Connect("server"));
     }
 
     [Fact]
@@ -53,9 +112,12 @@ public class RpcTests_NullChannel : RpcTests
         server.SetUrl("localhost", 1234);
         client.SetUrl("localhost", 1234);
 
+        var clientMessage = Array.Empty<byte>();
+        var serverMessage = Array.Empty<byte>();
+
         Assert.True(server.Connections.IsEmpty);
         client.ReceiveMessage += message =>
-            Console.WriteLine($"Client message received: {string.Join("", message)}");
+            Console.WriteLine($"Client message received: {string.Join("", serverMessage = message)}");
 
         server.StartListening();
         await client.ConnectAsync();
@@ -65,12 +127,22 @@ public class RpcTests_NullChannel : RpcTests
 
         var connection = server.Connections.First().Value;
         connection.ReceiveMessage += message =>
-            Console.WriteLine($"Server message received: {string.Join("", message)}");
+            Console.WriteLine($"Server message received: {string.Join("", clientMessage = message)}");
 
         await client.SendMessageAsync([1, 2, 3, 4]);
         await connection.SendMessageAsync([3, 2, 1, 0]);
+
         await Task.Delay(TimeSpan.FromSeconds(0.5));
+        Assert.Equal("1, 2, 3, 4", string.Join(", ", clientMessage));
+        Assert.Equal("3, 2, 1, 0", string.Join(", ", serverMessage));
     }
+
+    // these tests are known to be broken
+    public override void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption() =>
+        Assert.Fail();
+
+    public override Task Disposed_client_subscription_doesnt_break_other_clients() =>
+        Task.Run(() => Assert.Fail());
 
     [Fact]
     public async Task RemotingClient_can_connect_to_RemotingServer_using_NullChannel()

--- a/CoreRemoting/Channels/Null/NullClientChannel.cs
+++ b/CoreRemoting/Channels/Null/NullClientChannel.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CoreRemoting.Channels.Null;
+
+/// <summary>
+/// Simple in-process channel, client-side.
+/// </summary>
+public class NullClientChannel : NullTransport, IClientChannel
+{
+    /// <inheritdoc />
+    public void Init(IRemotingClient client) =>
+        SetUrl(client.Config.ServerHostName, client.Config.ServerPort);
+
+    /// <summary>
+    /// Sets the server URL.
+    /// </summary>
+    /// <param name="host">Server host</param>
+    /// <param name="port">Server port</param>
+    internal void SetUrl(string host, int port) =>
+        Url = $"null://{host}:{port}/rpc";
+
+    /// <inheritdoc />
+    public string Url { get; private set; }
+
+    /// <inheritdoc />
+    public IRawMessageTransport RawMessageTransport => this;
+
+    /// <inheritdoc />
+    public async Task ConnectAsync()
+    {
+        ThisEndpoint = NullMessageQueue.Connect(Url);
+        RemoteEndpoint = Url;
+
+        StartListening();
+
+        await SendMessageAsync([])
+            .ConfigureAwait(false);
+
+        OnConnected();
+    }
+
+    /// <inheritdoc />
+    public override async Task DisconnectAsync()
+    {
+        await base.DisconnectAsync().ConfigureAwait(false);
+        IsConnected = false;
+        OnDisconnected();
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await DisconnectAsync().ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/CoreRemoting/Channels/Null/NullMessage.cs
+++ b/CoreRemoting/Channels/Null/NullMessage.cs
@@ -1,0 +1,31 @@
+﻿namespace CoreRemoting.Channels.Null;
+
+/// <summary>
+/// Channel message.
+/// </summary>
+/// <param name="sender">Sender endpoint</param>
+/// <param name="receiver">Receiver endpoint</param>
+/// <param name="message">Message payload</param>
+/// <param name="metadata">Message metadata</param>
+public class NullMessage(string sender, string receiver, byte[] message, params string[] metadata)
+{
+    /// <summary>
+    /// Gets message sender.
+    /// </summary>
+    public string Sender { get; } = sender;
+
+    /// <summary>
+    /// Gets message receiver.
+    /// </summary>
+    public string Receiver { get; } = receiver;
+
+    /// <summary>
+    /// Gets message payload.
+    /// </summary>
+    public byte[] Message { get; } = message;
+
+    /// <summary>
+    /// Gets the metadata.
+    /// </summary>
+    public string[] Metadata { get; } = metadata;
+}

--- a/CoreRemoting/Channels/Null/NullMessageQueue.cs
+++ b/CoreRemoting/Channels/Null/NullMessageQueue.cs
@@ -58,6 +58,19 @@ public class NullMessageQueue
         throw new Exception($"No listener is registered for endpoint: {endpoint}");
     }
 
+    private static string GetAddress(string sender, string receiver) =>
+        $"{sender}:{receiver}";
+
+    /// <summary>
+    /// Sends a message to the specified endpoint.
+    /// </summary>
+    /// <param name="sender">Sender endpoint.</param>
+    /// <param name="receiver">Receiver endpoint.</param>
+    /// <param name="message">Message to send.</param>
+    /// <param name="metadata">Message metadata.</param>
+    public static void SendMessage(string sender, string receiver, byte[] message, params string[] metadata) =>
+        SendMessage(GetAddress(sender, receiver), sender, receiver, message, metadata);
+
     /// <summary>
     /// Sends a message to the specified endpoint.
     /// </summary>
@@ -66,7 +79,7 @@ public class NullMessageQueue
     /// <param name="receiver">Receiver endpoint.</param>
     /// <param name="message">Message to send.</param>
     /// <param name="metadata">Message metadata.</param>
-    public static void SendMessage(string address, string sender, string receiver, byte[] message, params string[] metadata)
+    private static void SendMessage(string address, string sender, string receiver, byte[] message, params string[] metadata)
     {
         var adr = address ?? $"{sender}:{receiver}";
         var mre = Events.GetOrAdd(adr, address => new(false));
@@ -87,9 +100,8 @@ public class NullMessageQueue
         var mre = Events.GetOrAdd(adr, address => new(false));
         var queue = Queues.GetOrAdd(adr, address => new());
 
-        //await mre.WaitAsync().ConfigureAwait(false);
-        await Task.Delay(TimeSpan.FromSeconds(0.1))
-            .ConfigureAwait(false);
+        await mre.WaitAsync().ConfigureAwait(false);
+        mre.Reset();
 
         while (queue.TryDequeue(out var message))
             yield return message;

--- a/CoreRemoting/Channels/Null/NullMessageQueue.cs
+++ b/CoreRemoting/Channels/Null/NullMessageQueue.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CoreRemoting.Threading;
+
+namespace CoreRemoting.Channels.Null;
+
+/// <summary>
+/// Simple in-process channel, request/response queue manager.
+/// </summary>
+public class NullMessageQueue
+{
+    /// <summary>
+    /// Synchronization events: endpoint or sender:receiver -> reset event
+    /// </summary>
+    private static ConcurrentDictionary<string, AsyncManualResetEvent> Events { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Incoming message queues: endpoint or sender:receiver -> message queue
+    /// </summary>
+    private static ConcurrentDictionary<string, ConcurrentQueue<NullMessage>> Queues { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Registered message listeners: endpoint -> endpoint
+    /// </summary>
+    private static ConcurrentDictionary<string, string> Listeners { get; } = new();
+
+    /// <summary>
+    /// Adds a new listener.
+    /// </summary>
+    /// <param name="endpoint">Listening endpoint.</param>
+    public static void StartListener(string endpoint) =>
+        Listeners.TryAdd(endpoint, endpoint);
+
+    /// <summary>
+    /// Stops the specified listener.
+    /// </summary>
+    /// <param name="endpoint">Listening endpoint.</param>
+    public static void StopListener(string endpoint) =>
+        Listeners.TryRemove(endpoint, out _);
+
+    /// <summary>
+    /// Connects to the specified listener endpoint.
+    /// </summary>
+    /// <param name="endpoint">Listener endpoint</param>
+    public static string Connect(string endpoint)
+    {
+        if (Listeners.TryGetValue(endpoint, out var _))
+        {
+            var sender = Guid.NewGuid().ToString();
+            SendMessage(endpoint, sender, endpoint, []);
+            return sender;
+        }
+
+        throw new Exception($"No listener is registered for endpoint: {endpoint}");
+    }
+
+    /// <summary>
+    /// Sends a message to the specified endpoint.
+    /// </summary>
+    /// <param name="address">Address, either sender:receiver or just receiver for incoming connections.</param>
+    /// <param name="sender">Sender endpoint.</param>
+    /// <param name="receiver">Receiver endpoint.</param>
+    /// <param name="message">Message to send.</param>
+    /// <param name="metadata">Message metadata.</param>
+    public static void SendMessage(string address, string sender, string receiver, byte[] message, params string[] metadata)
+    {
+        var adr = address ?? $"{sender}:{receiver}";
+        var mre = Events.GetOrAdd(adr, address => new(false));
+        var queue = Queues.GetOrAdd(adr, address => new());
+        queue.Enqueue(new(sender, receiver, message, metadata));
+        mre.Set();
+    }
+
+    /// <summary>
+    /// Receives all pending messages from the specified channel.
+    /// </summary>
+    /// <param name="address">Address, either sender:receiver or receiver for incoming connections.</param>
+    /// <param name="sender">Sender endpoint.</param>
+    /// <param name="receiver">Receiver endpoint.</param>
+    public static async IAsyncEnumerable<NullMessage> ReceiveMessagesAsync(string address, string sender, string receiver)
+    {
+        var adr = address ?? $"{sender}:{receiver}";
+        var mre = Events.GetOrAdd(adr, address => new(false));
+        var queue = Queues.GetOrAdd(adr, address => new());
+
+        //await mre.WaitAsync().ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromSeconds(0.1))
+            .ConfigureAwait(false);
+
+        while (queue.TryDequeue(out var message))
+            yield return message;
+    }
+}

--- a/CoreRemoting/Channels/Null/NullMessageQueue.cs
+++ b/CoreRemoting/Channels/Null/NullMessageQueue.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using CoreRemoting.Threading;
 
 namespace CoreRemoting.Channels.Null;
@@ -46,20 +45,18 @@ public class NullMessageQueue
     /// Connects to the specified listener endpoint.
     /// </summary>
     /// <param name="endpoint">Listener endpoint</param>
-    public static string Connect(string endpoint)
+    /// <param name="metadata">Optional metadata strings</param>
+    public static string Connect(string endpoint, params string[] metadata)
     {
         if (Listeners.TryGetValue(endpoint, out var _))
         {
             var sender = Guid.NewGuid().ToString();
-            SendMessage(endpoint, sender, endpoint, []);
+            SendMessage(endpoint, sender, endpoint, [], metadata);
             return sender;
         }
 
         throw new Exception($"No listener is registered for endpoint: {endpoint}");
     }
-
-    private static string GetAddress(string sender, string receiver) =>
-        $"{sender}:{receiver}";
 
     /// <summary>
     /// Sends a message to the specified endpoint.
@@ -69,7 +66,7 @@ public class NullMessageQueue
     /// <param name="message">Message to send.</param>
     /// <param name="metadata">Message metadata.</param>
     public static void SendMessage(string sender, string receiver, byte[] message, params string[] metadata) =>
-        SendMessage(GetAddress(sender, receiver), sender, receiver, message, metadata);
+        SendMessage($"{sender}:{receiver}", sender, receiver, message, metadata);
 
     /// <summary>
     /// Sends a message to the specified endpoint.

--- a/CoreRemoting/Channels/Null/NullServerChannel.cs
+++ b/CoreRemoting/Channels/Null/NullServerChannel.cs
@@ -76,7 +76,9 @@ public class NullServerChannel : IServerChannel
 
     private async Task ReceiveConnections()
     {
-        await foreach (var msg in ReceiveMessagesAsync(Url, string.Empty, Url))
+        await foreach (var msg in
+            ReceiveMessagesAsync(Url, string.Empty, Url)
+                .ConfigureAwait(false))
         {
             var connection = new NullServerConnection(msg, Server);
             var sessionId = connection.StartListening();

--- a/CoreRemoting/Channels/Null/NullServerChannel.cs
+++ b/CoreRemoting/Channels/Null/NullServerChannel.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Castle.MicroKernel.SubSystems.Conversion;
+using CoreRemoting.Channels.Websocket;
+using static CoreRemoting.Channels.Null.NullMessageQueue;
+
+namespace CoreRemoting.Channels.Null;
+
+/// <summary>
+/// Simple in-process channel, server-side.
+/// </summary>
+public class NullServerChannel : IServerChannel
+{
+    /// <inheritdoc/>
+    public void Init(IRemotingServer server)
+    {
+        Server = server;
+        SetUrl(Server.Config.HostName, Server.Config.NetworkPort);
+    }
+
+    /// <summary>
+    /// Sets the server URL.
+    /// </summary>
+    /// <param name="host">Server host</param>
+    /// <param name="port">Server port</param>
+    internal void SetUrl(string host, int port) =>
+        Url = $"null://{host}:{port}/rpc";
+
+    /// <summary>
+    /// Gets the associated remoting server.
+    /// </summary>
+    public IRemotingServer Server { get; private set; }
+
+    internal ConcurrentDictionary<Guid, NullServerConnection> Connections { get; } = new();
+
+    /// <inheritdoc/>
+    public string Url { get; private set; }
+
+    /// <inheritdoc/>
+    public bool IsListening { get; private set; }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        StopListening();
+
+        foreach (var conn in Connections)
+        {
+            await conn.Value.DisconnectAsync();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void StartListening()
+    {
+        IsListening = true;
+        StartListener(Url);
+
+        _ = Task.Factory.StartNew(async () =>
+        {
+            while (IsListening)
+                await ReceiveConnections();
+        });
+    }
+
+    /// <inheritdoc/>
+    public void StopListening()
+    {
+        if (IsListening)
+        {
+            IsListening = false;
+            StopListener(Url);
+        }
+    }
+
+    private async Task ReceiveConnections()
+    {
+        await foreach (var msg in ReceiveMessagesAsync(Url, string.Empty, Url))
+        {
+            var connection = new NullServerConnection(msg, Server);
+            var sessionId = connection.StartListening();
+            Connections[sessionId] = connection;
+        }
+    }
+}

--- a/CoreRemoting/Channels/Null/NullServerConnection.cs
+++ b/CoreRemoting/Channels/Null/NullServerConnection.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using CoreRemoting.Channels.Null;
+
+namespace CoreRemoting.Channels.Websocket;
+
+/// <summary>
+/// Websocket connection.
+/// </summary>
+public class NullServerConnection : NullTransport, IAsyncDisposable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullServerConnection"/> class.
+    /// </summary>
+    public NullServerConnection(NullMessage connectionMessage, IRemotingServer remotingServer)
+    {
+        ConnectionMessage = connectionMessage ?? throw new ArgumentNullException(nameof(connectionMessage));
+        ClientAddress = connectionMessage.Sender ?? throw new ArgumentNullException(nameof(connectionMessage.Sender));
+        RemotingServer = remotingServer; // ?? throw new ArgumentNullException(nameof(remotingServer));
+    }
+
+    private string ClientAddress { get; set; }
+
+    private NullMessage ConnectionMessage { get; set; }
+
+    private IRemotingServer RemotingServer { get; set; }
+
+    private RemotingSession Session { get; set; }
+
+    /// <summary>
+    /// Starts listening to the incoming messages.
+    /// </summary>
+    public override Guid StartListening()
+    {
+        var sessionId = CreateRemotingSession();
+        base.StartListening();
+        return sessionId;
+    }
+
+    /// <summary>
+    /// Creates <see cref="RemotingSession"/> for the incoming websocket connection.
+    /// </summary>
+    private Guid CreateRemotingSession()
+    {
+        byte[] clientPublicKey = null;
+
+        // get encryption metadata from NullMessage
+        //var cookies = WebSocketContext.CookieCollection;
+        //var messageEncryptionCookie = cookies[MessageEncryptionCookie];
+        //if (messageEncryptionCookie?.Value == "1")
+        //{
+        //    var shakeHandsCookie = cookies[ClientPublicKeyCookie];
+        //    clientPublicKey =
+        //        Convert.FromBase64String(
+        //            shakeHandsCookie.Value);
+        //}
+
+        if (RemotingServer != null)
+        {
+            Session = RemotingServer.SessionRepository.CreateSession(
+                clientPublicKey, ClientAddress, RemotingServer, this);
+
+            return Session.SessionId;
+        }
+
+        return Guid.NewGuid();
+    }
+}

--- a/CoreRemoting/Channels/Null/NullServerConnection.cs
+++ b/CoreRemoting/Channels/Null/NullServerConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using CoreRemoting.Channels.Null;
 
 namespace CoreRemoting.Channels.Websocket;
@@ -14,8 +15,10 @@ public class NullServerConnection : NullTransport, IAsyncDisposable
     public NullServerConnection(NullMessage connectionMessage, IRemotingServer remotingServer)
     {
         ConnectionMessage = connectionMessage ?? throw new ArgumentNullException(nameof(connectionMessage));
-        ClientAddress = connectionMessage.Sender ?? throw new ArgumentNullException(nameof(connectionMessage.Sender));
-        RemotingServer = remotingServer; // ?? throw new ArgumentNullException(nameof(remotingServer));
+        ClientAddress = IPAddress.Loopback.ToString(); // connections are always local
+        RemotingServer = remotingServer; // note: server is not required, null is acceptable for the unit tests
+        ThisEndpoint = connectionMessage.Receiver ?? throw new ArgumentNullException(nameof(connectionMessage.Receiver));
+        RemoteEndpoint = connectionMessage.Sender ?? throw new ArgumentNullException(nameof(connectionMessage.Sender));
     }
 
     private string ClientAddress { get; set; }

--- a/CoreRemoting/Channels/Null/NullServerConnection.cs
+++ b/CoreRemoting/Channels/Null/NullServerConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using CoreRemoting.Channels.Null;
 
@@ -47,15 +48,13 @@ public class NullServerConnection : NullTransport, IAsyncDisposable
         byte[] clientPublicKey = null;
 
         // get encryption metadata from NullMessage
-        //var cookies = WebSocketContext.CookieCollection;
-        //var messageEncryptionCookie = cookies[MessageEncryptionCookie];
-        //if (messageEncryptionCookie?.Value == "1")
-        //{
-        //    var shakeHandsCookie = cookies[ClientPublicKeyCookie];
-        //    clientPublicKey =
-        //        Convert.FromBase64String(
-        //            shakeHandsCookie.Value);
-        //}
+        if (ConnectionMessage.Metadata != null &&
+            ConnectionMessage.Metadata.Length == 2 &&
+            ConnectionMessage.Metadata.First() == nameof(RemotingClient.PublicKey))
+        {
+            clientPublicKey = Convert.FromBase64String(
+                ConnectionMessage.Metadata.Last());
+        }
 
         if (RemotingServer != null)
         {

--- a/CoreRemoting/Channels/Null/NullTransport.cs
+++ b/CoreRemoting/Channels/Null/NullTransport.cs
@@ -101,7 +101,9 @@ public class NullTransport : IRawMessageTransport, IAsyncDisposable
         {
             while (IsConnected)
             {
-                await foreach (var message in ReceiveMessagesAsync(null, ThisEndpoint, RemoteEndpoint))
+                await foreach (var message in
+                    ReceiveMessagesAsync(null, RemoteEndpoint, ThisEndpoint)
+                        .ConfigureAwait(false))
                 {
                     OnReceiveMessage(message.Message ?? []);
                 }
@@ -126,7 +128,7 @@ public class NullTransport : IRawMessageTransport, IAsyncDisposable
     {
         try
         {
-            SendMessage(null, ThisEndpoint, RemoteEndpoint, rawMessage);
+            SendMessage(ThisEndpoint, RemoteEndpoint, rawMessage);
             return Task.FromResult(true);
         }
         catch (Exception ex)

--- a/CoreRemoting/Channels/Null/NullTransport.cs
+++ b/CoreRemoting/Channels/Null/NullTransport.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Threading.Tasks;
+using static CoreRemoting.Channels.Null.NullMessageQueue;
+
+namespace CoreRemoting.Channels.Null;
+
+/// <summary>
+/// Simple in-process channel, base transport class.
+/// </summary>
+public class NullTransport : IRawMessageTransport, IAsyncDisposable
+{
+    /// <summary>
+    /// Buffer size to read incoming messages.
+    /// Note: LOH threshold is ~85 kilobytes
+    /// </summary>
+    protected const int BufferSize = 16 * 1024;
+
+    /// <summary>
+    /// This endpoint.
+    /// </summary>
+    public string ThisEndpoint { get; protected set; }
+
+    /// <summary>
+    /// Remote endpoint.
+    /// </summary>
+    public string RemoteEndpoint { get; protected set; }
+
+    /// <inheritdoc />
+    public bool IsConnected { get; protected set; }
+
+    /// <inheritdoc />
+    public NetworkException LastException { get; set; }
+
+    /// <summary>
+    /// Event: fires when the channel is connected.
+    /// </summary>
+    public event Action Connected;
+
+    /// <summary>
+    /// Fires the <see cref="Connected"/> event.
+    /// </summary>
+    protected void OnConnected() =>
+        Connected?.Invoke();
+
+    /// <inheritdoc />
+    public event Action Disconnected;
+
+    /// <summary>
+    /// Fires the <see cref="Disconnected"/> event.
+    /// </summary>
+    protected void OnDisconnected() =>
+        Disconnected?.Invoke();
+
+    /// <inheritdoc />
+    public event Action<byte[]> ReceiveMessage;
+
+    /// <summary>
+    /// Fires the <see cref="ReceiveMessage"/> event.
+    /// </summary>
+    protected void OnReceiveMessage(byte[] message) =>
+        ReceiveMessage?.Invoke(message);
+
+    /// <inheritdoc />
+    public event Action<string, Exception> ErrorOccured;
+
+    /// <summary>
+    /// Fires the <see cref="ErrorOccured"/> event.
+    /// </summary>
+    protected void OnErrorOccured(string message, Exception ex) =>
+        ErrorOccured?.Invoke(message, ex);
+
+    /// <summary>
+    /// Starts listening for the incoming messages.
+    /// </summary>
+    public virtual Guid StartListening()
+    {
+        IsConnected = true;
+        _ = ReadIncomingMessages();
+        return Guid.Empty;
+    }
+
+    /// <inheritdoc/>
+    public virtual ValueTask DisposeAsync() => default;
+
+    /// <summary>
+    /// Disconnects from the remote endpoint.
+    /// </summary>
+    public virtual Task DisconnectAsync()
+    {
+        IsConnected = false;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Reads the incoming websocket messages
+    /// and fires the <see cref="ReceiveMessage"/> event.
+    /// </summary>
+    private async Task ReadIncomingMessages()
+    {
+        try
+        {
+            while (IsConnected)
+            {
+                await foreach (var message in ReceiveMessagesAsync(null, ThisEndpoint, RemoteEndpoint))
+                {
+                    OnReceiveMessage(message.Message ?? []);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            OnErrorOccured(ex.Message, LastException);
+        }
+        finally
+        {
+            await DisconnectAsync()
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SendMessageAsync(byte[] rawMessage)
+    {
+        try
+        {
+            SendMessage(null, ThisEndpoint, RemoteEndpoint, rawMessage);
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            ErrorOccured?.Invoke(ex.Message, LastException);
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreRemoting.Toolbox;
 
 namespace CoreRemoting.Channels.Websocket;
 

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -516,20 +516,23 @@ namespace CoreRemoting
 
         private WireMessage TryDeserialize(byte[] rawMessage)
         {
+            WireMessage getInvalidMessage() => new()
+            {
+                Data = rawMessage,
+                Error = true,
+                Iv = [],
+                MessageType = "invalid",
+                UniqueCallKey = [],
+            };
+
             try
             {
-                return Serializer.Deserialize<WireMessage>(rawMessage);
+                return Serializer.Deserialize<WireMessage>(rawMessage) ??
+                    getInvalidMessage();
             }
             catch // TODO: dispatch message deserialization exception?
             {
-                return new WireMessage
-                {
-                    Data = rawMessage,
-                    Error = true,
-                    Iv = [],
-                    MessageType = "invalid",
-                    UniqueCallKey = [],
-                };
+                return getInvalidMessage();
             }
         }
 


### PR DESCRIPTION
This PR contains a simple in-process channel for unit testing.
It doesn't have any network operations, so it can be used for profiling the RPC stuff.
Also, it can serve as a sample for creating other channels such as UDP, Bluetooth, etc.