### PR TITLE
Disconnect RemotingClient after completing the current RPCs

### DIFF
--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -869,11 +869,6 @@ public sealed class RemotingSession : IAsyncDisposable
         _rawMessageTransport.ReceiveMessage -= OnReceiveMessage;
         _rawMessageTransport.ErrorOccured -= OnErrorOccured;
 
-        _currentlyProcessedMessagesCounter.Signal();
-        await _currentlyProcessedMessagesCounter.WaitAsync()
-            .ExpireMs(_server.Config.WaitTimeForCurrentlyProcessedMessagesOnDispose)
-                .ConfigureAwait(false);
-
         var sharedSecret =
             MessageEncryption
                 ? _sessionId.ToByteArray()
@@ -886,6 +881,11 @@ public sealed class RemotingSession : IAsyncDisposable
                 sharedSecret: sharedSecret,
                 keyPair: _keyPair,
                 messageType: "session_closed");
+
+        _currentlyProcessedMessagesCounter.Signal();
+        await _currentlyProcessedMessagesCounter.WaitAsync()
+            .ExpireMs(_server.Config.WaitTimeForCurrentlyProcessedMessagesOnDispose)
+                .ConfigureAwait(false);        
 
         try
         {


### PR DESCRIPTION
RemotingClient does not start new RPCs after receiving session_closed. The server starts counting completed RPCs AFTER sending session_closed. Otherwise, new RPCs will be received from the client while we wait for the RPC to complete or WaitTimeForCurrentlyProcessedMessagesOnDispose to expire. 

For example, WaitTimeForCurrentlyProcessedMessagesOnDispose has a value of 6 seconds, and the client calls RPC almost continuously. It was expected that when the connection is closed, new RPCs do not start, and those that have already started are executed to the end. In fact, the connection was closed only after 6 seconds. That is, new RPCs arrived and the client did not call DisconnectAsync, which would set _isDisconnected = true, which would not start new RPCs. However, the server has already been unsubscribed from _rawMessageTransport.ReceiveMessage and then he wouldn't even start new RPCs, but the client would start new ones.