### PR TITLE
Values in the Hashtable are deserialized as JObject.

### DIFF
--- a/CoreRemoting.Tests/BsonHashtableRpcTests.cs
+++ b/CoreRemoting.Tests/BsonHashtableRpcTests.cs
@@ -66,14 +66,15 @@ namespace CoreRemoting.Tests
         }
     }
 
-    #region Hashtable Deserialization - RPC Roundtrip Test
+    #region Hashtable Deserialization Bug - RPC Roundtrip Test
 
-    public interface ITestService
+    // Переименованные интерфейс и класс, чтобы не конфликтовать с существующими
+    public interface IHashtableEchoService
     {
         Hashtable Echo(Hashtable input);
     }
 
-    public class TestService : ITestService
+    public class HashtableEchoService : IHashtableEchoService
     {
         public Hashtable Echo(Hashtable input)
         {
@@ -107,7 +108,7 @@ namespace CoreRemoting.Tests
                 NetworkPort = 9099,
                 RegisterServicesAction = container =>
                 {
-                    container.RegisterService<ITestService, TestService>(
+                    container.RegisterService<IHashtableEchoService, HashtableEchoService>(
                         lifetime: ServiceLifetime.Singleton);
                 }
             };
@@ -129,7 +130,7 @@ namespace CoreRemoting.Tests
         [Fact]
         public void Hashtable_ShouldSurviveRoundtrip_WithoutBecomingJObject()
         {
-            var proxy = _client.CreateProxy<ITestService>();
+            var proxy = _client.CreateProxy<IHashtableEchoService>();
             var original = new Hashtable
             {
                 { "@param1", "test_value" },

--- a/CoreRemoting.Tests/BsonHashtableRpcTests.cs
+++ b/CoreRemoting.Tests/BsonHashtableRpcTests.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections;
 using CoreRemoting.Serialization.Bson;
 using Xunit;
+using CoreRemoting.DependencyInjection;
+using Newtonsoft.Json.Linq;
 
 namespace CoreRemoting.Tests
 {
@@ -16,26 +19,26 @@ namespace CoreRemoting.Tests
             originalHashtable["NestedHashtable"] = new Hashtable { ["inner"] = "value" };
 
             var serializer = new BsonSerializerAdapter();
-            
+
             // Simulate what happens in RPC: parameter is wrapped in Envelope
             var envelope = new Envelope(originalHashtable);
             var serializedBytes = serializer.Serialize(envelope);
-            
+
             // Deserialize back to Envelope (as in RPC)
             var deserializedEnvelope = serializer.Deserialize<Envelope>(serializedBytes);
             var deserializedHashtable = (Hashtable)deserializedEnvelope.Value;
-            
+
             // Verify all values are correctly deserialized with proper types
             Assert.Equal(originalHashtable.Count, deserializedHashtable.Count);
-            
+
             // Check string value
             Assert.Equal("test value", deserializedHashtable["StringValue"]);
             Assert.True(deserializedHashtable["StringValue"] is string);
-            
+
             // Check integer value
             Assert.Equal(42, deserializedHashtable["IntValue"]);
             Assert.True(deserializedHashtable["IntValue"] is int);
-            
+
             // Check nested hashtable
             var originalNested = (Hashtable)originalHashtable["NestedHashtable"];
             var deserializedNested = (Hashtable)deserializedHashtable["NestedHashtable"];
@@ -62,4 +65,97 @@ namespace CoreRemoting.Tests
             Assert.True(deserializedHashtable["IntValue"] is int);
         }
     }
+
+    #region Hashtable Deserialization - RPC Roundtrip Test
+
+    public interface ITestService
+    {
+        Hashtable Echo(Hashtable input);
+    }
+
+    public class TestService : ITestService
+    {
+        public Hashtable Echo(Hashtable input)
+        {
+            if (input != null)
+            {
+                foreach (DictionaryEntry entry in input)
+                {
+                    if (entry.Value is JObject)
+                    {
+                        throw new InvalidOperationException(
+                            $"BUG REPRODUCED: Parameter '{entry.Key}' deserialized as JObject. " +
+                            $"Original type was lost during deserialization.");
+                    }
+                }
+            }
+
+            return input;
+        }
+    }
+
+    public class HashtableDeserializationBugTest : IDisposable
+    {
+        private readonly RemotingServer _server;
+        private readonly RemotingClient _client;
+
+        public HashtableDeserializationBugTest()
+        {
+            var serverConfig = new ServerConfig
+            {
+                HostName = "localhost",
+                NetworkPort = 9099,
+                RegisterServicesAction = container =>
+                {
+                    container.RegisterService<ITestService, TestService>(
+                        lifetime: ServiceLifetime.Singleton);
+                }
+            };
+
+            _server = new RemotingServer(serverConfig);
+            _server.Start();
+
+            var clientConfig = new ClientConfig
+            {
+                ServerHostName = "localhost",
+                ServerPort = 9099,
+                ConnectionTimeout = 5000
+            };
+
+            _client = new RemotingClient(clientConfig);
+            _client.Connect();
+        }
+
+        [Fact]
+        public void Hashtable_ShouldSurviveRoundtrip_WithoutBecomingJObject()
+        {
+            var proxy = _client.CreateProxy<ITestService>();
+            var original = new Hashtable
+            {
+                { "@param1", "test_value" },
+                { "@param2", 123 },
+                { "@param3", true }
+            };
+
+            var exception = Record.Exception(() =>
+            {
+                var result = proxy.Echo(original);
+
+                foreach (DictionaryEntry entry in result)
+                {
+                    Assert.IsNotType<JObject>(entry.Value);
+                }
+            });
+
+            Assert.Null(exception);
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
+            _server?.Dispose();
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Values in the Hashtable are deserialized as JObject instead of the original types while RPC.