### PR TITLE
Work around DateTimeKind handling in Bson envelopes, close #203.

### DIFF
--- a/CoreRemoting.Tests/BsonSerializationTests.cs
+++ b/CoreRemoting.Tests/BsonSerializationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Numerics;
 using System.Text;
@@ -52,7 +53,7 @@ public class BsonSerializationTests
                 serializer,
                 testServiceInterfaceType.Name,
                 testServiceInterfaceType.GetMethod("TestMethod"),
-                new object[] { 4711});
+                [4711]);
 
         var rawData = serializer.Serialize(message);
         
@@ -98,10 +99,10 @@ public class BsonSerializationTests
     public void BsonSerializerAdapter_should_use_configured_JsonConverters()
     {
         var fakeConverter = new FakeDateTimeConverter();
-        var config = new BsonSerializerConfig(new []
-        {
+        var config = new BsonSerializerConfig(
+        [
             fakeConverter
-        });
+        ]);
 
         var serializerAdapter = new BsonSerializerAdapter(config);
 
@@ -248,6 +249,9 @@ public class BsonSerializationTests
         }
 
         SerializeAndDeserialize(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.FromMinutes(42)));
+        SerializeAndDeserialize(new DateTime(2025, 10, 1, 6, 11, 52, 123, DateTimeKind.Unspecified));
+        SerializeAndDeserialize(new DateTime(2025, 10, 1, 6, 11, 52, 321, DateTimeKind.Local));
+        SerializeAndDeserialize(new DateTime(2025, 10, 1, 6, 11, 52, 321, DateTimeKind.Utc));
         SerializeAndDeserialize(TimeSpan.FromSeconds(42));
         SerializeAndDeserialize(new Uri("http://127.0.0.1"));
         SerializeAndDeserialize(new RegionInfo("US"));

--- a/CoreRemoting/Toolbox/Extensions.cs
+++ b/CoreRemoting/Toolbox/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -90,4 +91,12 @@ public static class Extensions
 
         return typeof(Expression).IsAssignableFrom(type);
     }
+
+    /// <summary>
+    /// Dumps the given byte array as hexadecimal text.
+    /// </summary>
+    /// <param name="bytes">The array to dump.</param>
+    public static string HexDump(this byte[] bytes) => bytes == null ? "" :
+        string.Join("\n", Enumerable.Range(0, (bytes.Length + 15) / 16)
+            .Select(i => string.Join(" ", bytes.Skip(i * 16).Take(16).Select(b => b.ToString("X2")))));
 }


### PR DESCRIPTION
Looks like `Envelope` class breaks `JsonConverter` logic: its `ReadJson` method is never called.*
This PR doesn't fix this issue, it just works around the DateTimeKind loss.
Not sure how it should be fixed properly.