### PR TITLE
Use simple assembly resolving for types, close #194

### DIFF
--- a/CoreRemoting/Serialization/Bson/BsonSerializerAdapter.cs
+++ b/CoreRemoting/Serialization/Bson/BsonSerializerAdapter.cs
@@ -28,7 +28,7 @@ namespace CoreRemoting.Serialization.Bson
             var settings = new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.All,
-                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full,
+                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
                 Formatting = Formatting.Indented,
                 ObjectCreationHandling = ObjectCreationHandling.Auto,
                 FloatFormatHandling = FloatFormatHandling.String,


### PR DESCRIPTION
The previous commit solved the problem of different assembly versions only for Envelope._type, but this change solves it for the parameters and return values of the method.