### PR TITLE
fix for #194 Ignore assembly version for deserialized types

### DIFF
--- a/CoreRemoting/Serialization/Bson/Envelope.cs
+++ b/CoreRemoting/Serialization/Bson/Envelope.cs
@@ -17,6 +17,7 @@ namespace CoreRemoting.Serialization.Bson
         private object _value;
         
         [JsonProperty]
+        [JsonConverter(typeof(TypeIgnoreVersionConverter))]
         private Type _type;
         
         /// <summary>

--- a/CoreRemoting/Serialization/Bson/TypeIgnoreVersionConverter.cs
+++ b/CoreRemoting/Serialization/Bson/TypeIgnoreVersionConverter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace CoreRemoting.Serialization.Bson;
+
+internal class TypeIgnoreVersionConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(Type);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+        JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return null;
+        }
+
+        string typeFullName = reader.Value as string;
+
+        Type resultType = GetTypeWithoutVersion(typeFullName);
+
+        return resultType;
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        writer.WriteValue(((Type)value)?.AssemblyQualifiedName);
+    }
+
+    private Type GetTypeWithoutVersion(string fullTypeName)
+    {
+        var resultType = Type.GetType(fullTypeName);
+
+        if (resultType != null || string.IsNullOrEmpty(fullTypeName)) 
+            return resultType;
+            
+        var commaIndex = fullTypeName.IndexOf(',');
+        if (commaIndex <= 0)
+            return null;
+        string simpleTypeName = fullTypeName.Substring(0, commaIndex).Trim();
+        string assemblyName = new AssemblyName(fullTypeName.Substring(commaIndex + 1).Trim()).Name;
+        resultType = FindTypeInLoadedAssemblies(simpleTypeName, assemblyName);
+
+        return resultType;
+    }
+        
+    private static Type FindTypeInLoadedAssemblies(string typeName, string assemblyName)
+    {
+        return (from assembly in AppDomain.CurrentDomain.GetAssemblies()
+            where assembly.FullName != null && assembly.FullName.Contains(assemblyName)
+            select assembly.GetType(typeName)).FirstOrDefault(foundType => foundType != null);
+    }
+}


### PR DESCRIPTION
The reason was that All objects passed through Remoting were wrapped in an Envelope object
that contained a serializable _type field of type Type. And the Type type is serialized in bson
with the full name of the type "MyAssembly.Utils.Utils.AppType, MyAssembly, Version=3.5.5001.0,....".
During deserialization, the type was searched by its full name and was not in the assembly with a different number.