### PR TITLE
Non-deserializable value should trigger RemoteInvocationException

### DIFF
--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -1562,7 +1562,7 @@ public class RpcTests : IClassFixture<ServerFixture>
         using var client = new RemotingClient(new ClientConfig()
         {
             ConnectionTimeout = 0,
-            InvocationTimeout = 5,
+            InvocationTimeout = 0,
             SendTimeout = 0,
             MessageEncryption = false,
             Channel = ClientChannel,
@@ -1574,9 +1574,10 @@ public class RpcTests : IClassFixture<ServerFixture>
         var proxy = client.CreateProxy<ITestService>();
         try
         {
-            // TODO: it should throw something else
-            Assert.Throws<AggregateException>(() =>
-                proxy.Duplicate(new NonDeserializable(123))); // times out!
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                proxy.Duplicate(new NonDeserializable(123)));
+
+            Assert.Equal(NonDeserializable.ErrorMessage, ex.Message);
         }
         finally
         {

--- a/CoreRemoting.Tests/Tools/NonDeserializable.cs
+++ b/CoreRemoting.Tests/Tools/NonDeserializable.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace CoreRemoting.Tests.Tools
+{
+    [Serializable]
+    public class NonDeserializable
+    {
+        public NonDeserializable(int value) =>
+            Value = value;
+
+        public NonDeserializable() =>
+            Value = Throw();
+
+        public int Value { get; set; }
+
+        private int Throw() =>
+            throw new NotImplementedException();
+    }
+}

--- a/CoreRemoting.Tests/Tools/NonDeserializable.cs
+++ b/CoreRemoting.Tests/Tools/NonDeserializable.cs
@@ -5,6 +5,9 @@ namespace CoreRemoting.Tests.Tools
     [Serializable]
     public class NonDeserializable
     {
+        public const string ErrorMessage =
+            "This value cannot be deserialized";
+
         public NonDeserializable(int value) =>
             Value = value;
 
@@ -14,6 +17,6 @@ namespace CoreRemoting.Tests.Tools
         public int Value { get; set; }
 
         private int Throw() =>
-            throw new NotImplementedException();
+            throw new Exception(ErrorMessage);
     }
 }


### PR DESCRIPTION
Example:

```csharp
public class NonDeserializable
{
    public const string ErrorMessage =
        "This value cannot be deserialized";

    public NonDeserializable(int value) =>
        Value = value;

    public NonDeserializable() =>
        Value = Throw();

    public int Value { get; set; }

    private int Throw() =>
        throw new Exception(ErrorMessage);
}
```

Test:

```csharp
var proxy = client.CreateProxy<ITestService>();

// the next line shouldn't freeze!
var ex = Assert.Throws<RemoteInvocationException>(() =>
  proxy.Duplicate(new NonDeserializable(123)));

Assert.Equal(NonDeserializable.ErrorMessage, ex.Message);
```

See issue #198 for details.