### PR TITLE
Sync I/O in RemotingSession constructor

### DIFF
--- a/CoreRemoting.Channels.Quic/QuicServerConnection.cs
+++ b/CoreRemoting.Channels.Quic/QuicServerConnection.cs
@@ -54,9 +54,10 @@ public class QuicServerConnection : QuicTransport, IRawMessageTransport
         if (clientPublicKey != null && clientPublicKey.Length == 0)
             clientPublicKey = null;
 
-        Session = RemotingServer.SessionRepository.CreateSession(
+        Session = await RemotingServer.SessionRepository.CreateSession(
             clientPublicKey, Connection.RemoteEndPoint.ToString(),
-                RemotingServer, this);
+                RemotingServer, this)
+                    .ConfigureAwait(false);
 
         return Session.SessionId;
     }

--- a/CoreRemoting.Channels.WebsocketSharp/RpcWebsocketSharpBehavior.cs
+++ b/CoreRemoting.Channels.WebsocketSharp/RpcWebsocketSharpBehavior.cs
@@ -68,7 +68,8 @@ public class RpcWebsocketSharpBehavior : WebSocketBehavior, IRawMessageTransport
                     clientPublicKey,
                     Context.UserEndPoint.ToString(),
                     _server,
-                    this);
+                    this)
+                .GetAwaiter().GetResult();
 
             _session.BeforeDispose += BeforeDisposeSession;
         }

--- a/CoreRemoting/Channels/NamedPipe/SimpleNamedPipe.cs
+++ b/CoreRemoting/Channels/NamedPipe/SimpleNamedPipe.cs
@@ -156,7 +156,8 @@ public class SimpleNamedPipeConnection : IRawMessageTransport, IDisposable
 		{
 			// Create session immediately for NamedPipe connections
 			// This ensures proper session context for scoped services
-			if (!CreateSessionAsNeeded(null))
+			var sessionCreated = await CreateSessionAsNeeded(null).ConfigureAwait(false);
+			if (!sessionCreated)
 			{
 				// Session creation failed, stop processing
 				return;
@@ -254,16 +255,17 @@ public class SimpleNamedPipeConnection : IRawMessageTransport, IDisposable
 		}
 	}
 
-	private bool CreateSessionAsNeeded(Dictionary<string, object> metadata)
+	private async Task<bool> CreateSessionAsNeeded(Dictionary<string, object> metadata)
 	{
 		if (_session != null)
 			return false;
 
-		_session = _server.SessionRepository.CreateSession(
+		_session = await _server.SessionRepository.CreateSession(
 			null,
 			$"NamedPipe:{_connectionId}",
 			_server,
-			this);
+			this)
+			.ConfigureAwait(false);
 
 		_session.BeforeDispose += BeforeDisposeSession;
 

--- a/CoreRemoting/Channels/Null/NullServerChannel.cs
+++ b/CoreRemoting/Channels/Null/NullServerChannel.cs
@@ -80,7 +80,7 @@ public class NullServerChannel : IServerChannel
                 .ConfigureAwait(false))
         {
             var connection = new NullServerConnection(msg, Server);
-            var sessionId = connection.StartListening();
+            var sessionId = await connection.StartListening().ConfigureAwait(false);
             Connections[sessionId] = connection;
         }
     }

--- a/CoreRemoting/Channels/Null/NullServerConnection.cs
+++ b/CoreRemoting/Channels/Null/NullServerConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using CoreRemoting.Channels.Null;
 
 namespace CoreRemoting.Channels.Websocket;
@@ -33,17 +34,17 @@ public class NullServerConnection : NullTransport, IAsyncDisposable
     /// <summary>
     /// Starts listening to the incoming messages.
     /// </summary>
-    public override Guid StartListening()
+    public override async Task<Guid> StartListening()
     {
-        var sessionId = CreateRemotingSession();
-        base.StartListening();
+        var sessionId = await CreateRemotingSession().ConfigureAwait(false);
+        await base.StartListening().ConfigureAwait(false);
         return sessionId;
     }
 
     /// <summary>
     /// Creates <see cref="RemotingSession"/> for the incoming websocket connection.
     /// </summary>
-    private Guid CreateRemotingSession()
+    private async Task<Guid> CreateRemotingSession()
     {
         byte[] clientPublicKey = null;
 
@@ -58,8 +59,9 @@ public class NullServerConnection : NullTransport, IAsyncDisposable
 
         if (RemotingServer != null)
         {
-            Session = RemotingServer.SessionRepository.CreateSession(
-                clientPublicKey, ClientAddress, RemotingServer, this);
+            Session = await RemotingServer.SessionRepository.CreateSession(
+                clientPublicKey, ClientAddress, RemotingServer, this)
+                    .ConfigureAwait(false);
 
             return Session.SessionId;
         }

--- a/CoreRemoting/Channels/Null/NullTransport.cs
+++ b/CoreRemoting/Channels/Null/NullTransport.cs
@@ -72,11 +72,11 @@ public class NullTransport : IRawMessageTransport, IAsyncDisposable
     /// <summary>
     /// Starts listening for the incoming messages.
     /// </summary>
-    public virtual Guid StartListening()
+    public virtual Task<Guid> StartListening()
     {
         IsConnected = true;
         _ = ReadIncomingMessages();
-        return Guid.Empty;
+        return Task.FromResult(Guid.Empty);
     }
 
     /// <inheritdoc/>

--- a/CoreRemoting/Channels/Tcp/TcpConnection.cs
+++ b/CoreRemoting/Channels/Tcp/TcpConnection.cs
@@ -97,7 +97,8 @@ public class TcpConnection : IRawMessageTransport
                 clientPublicKey,
                 _clientMetadata.IpPort,
                 _server,
-                this);
+                this)
+            .GetAwaiter().GetResult();
 
         _session.BeforeDispose += BeforeDisposeSession;
         return true;

--- a/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
+++ b/CoreRemoting/Channels/Websocket/WebSocketTransport.cs
@@ -70,10 +70,10 @@ public abstract class WebsocketTransport : IRawMessageTransport, IAsyncDisposabl
     /// <summary>
     /// Starts listening for the incoming messages.
     /// </summary>
-    public virtual Guid StartListening()
+    public virtual Task<Guid> StartListening()
     {
         _ = ReadIncomingMessages();
-        return Guid.Empty;
+        return Task.FromResult(Guid.Empty);
     }
 
     private AsyncLock ReceiveLock { get; } = new();

--- a/CoreRemoting/Channels/Websocket/WebsocketServerChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketServerChannel.cs
@@ -70,7 +70,9 @@ public class WebsocketServerChannel : IServerChannel
             websocketContext, websocket, Server);
 
         // handle incoming websocket messages
-        var sessionId = connection.StartListening();
+        var sessionId = await connection.StartListening()
+            .ConfigureAwait(false);
+
         Connections[sessionId] = connection;
         connection.Disconnected += async () =>
         {

--- a/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketServerConnection.cs
@@ -34,17 +34,17 @@ public class WebsocketServerConnection : WebsocketTransport, IAsyncDisposable
     /// <summary>
     /// Starts listening to the incoming messages.
     /// </summary>
-    public override Guid StartListening()
+    public override async Task<Guid> StartListening()
     {
-        var sessionId = CreateRemotingSession();
-        base.StartListening();
+        var sessionId = await CreateRemotingSession().ConfigureAwait(false);
+        await base.StartListening().ConfigureAwait(false);
         return sessionId;
     }
 
     /// <summary>
     /// Creates <see cref="RemotingSession"/> for the incoming websocket connection.
     /// </summary>
-    private Guid CreateRemotingSession()
+    private async Task<Guid> CreateRemotingSession()
     {
         byte[] clientPublicKey = null;
 
@@ -58,8 +58,9 @@ public class WebsocketServerConnection : WebsocketTransport, IAsyncDisposable
                     shakeHandsCookie.Value);
         }
 
-        Session = RemotingServer.SessionRepository.CreateSession(
-            clientPublicKey, ClientAddress, RemotingServer, this);
+        Session = await RemotingServer.SessionRepository.CreateSession(
+            clientPublicKey, ClientAddress, RemotingServer, this)
+                .ConfigureAwait(false);
 
         return Session.SessionId;
     }

--- a/CoreRemoting/ISessionRepository.cs
+++ b/CoreRemoting/ISessionRepository.cs
@@ -18,7 +18,7 @@ public interface ISessionRepository : IAsyncDisposable
     /// <param name="server">Server instance</param>
     /// <param name="rawMessageTransport">Component that does the raw message transport</param>
     /// <returns>The newly created session</returns>
-    RemotingSession CreateSession(
+    Task<RemotingSession> CreateSession(
         byte[] clientPublicKey,
         string clientAddress,
         IRemotingServer server,
@@ -29,7 +29,7 @@ public interface ISessionRepository : IAsyncDisposable
     /// </summary>
     /// <param name="sessionId">Session ID</param>
     /// <returns>The session correlating to the specified session ID</returns>
-    RemotingSession GetSession(Guid sessionId);
+    Task<RemotingSession> GetSession(Guid sessionId);
 
     /// <summary>
     /// Gets a list of all sessions.

--- a/CoreRemoting/ISessionRepository.cs
+++ b/CoreRemoting/ISessionRepository.cs
@@ -11,11 +11,6 @@ namespace CoreRemoting;
 public interface ISessionRepository : IAsyncDisposable
 {
     /// <summary>
-    /// Gets the key size for asymmetric encryption. Should be 3072 or better in 2021 ;)
-    /// </summary>
-    int KeySize { get; }
-
-    /// <summary>
     /// Creates a new session.
     /// </summary>
     /// <param name="clientPublicKey">Client's public key</param>

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreRemoting.Authentication;
@@ -130,11 +129,9 @@ public sealed class RemotingSession : IAsyncDisposable
                         $"Handler key: {handlerKey}", ex);
                 }
             };
-
-        SendCompleteHandshakeMessage();
     }
 
-    private void SendCompleteHandshakeMessage()
+    internal async Task SendCompleteHandshakeMessageAsync()
     {
         WireMessage completeHandshakeMessage;
 
@@ -179,9 +176,9 @@ public sealed class RemotingSession : IAsyncDisposable
                 };
         }
 
-        _rawMessageTransport?.SendMessageAsync(
-            _server.Serializer.Serialize(completeHandshakeMessage))
-                .JustWait();
+        await (_rawMessageTransport?.SendMessageAsync(
+            _server.Serializer.Serialize(completeHandshakeMessage)))
+                .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -89,7 +89,7 @@ public sealed class RemotingSession : IAsyncDisposable
         {
             var encryptedSessionId =
                 RsaKeyExchange.EncryptSecret(
-                    keySize: _server.SessionRepository.KeySize,
+                    keySize: keySize,
                     receiversPublicKeyBlob: clientPublicKey,
                     secretToEncrypt: _sessionId.ToByteArray(),
                     sendersPublicKeyBlob: _keyPair.PublicKey);

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -4,17 +4,18 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreRemoting.Authentication;
 using CoreRemoting.Channels;
+using CoreRemoting.DependencyInjection;
 using CoreRemoting.Encryption;
 using CoreRemoting.RemoteDelegates;
 using CoreRemoting.RpcMessaging;
 using CoreRemoting.Serialization;
 using CoreRemoting.Threading;
 using CoreRemoting.Toolbox;
-using CoreRemoting.DependencyInjection;
 using Serialize.Linq.Extensions;
 using Serialize.Linq.Nodes;
 
@@ -31,6 +32,7 @@ public sealed class RemotingSession : IAsyncDisposable
     private readonly IRemotingServer _server;
     private IRawMessageTransport _rawMessageTransport;
     private readonly RsaKeyPair _keyPair;
+    private readonly int _keySize;
     private readonly Guid _sessionId;
     private readonly byte[] _clientPublicKeyBlob;
     private readonly string _clientAddress;
@@ -68,7 +70,8 @@ public sealed class RemotingSession : IAsyncDisposable
         _sessionId = Guid.NewGuid();
         _lastActivityTimestamp = DateTime.Now;
         _isAuthenticated = false;
-        _keyPair = new RsaKeyPair(keySize);
+        _keySize = keySize;
+        _keyPair = new RsaKeyPair(_keySize);
         CreatedOn = DateTime.Now;
         _remoteDelegateInvocationEventAggregator = new RemoteDelegateInvocationEventAggregator();
         _server = server ?? throw new ArgumentNullException(nameof(server));
@@ -82,49 +85,6 @@ public sealed class RemotingSession : IAsyncDisposable
         _rawMessageTransport.ErrorOccured += OnErrorOccured;
 
         MessageEncryption = clientPublicKey != null;
-
-        WireMessage completeHandshakeMessage;
-
-        if (MessageEncryption)
-        {
-            var encryptedSessionId =
-                RsaKeyExchange.EncryptSecret(
-                    keySize: keySize,
-                    receiversPublicKeyBlob: clientPublicKey,
-                    secretToEncrypt: _sessionId.ToByteArray(),
-                    sendersPublicKeyBlob: _keyPair.PublicKey);
-
-            var rawContent = _server.Serializer.Serialize(encryptedSessionId);
-
-            var signedMessageData =
-                new SignedMessageData
-                {
-                    MessageRawData = rawContent,
-                    Signature =
-                        RsaSignature.CreateSignature(
-                            keySize: keySize,
-                            sendersPrivateKeyBlob: _keyPair.PrivateKey,
-                            rawData: rawContent)
-                };
-
-            var rawData = _server.Serializer.Serialize(typeof(SignedMessageData), signedMessageData);
-
-            completeHandshakeMessage =
-                new WireMessage
-                {
-                    MessageType = "complete_handshake",
-                    Data = rawData
-                };
-        }
-        else
-        {
-            completeHandshakeMessage =
-                new WireMessage
-                {
-                    MessageType = "complete_handshake",
-                    Data = _sessionId.ToByteArray()
-                };
-        }
 
         _remoteDelegateInvocationEventAggregator.RemoteDelegateInvocationNeeded +=
             async (_, uniqueCallKey, handlerKey, arguments) =>
@@ -170,6 +130,54 @@ public sealed class RemotingSession : IAsyncDisposable
                         $"Handler key: {handlerKey}", ex);
                 }
             };
+
+        SendCompleteHandshakeMessage();
+    }
+
+    private void SendCompleteHandshakeMessage()
+    {
+        WireMessage completeHandshakeMessage;
+
+        if (MessageEncryption)
+        {
+            var encryptedSessionId =
+                RsaKeyExchange.EncryptSecret(
+                    keySize: _keySize,
+                    receiversPublicKeyBlob: _clientPublicKeyBlob,
+                    secretToEncrypt: _sessionId.ToByteArray(),
+                    sendersPublicKeyBlob: _keyPair.PublicKey);
+
+            var rawContent = _server.Serializer.Serialize(encryptedSessionId);
+
+            var signedMessageData =
+                new SignedMessageData
+                {
+                    MessageRawData = rawContent,
+                    Signature =
+                        RsaSignature.CreateSignature(
+                            keySize: _keySize,
+                            sendersPrivateKeyBlob: _keyPair.PrivateKey,
+                            rawData: rawContent)
+                };
+
+            var rawData = _server.Serializer.Serialize(typeof(SignedMessageData), signedMessageData);
+
+            completeHandshakeMessage =
+                new WireMessage
+                {
+                    MessageType = "complete_handshake",
+                    Data = rawData
+                };
+        }
+        else
+        {
+            completeHandshakeMessage =
+                new WireMessage
+                {
+                    MessageType = "complete_handshake",
+                    Data = _sessionId.ToByteArray()
+                };
+        }
 
         _rawMessageTransport?.SendMessageAsync(
             _server.Serializer.Serialize(completeHandshakeMessage))

--- a/CoreRemoting/SessionRepository.cs
+++ b/CoreRemoting/SessionRepository.cs
@@ -75,7 +75,7 @@ public class SessionRepository : ISessionRepository
     /// <summary>
     /// Gets the key size for asymmetric encryption. Should be 3072 or better in 2021 ;)
     /// </summary>
-    public int KeySize { get; }
+    private int KeySize { get; }
 
     /// <summary>
     /// Creates a new session.

--- a/CoreRemoting/SessionRepository.cs
+++ b/CoreRemoting/SessionRepository.cs
@@ -85,7 +85,7 @@ public class SessionRepository : ISessionRepository
     /// <param name="server">Server instance</param>
     /// <param name="rawMessageTransport">Component that does the raw message transport</param>
     /// <returns>The newly created session</returns>
-    public RemotingSession CreateSession(byte[] clientPublicKey, string clientAddress, IRemotingServer server, IRawMessageTransport rawMessageTransport)
+    public async Task<RemotingSession> CreateSession(byte[] clientPublicKey, string clientAddress, IRemotingServer server, IRawMessageTransport rawMessageTransport)
     {
         if (server == null)
             throw new ArgumentException(nameof(server));
@@ -100,6 +100,9 @@ public class SessionRepository : ISessionRepository
             server,
             rawMessageTransport);
 
+        await session.SendCompleteHandshakeMessageAsync()
+            .ConfigureAwait(false);
+
         _sessions.TryAdd(session.SessionId, session);
 
         return session;
@@ -111,10 +114,10 @@ public class SessionRepository : ISessionRepository
     /// <param name="sessionId">Session ID</param>
     /// <returns>The session correlating to the specified session ID</returns>
     /// <exception cref="KeyNotFoundException">Thrown, if no session with the specified session ID is found</exception>
-    public RemotingSession GetSession(Guid sessionId)
+    public Task<RemotingSession> GetSession(Guid sessionId)
     {
         if (_sessions.TryGetValue(sessionId, out var session))
-            return session;
+            return Task.FromResult(session);
 
         throw new KeyNotFoundException($"Session '{sessionId}' not found.");
     }


### PR DESCRIPTION
There is an issue I forgot to fix in [RemotingSession constructor](https://github.com/theRainbird/CoreRemoting/blob/a5f50bbed0b8f1cada7dac87d035606f66cf3087/CoreRemoting/RemotingSession.cs#L174) when converting [transport channels to async](https://github.com/theRainbird/CoreRemoting/issues/84):

```c#
internal RemotingSession(int keySize, byte[] clientPublicKey, string clientAddress,
    IRemotingServer server, IRawMessageTransport rawMessageTransport)
{
    // ...
    _rawMessageTransport?.SendMessageAsync(
            _server.Serializer.Serialize(completeHandshakeMessage))
                .JustWait();
}
```

Unfortunately, fixing it requires more breaking changes, this time to `ISessionRepository` interface.
Namely, `CreateSession` method should be asynchronous because it sends a handshake message.
So, it's one more argument in favor of releasing a new major version.