### PR TITLE
Comment an adding HashtableConverter

### DIFF
--- a/CoreRemoting.Tests/BsonHashtableRpcTests.cs
+++ b/CoreRemoting.Tests/BsonHashtableRpcTests.cs
@@ -1,13 +1,25 @@
 using System.Collections;
 using CoreRemoting.Serialization.Bson;
+using CoreRemoting.Serialization.Bson.Converters;
 using Xunit;
 
 namespace CoreRemoting.Tests
 {
     public class BsonHashtableRpcTests
     {
+        private BsonSerializerConfig UseHashtableConverter
+        {
+            get
+            {
+                var config = new BsonSerializerConfig();
+                config.AddCommonJsonConverters = true;
+                config.JsonConverters.Add(new HashtableConverter());
+                return config;
+            }
+        }
+
         [Fact]
-        public void BsonSerializerAdapter_should_handle_Hashtable_with_objects_in_RPC_scenario()
+        public void BsonSerializerAdapter_should_handle_Hashtable_with_objects_in_RPC_scenario_UsingHashtableConverter()
         {
             // Simulate RPC scenario where Hashtable parameters are wrapped in Envelope
             var originalHashtable = new Hashtable();
@@ -15,8 +27,8 @@ namespace CoreRemoting.Tests
             originalHashtable["IntValue"] = 42;
             originalHashtable["NestedHashtable"] = new Hashtable { ["inner"] = "value" };
 
-            var serializer = new BsonSerializerAdapter();
-            
+            var serializer = new BsonSerializerAdapter(UseHashtableConverter);
+
             // Simulate what happens in RPC: parameter is wrapped in Envelope
             var envelope = new Envelope(originalHashtable);
             var serializedBytes = serializer.Serialize(envelope);
@@ -43,14 +55,14 @@ namespace CoreRemoting.Tests
         }
 
         [Fact]
-        public void BsonSerializerAdapter_should_preserve_Hashtable_types_without_Envelope()
+        public void BsonSerializerAdapter_should_preserve_Hashtable_types_without_Envelope_UsingHashtableConverter()
         {
             // Test normal Hashtable serialization (not in RPC scenario)
             var originalHashtable = new Hashtable();
             originalHashtable["StringValue"] = "test value";
             originalHashtable["IntValue"] = 42;
 
-            var serializer = new BsonSerializerAdapter();
+            var serializer = new BsonSerializerAdapter(UseHashtableConverter);
             var serializedBytes = serializer.Serialize(originalHashtable);
             var deserializedHashtable = serializer.Deserialize<Hashtable>(serializedBytes);
 

--- a/CoreRemoting.Tests/BsonSerializationTests.cs
+++ b/CoreRemoting.Tests/BsonSerializationTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using CoreRemoting.RpcMessaging;
 using CoreRemoting.Serialization.Bson;
+using CoreRemoting.Serialization.Bson.Converters;
 using CoreRemoting.Tests.Tools;
 using Newtonsoft.Json;
 using Xunit;
@@ -41,6 +42,17 @@ public class BsonSerializationTests
     }
 
     #endregion
+
+    private BsonSerializerConfig UseHashtableConverter
+    {
+        get
+        {
+            var config = new BsonSerializerConfig();
+            config.AddCommonJsonConverters = true;
+            config.JsonConverters.Add(new HashtableConverter());
+            return config;
+        }
+    }
 
     [Fact]
     public void BsonSerializerAdapter_should_deserialize_MethodCallMessage()
@@ -271,13 +283,13 @@ public class BsonSerializationTests
     }
     
     [Fact]
-    public void BsonSerializerAdapter_should_deserialize_Hashtable_original_content_types()
+    public void BsonSerializerAdapter_should_deserialize_Hashtable_original_content_types_UsingHashtableConverter()
     {
         var originalHashtable = new Hashtable();
         int originalValue = 10;
         originalHashtable["StoredValue"] = originalValue;
         
-        var serializer = new BsonSerializerAdapter();
+        var serializer = new BsonSerializerAdapter(UseHashtableConverter);
         var serializedBytes = serializer.Serialize(originalHashtable);
         var deserializedHastable = serializer.Deserialize<Hashtable>(serializedBytes);
         var deserializedValue = deserializedHastable["StoredValue"];
@@ -318,12 +330,12 @@ public class BsonSerializationTests
     }
     
     [Fact]
-    public void BsonSerializerAdapter_should_deserialize_nested_Hashtables()
+    public void BsonSerializerAdapter_should_deserialize_nested_Hashtables_UsingHashtableConverter()
     {
         var innerHt = new Hashtable { ["value"] = 1 };
         var ht = new Hashtable { ["innerHt"] = innerHt };
         
-        var serializer = new BsonSerializerAdapter();
+        var serializer = new BsonSerializerAdapter(UseHashtableConverter);
         var bytes = serializer.Serialize(ht);
         var desDto = serializer.Deserialize<Hashtable>(bytes);
         
@@ -348,9 +360,9 @@ public class BsonSerializationTests
         Assert.Equal(originalObj.Count, deserializedObj.Count);
     }
     
-    private Hashtable BSONSerializeDeserialize(Hashtable testHashtable)
+    private Hashtable BSONSerializeDeserialize(Hashtable testHashtable, BsonSerializerConfig cfg =  null)
     {
-        var serializer = new BsonSerializerAdapter();
+        var serializer = new BsonSerializerAdapter(cfg);
         var input = serializer.Serialize(testHashtable);
         var output = serializer.Deserialize<Hashtable>(input);
         return output;
@@ -441,13 +453,13 @@ public class BsonSerializationTests
     }
 
     [Fact]
-    public void BsonSerializerAdapter_should_deserialize_Hashtable_NestedHashtableInt()
+    public void BsonSerializerAdapter_should_deserialize_Hashtable_NestedHashtableInt_UsingHashtableConverter()
     {
         var innerHashtable = new Hashtable();
         innerHashtable.Add("key", 42); // int значение
         var outerHashtable = new Hashtable();
         outerHashtable.Add("@innerObject", innerHashtable);
-        Hashtable deserializedOuter = BSONSerializeDeserialize(outerHashtable);
+        Hashtable deserializedOuter = BSONSerializeDeserialize(outerHashtable, UseHashtableConverter);
         Assert.IsType<Hashtable>(deserializedOuter["@innerObject"]);
         var deserializedInner = (Hashtable)deserializedOuter["@innerObject"];
         Assert.Equal(42, deserializedInner["key"]);
@@ -651,24 +663,24 @@ public class BsonSerializationTests
     }
 
     [Fact]
-    public void BsonSerializerAdapter_should_deserialize_Hashtable_NestedHashtableDateTime()
+    public void BsonSerializerAdapter_should_deserialize_Hashtable_NestedHashtableDateTime_UsingHashtableConverter()
     {
         var innerHashtable = new Hashtable();
         innerHashtable.Add("key", new DateTime(2023, 10, 1, 12, 30, 45, 500));
         var outerHashtable = new Hashtable();
         outerHashtable.Add("@innerObject", innerHashtable);
-        Hashtable deserializedOuter = BSONSerializeDeserialize(outerHashtable);
+        Hashtable deserializedOuter = BSONSerializeDeserialize(outerHashtable, UseHashtableConverter);
         Assert.IsType<Hashtable>(deserializedOuter["@innerObject"]);
         var deserializedInner = (Hashtable)deserializedOuter["@innerObject"];
         Assert.Equal(new DateTime(2023, 10, 1, 12, 30, 45, 500), deserializedInner["key"]);
     }
 
     [Fact]
-    public void BsonSerializerAdapter_should_deserialize_Hashtable_TimeSpan()
+    public void BsonSerializerAdapter_should_deserialize_Hashtable_TimeSpan_UsingHashtableConverter()
     {
         var timeSpan = new TimeSpan(0, 5, 0);
         Hashtable dto = new Hashtable { ["TimeSpan"] = timeSpan };
-        var desDto = BSONSerializeDeserialize(dto);
+        var desDto = BSONSerializeDeserialize(dto, UseHashtableConverter);
         Assert.Equal((TimeSpan)dto["TimeSpan"], (TimeSpan)desDto["TimeSpan"]);
     }
     

--- a/CoreRemoting.Tests/NeoBinaryCustomSerializationTests.cs
+++ b/CoreRemoting.Tests/NeoBinaryCustomSerializationTests.cs
@@ -4,6 +4,8 @@ using CoreRemoting.Serialization.NeoBinary;
 using System.Runtime.Serialization;
 using Xunit;
 
+namespace CoreRemoting.Tests.Serialization.NeoBinary;
+
 public class NeoBinaryCustomSerializationTests
 {
 	[Fact]

--- a/CoreRemoting.Tests/NeoBinaryExpressionSerializationTests.cs
+++ b/CoreRemoting.Tests/NeoBinaryExpressionSerializationTests.cs
@@ -3,7 +3,7 @@ using System.Linq.Expressions;
 using CoreRemoting.Serialization.NeoBinary;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests.Serialization.NeoBinary
 {
     public class NeoBinaryExpressionSerializationTests
     {

--- a/CoreRemoting.Tests/NeoBinaryReflectionTypesTests.cs
+++ b/CoreRemoting.Tests/NeoBinaryReflectionTypesTests.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using CoreRemoting.Serialization.NeoBinary;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests.Serialization.NeoBinary
 {
     public class NeoBinaryReflectionTypesTests
     {

--- a/CoreRemoting.Tests/NeoBinarySerializationTests.cs
+++ b/CoreRemoting.Tests/NeoBinarySerializationTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using CoreRemoting.Serialization.NeoBinary;
 using Xunit;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests.Serialization.NeoBinary
 {
 	public class NeoBinarySerializationTests
 	{

--- a/CoreRemoting.Tests/NeoBinaryWebsocketIntegrationTests.cs
+++ b/CoreRemoting.Tests/NeoBinaryWebsocketIntegrationTests.cs
@@ -6,7 +6,7 @@ using CoreRemoting.Tests.Tools;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace CoreRemoting.Tests;
+namespace CoreRemoting.Tests.Serialization.NeoBinary;
 
 /// <summary>
 /// Integrationstests für CoreRemoting mit Websocket-Kanal und NeoBinary-Serialisierung

--- a/CoreRemoting/Serialization/Bson/BsonSerializerAdapter.cs
+++ b/CoreRemoting/Serialization/Bson/BsonSerializerAdapter.cs
@@ -59,7 +59,7 @@ namespace CoreRemoting.Serialization.Bson
                     new IPAddressConverter(),
                     new IPEndPointConverter(),
                     new IsoDateTimeConverter(),
-                    new HashtableConverter()
+                  //  new HashtableConverter()
                 ]);
             }
 


### PR DESCRIPTION
Can you please remove HastableConveter from the adapter settings, as it does solve a lot of problems, but it also causes some serious ones like #224 . That would help us to switch directly to your package. 

P.S. Previously, on revision 1.2.3, the behavior of the hashtable was acceptable and we could adapt to it, but after adding the HastableConveter, we are unable to handle its behavior.

Thank you in advance! 👉👈(ಥ_ಥ)