### PR TITLE
Processing BeforeDispose safely

### DIFF
--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -851,7 +851,7 @@ namespace CoreRemoting
             {
                 BeforeDispose?.Invoke();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // ignored
                 // TODO: dispatch the exception

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -847,7 +847,15 @@ namespace CoreRemoting
                 // TODO: dispatch the exception
             }
 
-            BeforeDispose?.Invoke();
+            try
+            {
+                BeforeDispose?.Invoke();
+            }
+            catch (Exception e)
+            {
+                // ignored
+                // TODO: dispatch the exception
+            }
 
             _keyPair?.Dispose();
             _delegateProxyFactory = null;


### PR DESCRIPTION
A custom handler can fall with an exception, and this code is called in Dispose, so we make the call safely.