### PR TITLE
Handle non-serializable return values

### DIFF
--- a/CoreRemoting.Tests/Tools/ITestService.cs
+++ b/CoreRemoting.Tests/Tools/ITestService.cs
@@ -45,6 +45,8 @@ public interface ITestService : IBaseService
 
     void NonSerializableError(string text, params object[] data);
 
+    object NonSerializableReturnValue(string text);
+
     DataTable TestDt(DataTable dt, long num);
 
     (T duplicate, int size) Duplicate<T>(T sample) where T : class;

--- a/CoreRemoting.Tests/Tools/TestService.cs
+++ b/CoreRemoting.Tests/Tools/TestService.cs
@@ -120,6 +120,16 @@ public class TestService : ITestService
         throw ex;
     }
 
+    public class NonSerializableObject(string text)
+    {
+        public string Text => throw new Exception(text);
+    }
+
+    public object NonSerializableReturnValue(string text)
+    {
+        return new NonSerializableObject(text);
+    }
+
     public DataTable TestDt(DataTable dt, long num)
     {
         dt.Rows.Clear();


### PR DESCRIPTION
Non-serializable RPC return value should produce a `RemoteInvocationException` explicitly saying that method return value failed to be serialized. Serialization exception should be included as an inner exception.