### PR TITLE
Separate shared key + authentication code generator

### DIFF
--- a/CoreRemoting.SourceGenerators/AuthenticationAdaptorGenerator.cs
+++ b/CoreRemoting.SourceGenerators/AuthenticationAdaptorGenerator.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CoreRemoting.SourceGenerators;
+
+/// <summary>
+/// Generates a new Authenticate method for classes that implement the legacy
+/// IAuthenticationProvider interface (with out parameter) but lack the new
+/// Task-based method.
+/// </summary>
+[Generator]
+public class AuthenticationAdapterGenerator : IIncrementalGenerator
+{
+    private const string InterfaceName = "CoreRemoting.Authentication.IAuthenticationProvider";
+    private const string MethodName = "Authenticate";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var classDeclarations = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (s, _) => IsClassOrStruct(s),
+                transform: static (ctx, _) => GetTypeInfo(ctx))
+            .Where(static info => info is not null)
+            .Collect();
+
+        context.RegisterSourceOutput(classDeclarations, Execute);
+    }
+
+    private static bool IsClassOrStruct(SyntaxNode node) =>
+        node is ClassDeclarationSyntax or StructDeclarationSyntax;
+
+    private static TypeInfo GetTypeInfo(GeneratorSyntaxContext context)
+    {
+        var declaration = (TypeDeclarationSyntax)context.Node;
+        var model = context.SemanticModel;
+        var typeSymbol = model.GetDeclaredSymbol(declaration);
+        if (typeSymbol is null) return null;
+
+        if (typeSymbol.TypeKind != TypeKind.Class) return null;
+
+        // Get the interface symbol from the compilation
+        var compilation = model.Compilation;
+        var interfaceSymbol = compilation.GetTypeByMetadataName(InterfaceName);
+        if (interfaceSymbol is null) return null;
+
+        // Check if the class implements the interface
+        bool implementsInterface = typeSymbol.AllInterfaces
+            .Any(i => SymbolEqualityComparer.Default.Equals(i, interfaceSymbol));
+        if (!implementsInterface) return null;
+
+        // Find legacy method: bool Authenticate(..., out ...)
+        // We only check the return type, parameter count, and that the last parameter is 'out'
+        var legacyMethod = typeSymbol.GetMembers(MethodName).OfType<IMethodSymbol>()
+            .FirstOrDefault(m =>
+                m.ReturnsVoid == false &&
+                m.ReturnType.SpecialType == SpecialType.System_Boolean &&
+                m.Parameters.Length == 2 &&
+                m.Parameters[1].RefKind == RefKind.Out);
+
+        if (legacyMethod is null) return null;
+
+        // Check if the class already has the new method
+        bool hasNewMethod = typeSymbol.GetMembers(MethodName).OfType<IMethodSymbol>()
+            .Any(m =>
+                m.ReturnsVoid == false &&
+                m.ReturnType is INamedTypeSymbol ret &&
+                ret.Name == "Task" &&
+                ret.TypeArguments.Length == 1 &&
+                ret.TypeArguments[0].Name == "AuthenticationResponseMessage" &&
+                m.Parameters.Length == 1 &&
+                m.Parameters[0].Type.Name == "AuthenticationRequestMessage");
+
+        if (hasNewMethod) return null;
+
+        // Require the class to be partial
+        if (!declaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+            return null;
+
+        return new TypeInfo(typeSymbol, declaration);
+    }
+
+    private static void Execute(SourceProductionContext context, ImmutableArray<TypeInfo> typeInfos)
+    {
+        // Diagnostics to see how many classes were found
+        context.ReportDiagnostic(Diagnostic.Create(
+            new DiagnosticDescriptor("AD001", "Debug", $"Found {typeInfos.Length} classes requiring adapter", "Debug", DiagnosticSeverity.Info, true),
+            Location.None));
+
+        foreach (var info in typeInfos)
+        {
+            string source = GenerateSource(info.TypeSymbol);
+            string rawName = info.TypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ".AuthenticationAdapter.g.cs";
+            string fileName = GeneratorHelpers.SanitizeFileName(rawName);
+            context.AddSource(fileName, source);
+        }
+    }
+
+    private static string GenerateSource(INamedTypeSymbol typeSymbol)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Threading.Tasks;");
+        sb.AppendLine("using CoreRemoting.Authentication;");
+        sb.AppendLine();
+
+        var ns = typeSymbol.ContainingNamespace.ToDisplayString();
+        if (!string.IsNullOrEmpty(ns))
+        {
+            sb.AppendLine($"namespace {ns}");
+            sb.AppendLine("{");
+        }
+
+        // Nested types
+        var containingTypes = new List<INamedTypeSymbol>();
+        var current = typeSymbol.ContainingType;
+        while (current != null)
+        {
+            containingTypes.Insert(0, current);
+            current = current.ContainingType;
+        }
+
+        foreach (var outer in containingTypes)
+        {
+            sb.AppendLine($"partial class {outer.Name}");
+            sb.AppendLine("{");
+        }
+
+        sb.AppendLine($"partial class {typeSymbol.Name}");
+        sb.AppendLine("{");
+        sb.AppendLine($"    [global::System.CodeDom.Compiler.GeneratedCode(\"{nameof(AuthenticationAdapterGenerator)}\", \"1.0.0.0\")]");
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Adapter method that calls the legacy Authenticate method.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"request\">Authentication request.</param>");
+        sb.AppendLine("    /// <returns>Authentication response.</returns>");
+        sb.AppendLine($"    public Task<AuthenticationResponseMessage> {MethodName}(AuthenticationRequestMessage request)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        var isAuthenticated = Authenticate(request.Credentials, out var identity);");
+        sb.AppendLine("        return Task.FromResult(new AuthenticationResponseMessage");
+        sb.AppendLine("        {");
+        sb.AppendLine("            IsAuthenticated = isAuthenticated,");
+        sb.AppendLine("            AuthenticatedIdentity = identity");
+        sb.AppendLine("        });");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        // Close outer types
+        foreach (var _ in containingTypes)
+        {
+            sb.AppendLine("}");
+        }
+
+        if (!string.IsNullOrEmpty(ns))
+            sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private record TypeInfo(INamedTypeSymbol TypeSymbol, TypeDeclarationSyntax Declaration);
+}

--- a/CoreRemoting.SourceGenerators/CoreRemoting.SourceGenerators.csproj
+++ b/CoreRemoting.SourceGenerators/CoreRemoting.SourceGenerators.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <PackageVersion>1.2.2</PackageVersion>
+    <Authors>Alexey Yakovlev</Authors>
+    <Description>Source generators for CoreRemoting</Description>
+    <Copyright>2026 Alexey Yakovlev</Copyright>
+    <PackageProjectUrl>https://github.com/theRainbird/CoreRemoting</PackageProjectUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="AuthenticationProviderPolyfillGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="AuthenticationProviderPolyfillGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/CoreRemoting.SourceGenerators/CoreRemoting.SourceGenerators.csproj
+++ b/CoreRemoting.SourceGenerators/CoreRemoting.SourceGenerators.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="AuthenticationProviderPolyfillGenerator.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>

--- a/CoreRemoting.SourceGenerators/GeneratorHelpers.cs
+++ b/CoreRemoting.SourceGenerators/GeneratorHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System.Text;
+
+namespace CoreRemoting.SourceGenerators;
+
+public static class GeneratorHelpers
+{
+    public static string SanitizeFileName(string name)
+    {
+        if (name.StartsWith("global::"))
+            name = name.Substring(8);
+
+        var sb = new StringBuilder(name.Length);
+        foreach (char c in name)
+        {
+            if (char.IsLetterOrDigit(c) || c == '.' || c == '_')
+                sb.Append(c);
+            else
+                sb.Append('_');
+        }
+        return sb.ToString();
+    }
+}

--- a/CoreRemoting.SourceGenerators/IsExternalInitPolyfill.cs
+++ b/CoreRemoting.SourceGenerators/IsExternalInitPolyfill.cs
@@ -1,0 +1,5 @@
+﻿namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}

--- a/CoreRemoting.SourceGenerators/NotImplementedMembersGenerator.cs
+++ b/CoreRemoting.SourceGenerators/NotImplementedMembersGenerator.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CoreRemoting.SourceGenerators;
+
+/// <summary>
+/// Implements missing interface members for classes
+/// marked with NotImplementedAttribute.
+/// </summary>
+[Generator]
+public class NotImplementedMembersGenerator : IIncrementalGenerator
+{
+    private static readonly SymbolDisplayFormat InterfaceNameFormat =
+        new SymbolDisplayFormat(
+            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var classInfos = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (s, _) => IsClassWithAttribute(s),
+                transform: static (ctx, _) => GetClassInfo(ctx))
+            .Where(static info => info is not null)
+            .Collect();
+
+        context.RegisterSourceOutput(classInfos, Execute);
+    }
+
+    private static bool IsClassWithAttribute(SyntaxNode node) =>
+        node is ClassDeclarationSyntax { AttributeLists.Count: > 0 };
+
+    private static ClassInfo GetClassInfo(GeneratorSyntaxContext context)
+    {
+        var classDecl = (ClassDeclarationSyntax)context.Node;
+        var model = context.SemanticModel;
+        var classSymbol = model.GetDeclaredSymbol(classDecl);
+        if (classSymbol is null) return null;
+
+        bool hasAttr = classSymbol.GetAttributes().Any(attr =>
+            attr.AttributeClass?.Name is "NotImplementedAttribute" or "NotImplemented");
+
+        if (!hasAttr) return null;
+
+        var allInterfaces = classSymbol.AllInterfaces;
+        if (allInterfaces.IsEmpty) return null;
+
+        var missingMethods = new List<IMethodSymbol>();
+        var missingProperties = new List<IPropertySymbol>();
+        var missingEvents = new List<IEventSymbol>();
+
+        foreach (var interfaceSymbol in allInterfaces)
+        {
+            foreach (var member in interfaceSymbol.GetMembers())
+            {
+                if (member.IsImplicitlyDeclared) continue;
+
+                var impl = classSymbol.FindImplementationForInterfaceMember(member);
+                if (impl == null)
+                {
+                    switch (member)
+                    {
+                        case IMethodSymbol m when m.MethodKind == MethodKind.Ordinary:
+                            missingMethods.Add(m);
+                            break;
+                        case IPropertySymbol p:
+                            missingProperties.Add(p);
+                            break;
+                        case IEventSymbol e:
+                            missingEvents.Add(e);
+                            break;
+                    }
+                }
+            }
+        }
+
+        if (missingMethods.Count == 0 && missingProperties.Count == 0 && missingEvents.Count == 0)
+            return null;
+
+        return new ClassInfo(classSymbol, classDecl, missingMethods, missingProperties, missingEvents);
+    }
+
+    private static void Execute(SourceProductionContext context, ImmutableArray<ClassInfo> classInfos)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(
+            new DiagnosticDescriptor("NG001", "Debug", $"Found {classInfos.Length} classes with [NotImplemented] and missing members", "Debug", DiagnosticSeverity.Info, true),
+            Location.None));
+
+        if (classInfos.Length == 0)
+        {
+            context.AddSource("NoClassesFound.g.cs", "// No classes with [NotImplemented] and missing members found.");
+            return;
+        }
+
+        foreach (var info in classInfos)
+        {
+            string source = GenerateSource(info);
+            string rawName = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ".NotImplemented.g.cs";
+            string fileName = SanitizeFileName(rawName);
+            context.AddSource(fileName, source);
+        }
+    }
+
+    private static string GenerateSource(ClassInfo info)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("using System;");
+        sb.AppendLine("using CoreRemoting.Toolbox;");
+        sb.AppendLine();
+
+        var ns = info.ClassSymbol.ContainingNamespace.ToDisplayString();
+        if (!string.IsNullOrEmpty(ns))
+        {
+            sb.AppendLine($"namespace {ns}");
+            sb.AppendLine("{");
+        }
+
+        var containingTypes = new List<INamedTypeSymbol>();
+        var current = info.ClassSymbol.ContainingType;
+        while (current != null)
+        {
+            containingTypes.Insert(0, current);
+            current = current.ContainingType;
+        }
+
+        foreach (var outer in containingTypes)
+        {
+            sb.AppendLine($"partial class {outer.Name}");
+            sb.AppendLine("{");
+        }
+
+        sb.AppendLine($"partial class {info.ClassSymbol.Name}");
+        sb.AppendLine("{");
+
+        foreach (var method in info.MissingMethods)
+        {
+            GenerateMethod(sb, method);
+            sb.AppendLine();
+        }
+
+        foreach (var prop in info.MissingProperties)
+        {
+            GenerateProperty(sb, prop);
+            sb.AppendLine();
+        }
+
+        foreach (var ev in info.MissingEvents)
+        {
+            GenerateEvent(sb, ev);
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("}"); // close target class
+
+        foreach (var _ in containingTypes)
+        {
+            sb.AppendLine("}");
+        }
+
+        if (!string.IsNullOrEmpty(ns))
+            sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private static void GenerateMethod(StringBuilder sb, IMethodSymbol method)
+    {
+        string interfaceName = method.ContainingType.ToDisplayString(InterfaceNameFormat);
+        string methodName = method.Name;
+        string typeParams = method.TypeParameters.Any() ? $"<{string.Join(", ", method.TypeParameters.Select(t => t.Name))}>" : "";
+        string returnType = method.ReturnsVoid ? "void" : method.ReturnType.ToDisplayString();
+
+        var paramStrings = method.Parameters.Select(p =>
+        {
+            string mod = p.RefKind switch
+            {
+                RefKind.Ref => "ref ",
+                RefKind.Out => "out ",
+                RefKind.In => "in ",
+                _ => ""
+            };
+            string type = p.Type.ToDisplayString();
+            string name = p.Name;
+            return $"{mod}{type} {name}";
+        });
+
+        string paramList = string.Join(", ", paramStrings);
+
+        sb.AppendLine("    [NotImplemented]");
+        sb.AppendLine($"    {returnType} {interfaceName}.{methodName}{typeParams}({paramList})");
+        sb.AppendLine("    {");
+        sb.AppendLine("        throw new NotImplementedException();");
+        sb.AppendLine("    }");
+    }
+
+    private static void GenerateProperty(StringBuilder sb, IPropertySymbol prop)
+    {
+        string interfaceName = prop.ContainingType.ToDisplayString(InterfaceNameFormat);
+        string propName = prop.Name;
+        bool isIndexer = prop.IsIndexer;
+        string accessor = isIndexer ? "this" : propName;
+
+        string parameters = "";
+        if (isIndexer)
+        {
+            var paramStrings = prop.Parameters.Select(p =>
+            {
+                string mod = p.RefKind switch
+                {
+                    RefKind.Ref => "ref ",
+                    RefKind.Out => "out ",
+                    RefKind.In => "in ",
+                    _ => ""
+                };
+                return $"{mod}{p.Type.ToDisplayString()} {p.Name}";
+            });
+            parameters = $"[{string.Join(", ", paramStrings)}]";
+        }
+
+        sb.AppendLine("    [NotImplemented]");
+        sb.AppendLine($"    {prop.Type.ToDisplayString()} {interfaceName}.{accessor}{parameters}");
+        sb.AppendLine("    {");
+        if (prop.GetMethod != null)
+            sb.AppendLine($"        get {{ throw new NotImplementedException(); }}");
+        if (prop.SetMethod != null)
+            sb.AppendLine($"        set {{ throw new NotImplementedException(); }}");
+        sb.AppendLine("    }");
+    }
+
+    private static void GenerateEvent(StringBuilder sb, IEventSymbol ev)
+    {
+        string interfaceName = ev.ContainingType.ToDisplayString(InterfaceNameFormat);
+        string eventName = ev.Name;
+
+        sb.AppendLine("    [NotImplemented]");
+        sb.AppendLine($"    event {ev.Type.ToDisplayString()} {interfaceName}.{eventName}");
+        sb.AppendLine("    {");
+        sb.AppendLine($"        add {{ throw new NotImplementedException(); }}");
+        sb.AppendLine($"        remove {{ throw new NotImplementedException(); }}");
+        sb.AppendLine("    }");
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        if (name.StartsWith("global::"))
+        {
+            name = name.Substring(8);
+        }
+
+        var sb = new StringBuilder(name.Length);
+        foreach (char c in name)
+        {
+            if (char.IsLetterOrDigit(c) || c == '.' || c == '_')
+                sb.Append(c);
+            else
+                sb.Append('_');
+        }
+
+        return sb.ToString();
+    }
+
+    private record ClassInfo(
+        INamedTypeSymbol ClassSymbol,
+        ClassDeclarationSyntax ClassDeclaration,
+        List<IMethodSymbol> MissingMethods,
+        List<IPropertySymbol> MissingProperties,
+        List<IEventSymbol> MissingEvents);
+}

--- a/CoreRemoting.SourceGenerators/NotImplementedMembersGenerator.cs
+++ b/CoreRemoting.SourceGenerators/NotImplementedMembersGenerator.cs
@@ -102,7 +102,7 @@ public class NotImplementedMembersGenerator : IIncrementalGenerator
         {
             string source = GenerateSource(info);
             string rawName = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ".NotImplemented.g.cs";
-            string fileName = SanitizeFileName(rawName);
+            string fileName = GeneratorHelpers.SanitizeFileName(rawName);
             context.AddSource(fileName, source);
         }
     }
@@ -245,25 +245,6 @@ public class NotImplementedMembersGenerator : IIncrementalGenerator
         sb.AppendLine($"        add {{ throw new NotImplementedException(); }}");
         sb.AppendLine($"        remove {{ throw new NotImplementedException(); }}");
         sb.AppendLine("    }");
-    }
-
-    private static string SanitizeFileName(string name)
-    {
-        if (name.StartsWith("global::"))
-        {
-            name = name.Substring(8);
-        }
-
-        var sb = new StringBuilder(name.Length);
-        foreach (char c in name)
-        {
-            if (char.IsLetterOrDigit(c) || c == '.' || c == '_')
-                sb.Append(c);
-            else
-                sb.Append('_');
-        }
-
-        return sb.ToString();
     }
 
     private record ClassInfo(

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -62,6 +62,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\CoreRemoting.SourceGenerators\CoreRemoting.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Compile Remove="DicTests_DryIoc.cs" />
       <Compile Include="DicTests_DryIoc.cs">
         <DependentUpon>DicTests.cs</DependentUpon>

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1502,8 +1503,23 @@ public class RpcTests : IClassFixture<ServerFixture>
         }
     }
 
-    [Fact(Skip = "This scenario is not supported anymore because client.Connect would throw if authentication is required")]
-    public void BeginCall_event_handler_can_bypass_authentication_for_chosen_method()
+    private class FreezingAuthenticator : IAuthenticator
+    {
+        private TaskCompletionSource Freezing { get; } = new();
+
+        public TaskCompletionSource Connected { get; } = new();
+
+        public Task Authenticate(Credential[] credentials, IAuthenticationProvider authProxy)
+        {
+            // now we know we're connected, but not yet authenticated
+            Connected.TrySetResult();
+            return Freezing.Task;
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait(false) in test method", Justification = "Required by ValidationSyncContext")]
+    public async Task BeginCall_event_handler_can_bypass_authentication_for_chosen_method_but_then_authentication_times_out_anyway()
     {
         void BypassAuthorizationForEcho(object sender, ServerRpcContext e) =>
             e.AuthenticationRequired =
@@ -1515,19 +1531,24 @@ public class RpcTests : IClassFixture<ServerFixture>
 
         try
         {
+            var dirtyHack = new FreezingAuthenticator();
             using var client = new RemotingClient(new ClientConfig()
             {
+                AuthenticationTimeout = 2,
                 ConnectionTimeout = 0,
                 InvocationTimeout = 0,
                 SendTimeout = 0,
                 Channel = ClientChannel,
                 MessageEncryption = false,
                 ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Authenticator = dirtyHack,
             });
 
-            // not sure can we establish unauthenticated connection
-            // even if the server says it's required?
-            client.Connect();
+            // note: this scenario is actually not supported
+            // we cannot establish unauthenticated connection
+            // if the server says it's required (unless we use this hack)
+            var connectTask = client.ConnectAsync();
+            await dirtyHack.Connected.Task.ConfigureAwait(false);
 
             // try allowed method "Echo"
             var proxy = client.CreateProxy<ITestService>();
@@ -1535,7 +1556,12 @@ public class RpcTests : IClassFixture<ServerFixture>
 
             // try disallowed method "Reverse"
             var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Reverse("This method is not allowed"));
-            Assert.Contains("auth", ex.Message);
+            Assert.Contains("auth", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+            // connection timeout
+            var sx = await Assert.ThrowsAsync<SecurityException>(() => connectTask);
+            Assert.Contains("auth", sx.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("timeout", sx.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -1579,6 +1605,7 @@ public class RpcTests : IClassFixture<ServerFixture>
             client.Disconnect();
 
             // enable optional authentication
+            Assert.False(_serverFixture.Server.Config.AuthenticationRequired);
             _serverFixture.Server.Config.AuthenticationProvider = new FakeAuthProvider
             {
                 AuthenticateFake = c => c.First().Name.StartsWith("foo")

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -2,18 +2,19 @@ using System;
 using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreRemoting.Authentication;
 using CoreRemoting.Channels;
+using CoreRemoting.Channels.NamedPipe;
 using CoreRemoting.RemoteDelegates;
 using CoreRemoting.Serialization;
 using CoreRemoting.Tests.ExternalTypes;
 using CoreRemoting.Tests.Tools;
 using CoreRemoting.Threading;
 using CoreRemoting.Toolbox;
-using CoreRemoting.Channels.NamedPipe;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,1632 +23,1676 @@ namespace CoreRemoting.Tests;
 [Collection("CoreRemoting")]
 public class RpcTests : IClassFixture<ServerFixture>
 {
-	protected readonly ServerFixture _serverFixture;
-	protected readonly ITestOutputHelper _testOutputHelper;
-	protected bool _remoteServiceCalled;
-
-	protected virtual IServerChannel ServerChannel => null;
-
-	protected virtual IClientChannel ClientChannel => null;
-
-	public RpcTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
-	{
-		_serverFixture = serverFixture;
-		_testOutputHelper = testOutputHelper;
-
-		// Allow derived test classes to tweak server configuration before server start
-		ConfigureServer(_serverFixture.ServerConfig);
-
-		_serverFixture.TestService.TestMethodFake = arg =>
-		{
-			_remoteServiceCalled = true;
-			return arg;
-		};
-
-		_serverFixture.Start(ServerChannel);
-
-		// setup event handler invoker
-		EventStub.DelegateInvoker = DelegateInvoker;
-	}
-
-	/// <summary>
-	/// Gives derived tests a chance to configure the server before it starts.
-	/// </summary>
-	/// <param name="config">Server configuration object that will be used to create the server.</param>
-	protected virtual void ConfigureServer(ServerConfig config)
-	{
-	}
-
-	/// <summary>
-	/// Gets the delegate invoker to be used for event handler tests.
-	/// </summary>
-	protected virtual IDelegateInvoker DelegateInvoker => new SafeDynamicInvoker();
-
-	[Fact]
-	public void ValidationSyncContext_is_installed()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		Assert.IsType<ValidationSyncContext>(SynchronizationContext.Current);
-	}
-
-	private void CheckServerErrorCount()
-	{
-		try
-		{
-			Assert.Equal(0, _serverFixture.ServerErrorCount);
-		}
-		finally
-		{
-			if (_serverFixture.ServerErrorCount != 0)
-			{
-				Console.WriteLine($"LastServerError: {_serverFixture.LastServerError}");
-			}
-		}
-	}
-
-	[Fact]
-	public void Call_on_Proxy_should_be_invoked_on_remote_service()
-	{
-		void ClientAction()
-		{
-			using var ctx = ValidationSyncContext.Install();
-
-			try
-			{
-				var stopWatch = new Stopwatch();
-				stopWatch.Start();
-
-				using var client = new RemotingClient(new ClientConfig()
-				{
-					ConnectionTimeout = 0,
-					MessageEncryption = false,
-					Channel = ClientChannel,
-					ServerPort = _serverFixture.Server.Config.NetworkPort,
-				});
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				client.Connect();
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				var proxy = client.CreateProxy<ITestService>();
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				var result = proxy.TestMethod("test");
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				var result2 = proxy.TestMethod("test");
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-
-				Assert.Equal("test", result);
-				Assert.Equal("test", result2);
-
-				proxy.MethodWithOutParameter(out int methodCallCount);
-
-				Assert.Equal(1, methodCallCount);
-			}
-			catch (Exception e)
-			{
-				_testOutputHelper.WriteLine(e.ToString());
-				throw;
-			}
-		}
-
-		var clientThread = new Thread(ClientAction);
-		clientThread.Start();
-		clientThread.Join();
-
-		Assert.True(_remoteServiceCalled);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public virtual void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
-	{
-		_serverFixture.Server.Config.MessageEncryption = true;
-		// Use a smaller RSA key size for tests to avoid very slow key generation on some platforms
-		var oldKeySize = _serverFixture.Server.Config.KeySize;
-		_serverFixture.Server.Config.KeySize = 1024;
-
-		void ClientAction()
-		{
-			using var ctx = ValidationSyncContext.Install();
-
-			try
-			{
-				var stopWatch = new Stopwatch();
-				stopWatch.Start();
-
-				using var client = new RemotingClient(new ClientConfig()
-				{
-					ConnectionTimeout = 0,
-					Channel = ClientChannel,
-					ServerPort = _serverFixture.Server.Config.NetworkPort,
-					MessageEncryption = true,
-					KeySize = 1024,
-				});
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				client.Connect();
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				var proxy = client.CreateProxy<ITestService>();
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				var result = proxy.TestMethod("test");
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-				stopWatch.Reset();
-				stopWatch.Start();
-
-				var result2 = proxy.TestMethod("test");
-
-				stopWatch.Stop();
-				_testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
-
-				Assert.Equal("test", result);
-				Assert.Equal("test", result2);
-			}
-			catch (Exception e)
-			{
-				_testOutputHelper.WriteLine(e.ToString());
-				throw;
-			}
-			finally
-			{
-				// restore server key size for other tests
-				_serverFixture.Server.Config.KeySize = oldKeySize;
-			}
-		}
-
-		var clientThread = new Thread(ClientAction);
-		clientThread.Start();
-		clientThread.Join();
-
-		_serverFixture.Server.Config.MessageEncryption = false;
-
-		Assert.True(_remoteServiceCalled);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public async Task Delegate_invoked_on_server_should_callback_client()
-	{
-		string argumentFromServer = null;
-		var serverCalled = new TaskCompletionSource<bool>();
-
-		void ClientAction()
-		{
-			using var ctx = ValidationSyncContext.Install();
-
-			try
-			{
-				using var client = new RemotingClient(
-					new ClientConfig()
-					{
-						ConnectionTimeout = 0,
-						Channel = ClientChannel,
-						MessageEncryption = false,
-						ServerPort = _serverFixture.Server.Config.NetworkPort,
-					});
-
-				client.Connect();
-
-				var proxy = client.CreateProxy<ITestService>();
-				proxy.TestMethodWithDelegateArg(arg =>
-				{
-					argumentFromServer = arg;
-					serverCalled.TrySetResult(true);
-				});
-			}
-			catch (Exception e)
-			{
-				_testOutputHelper.WriteLine(e.ToString());
-				throw;
-			}
-		}
-
-		var clientThread = new Thread(ClientAction);
-		clientThread.Start();
-		clientThread.Join();
-
-		await serverCalled.Task.Timeout(1);
-		Assert.Equal("test", argumentFromServer);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public async Task Call_on_Proxy_should_be_executed_asynchronously()
-	{
-		var longRunnigMethodStarted = new AsyncCounter();
-
-		void BeforeCall(object sender, ServerRpcContext e)
-		{
-			if (e.MethodCallMessage.MethodName == "LongRunnigTestMethod")
-				longRunnigMethodStarted++;
-		}
-
-		try
-		{
-			_serverFixture.Server.BeforeCall += BeforeCall;
-			using var client = new RemotingClient(
-				new ClientConfig()
-				{
-					ConnectionTimeout = 0,
-					Channel = ClientChannel,
-					MessageEncryption = false,
-					ServerPort = _serverFixture.Server.Config.NetworkPort,
-				});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			var longRun = Task.Run(() => proxy.LongRunnigTestMethod(2000));
-
-			// wait until long-running test method is started on server
-			await longRunnigMethodStarted.WaitForValue(1).Timeout(2);
-
-			// try running another RPC call in parallel
-			proxy.TestMethod("x");
-
-			// if a client is disposed before LongRunningTestMethod rpc result is received,
-			// _serverFixture gets its error counter incremented which breaks other tests
-			await longRun;
-		}
-		catch (Exception e)
-		{
-			_testOutputHelper.WriteLine(e.ToString());
-			throw;
-		}
-		finally
-		{
-			_serverFixture.Server.BeforeCall -= BeforeCall;
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Theory]
-	[InlineData("TestService_Singleton_Service")]
-	[InlineData("TestService_Singleton_Factory")]
-	[InlineData("TestService_SingleCall_Service")]
-	[InlineData("TestService_SingleCall_Factory")]
-	[InlineData("TestService_Scoped_Service")]
-	[InlineData("TestService_Scoped_Factory")]
-	public void Component_lifetime_matches_the_expectation(string serviceName)
-	{
-		using var ctx = ValidationSyncContext.Install();
-		using var client = new RemotingClient(
-			new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<ITestService>(serviceName);
-
-		// check if service lifetime matches the expectations
-		proxy.SaveLastInstance();
-
-		// singleton component should have the same instance
-		var sameInstance = serviceName.Contains("Singleton");
-		Assert.Equal(sameInstance, proxy.CheckLastSavedInstance());
-	}
-
-	[Theory]
-	[InlineData("TestService_Singleton_Service")]
-	[InlineData("TestService_Singleton_Factory")]
-	[InlineData("TestService_SingleCall_Service")]
-	[InlineData("TestService_SingleCall_Factory")]
-	[InlineData("TestService_Scoped_Service")]
-	[InlineData("TestService_Scoped_Factory")]
-	public virtual void Events_should_work_remotely(string serviceName)
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		var serviceEventCallCount = 0;
-		var customDelegateEventCallCount = 0;
-
-		using var client = new RemotingClient(
-			new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<ITestService>(serviceName);
-
-		var serviceEventResetEvent = new ManualResetEventSlim(initialState: false);
-		var customDelegateEventResetEvent = new ManualResetEventSlim(initialState: false);
-
-		proxy.ServiceEvent += () =>
-		{
-			Interlocked.Increment(ref serviceEventCallCount);
-			serviceEventResetEvent.Set();
-		};
-
-		proxy.CustomDelegateEvent += _ =>
-		{
-			Interlocked.Increment(ref customDelegateEventCallCount);
-			customDelegateEventResetEvent.Set();
-		};
-
-		proxy.FireServiceEvent();
-		proxy.FireCustomDelegateEvent();
-
-		serviceEventResetEvent.Wait(1000);
-		customDelegateEventResetEvent.Wait(1000);
-
-		Assert.Equal(1, serviceEventCallCount);
-		Assert.Equal(1, customDelegateEventCallCount);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void External_types_should_work_as_remote_service_parameters()
-	{
-		// Reset server error state to ensure this test only verifies errors produced within its own scope.
-		// Other tests in the shared collection may increment ServerErrorCount on the shared ServerFixture instance.
-		_serverFixture.ServerErrorCount = 0;
-		_serverFixture.LastServerError = null;
-
-		DataClass parameterValue = null;
-
-		_serverFixture.TestService.TestExternalTypeParameterFake = arg =>
-		{
-			_remoteServiceCalled = true;
-			parameterValue = arg;
-		};
-
-		void ClientAction()
-		{
-			using var ctx = ValidationSyncContext.Install();
-
-			try
-			{
-				using var client = new RemotingClient(new ClientConfig()
-				{
-					ConnectionTimeout = 0,
-					Channel = ClientChannel,
-					MessageEncryption = false,
-					ServerPort = _serverFixture.Server.Config.NetworkPort,
-				});
-
-				client.Connect();
-
-				var proxy = client.CreateProxy<ITestService>();
-				proxy.TestExternalTypeParameter(new DataClass() { Value = 42 });
-
-				Assert.Equal(42, parameterValue.Value);
-			}
-			catch (Exception e)
-			{
-				_testOutputHelper.WriteLine(e.ToString());
-				throw;
-			}
-		}
-
-		var clientThread = new Thread(ClientAction);
-		clientThread.Start();
-		clientThread.Join();
-
-		Assert.True(_remoteServiceCalled);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Generic_methods_should_be_called_correctly()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-		var proxy = client.CreateProxy<IGenericEchoService>();
-
-		var result = proxy.Echo("Yay");
-
-		Assert.Equal("Yay", result);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Inherited_methods_should_be_called_correctly()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-		var proxy = client.CreateProxy<ITestService>();
-
-		var result = proxy.BaseMethod();
-
-		Assert.True(result);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Enum_arguments_should_be_passed_correctly()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort
-		});
-
-		client.Connect();
-		var proxy = client.CreateProxy<IEnumTestService>();
-
-		var resultFirst = proxy.Echo(TestEnum.First);
-		var resultSecond = proxy.Echo(TestEnum.Second);
-
-		Assert.Equal(TestEnum.First, resultFirst);
-		Assert.Equal(TestEnum.Second, resultSecond);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Missing_method_throws_RemoteInvocationException()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort
-		});
-
-		// simulate MissingMethodException
-		var mb = new CustomMessageBuilder
-		{
-			ProcessMethodCallMessage = m =>
-			{
-				if (m.MethodName == "TestMethod")
-				{
-					m.MethodName = "Missing Method";
-				}
-			}
-		};
-
-		client.MethodCallMessageBuilder = mb;
-		client.Connect();
-
-		var proxy = client.CreateProxy<ITestService>();
-		var ex = Assert.Throws<RemoteInvocationException>(() => proxy.TestMethod(null));
-
-		// a localized message similar to "Method 'Missing method' not found"
-		Assert.NotNull(ex);
-		Assert.Contains("Missing Method", ex.Message);
-
-		_testOutputHelper.WriteLine(_serverFixture.LastServerError.ToString());
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Missing_service_throws_RemoteInvocationException()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort
-		});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<IDisposable>();
-		var ex = Assert.Throws<RemoteInvocationException>(proxy.Dispose);
-
-		// a localized message similar to "Service 'System.IDisposable' is not registered"
-		Assert.NotNull(ex);
-		Assert.Contains("IDisposable", ex.Message);
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Error_method_throws_Exception()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 5,
-				InvocationTimeout = 5,
-				SendTimeout = 5,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			var ex = Assert.Throws<RemoteInvocationException>(() =>
-					proxy.Error(nameof(Error_method_throws_Exception)))
-				.GetInnermostException();
-
-			Assert.NotNull(ex);
-			Assert.Equal(nameof(Error_method_throws_Exception), ex.Message);
-		}
-		finally
-		{
-			// reset the error counter for other tests
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Fact]
-	[SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-	public async Task ErrorAsync_method_throws_Exception()
-	{
-		// using var ctx = ValidationSyncContext.Install(); // fails?
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 5,
-				InvocationTimeout = 5,
-				SendTimeout = 5,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			var ex = (await Assert.ThrowsAsync<RemoteInvocationException>(async () =>
-				{
-					await proxy.ErrorAsync(nameof(ErrorAsync_method_throws_Exception)).ConfigureAwait(false);
-				})
-				.ConfigureAwait(false)).GetInnermostException();
-
-			Assert.NotNull(ex);
-			Assert.Equal(nameof(ErrorAsync_method_throws_Exception), ex.Message);
-		}
-		finally
-		{
-			// reset the error counter for other tests
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Fact]
-	public void NonSerializableError_method_throws_Exception()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 5,
-				InvocationTimeout = 5,
-				SendTimeout = 5,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-
-			var ex = Assert.Throws<RemoteInvocationException>(() =>
-					proxy.NonSerializableError("Hello", "Serializable", "World"))
-				.GetInnermostException();
-
-			Assert.NotNull(ex);
-			Assert.IsType<SerializableException>(ex);
-
-			if (ex is SerializableException sx)
-			{
-				Assert.Equal("NonSerializable", sx.SourceTypeName);
-				Assert.Equal("Hello", ex.Message);
-
-				// Extract values from Data dictionary, handling JObject-wrapped values from BSON serialization
-				string ExtractDataValue(object value) =>
-					value is Newtonsoft.Json.Linq.JObject jObj ? jObj["V"]?.ToString() : value?.ToString();
-
-				Assert.Equal("Serializable", ExtractDataValue(ex.Data["Serializable"]));
-				Assert.Equal("World", ExtractDataValue(ex.Data["World"]));
-				Assert.NotNull(ex.StackTrace);
-			}
-		}
-		finally
-		{
-			// reset the error counter for other tests
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Fact]
-	public void Nonserializable_method_return_value_throws_Exception()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 5,
-				InvocationTimeout = 5,
-				SendTimeout = 5,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			var ex = Assert.Throws<RemoteInvocationException>(() =>
-				proxy.NonSerializableReturnValue("Hello"));
-
-			Assert.NotNull(ex);
-			Assert.Contains("Failed to serialize method return value", ex.Message);
-			Assert.NotNull(ex.InnerException);
-		}
-		finally
-		{
-			// reset the error counter for other tests
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Fact]
-	public void AfterCall_event_handler_can_translate_exceptions_to_improve_diagnostics()
-	{
-		// replace cryptic database error report with a user-friendly error message
-		void AfterCall(object sender, ServerRpcContext ctx)
-		{
-			var errorMsg = ctx.Exception?.InnerException?.Message ?? ctx.Exception?.Message ?? string.Empty;
-			if (errorMsg.StartsWith("23503:"))
-				ctx.Exception = new Exception("Deleting clients is not allowed.",
-					ctx.Exception);
-		}
-
-		using var ctx = ValidationSyncContext.Install();
-		_serverFixture.Server.AfterCall += AfterCall;
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 5,
-				InvocationTimeout = 5,
-				SendTimeout = 5,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort
-			});
-
-			client.Connect();
-
-			var dbError = "23503: delete from table 'clients' violates " +
-			              "foreign key constraint 'order_client_fk' on table 'orders'";
-
-			// simulate a database error on the server-side
-			var proxy = client.CreateProxy<ITestService>();
-			var ex = Assert.Throws<Exception>(() => proxy.Error(dbError));
-
-			Assert.NotNull(ex);
-			Assert.Equal("Deleting clients is not allowed.", ex.Message);
-			Assert.NotNull(ex.InnerException);
-			Assert.IsType<RemoteInvocationException>(ex.InnerException);
-			Assert.Equal(dbError, ex.InnerException.InnerException.Message);
-		}
-		finally
-		{
-			// reset the error counter for other tests
-			_serverFixture.ServerErrorCount = 0;
-			_serverFixture.Server.AfterCall -= AfterCall;
-		}
-	}
-
-	[Fact]
-	public void Failing_component_constructor_throws_RemoteInvocationException()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 3,
-			InvocationTimeout = 3,
-			SendTimeout = 3,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<IFailingService>();
-		var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Hello());
-
-		Assert.NotNull(ex);
-		Assert.Contains("FailingService", ex.Message);
-	}
-
-	[Fact]
-	[SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
-	public async Task Disposed_client_subscription_doesnt_break_other_clients()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		async Task Roundtrip(bool encryption)
-		{
-			var oldEncryption = _serverFixture.Server.Config.MessageEncryption;
-			_serverFixture.Server.Config.MessageEncryption = encryption;
-
-			try
-			{
-				RemotingClient CreateClient() => new RemotingClient(new ClientConfig()
-				{
-					Channel = ClientChannel,
-					ServerPort = _serverFixture.Server.Config.NetworkPort,
-					MessageEncryption = encryption,
-					ConnectionTimeout = encryption ? 0 : 5,
-					KeySize = 1024
-				});
-
-				using var client1 = CreateClient();
-				using var client2 = CreateClient();
-
-				client1.Connect();
-				client2.Connect();
-
-				var proxy1 = client1.CreateProxy<ITestService>();
-				var fired1 = new TaskCompletionSource<bool>();
-				proxy1.ServiceEvent += () => fired1.TrySetResult(true);
-
-				var proxy2 = client2.CreateProxy<ITestService>();
-				var fired2 = new TaskCompletionSource<bool>();
-				proxy2.ServiceEvent += () => fired2.TrySetResult(true);
-
-				// early disposal, proxy1 subscription isn't canceled
-				client1.Disconnect();
-
-				proxy2.FireServiceEvent();
-				Assert.True(await fired2.Task.ConfigureAwait(false));
-				Assert.True(fired2.Task.IsCompleted);
-				Assert.False(fired1.Task.IsCompleted);
-			}
-			finally
-			{
-				_serverFixture.Server.Config.MessageEncryption = oldEncryption;
-
-				// reset the error counter for other tests
-				_serverFixture.ServerErrorCount = 0;
-			}
-		}
-
-		// works!
-		await Roundtrip(encryption: false).ConfigureAwait(false);
-
-		// For NamedPipe channel, skip encrypted roundtrip due to known hanging issue
-		var isNamedPipe = ClientChannel is NamedPipeClientChannel || ServerChannel is NamedPipeServerChannel;
-		if (!isNamedPipe)
-		{
-			// encrypted roundtrip validated for other channels
-			await Roundtrip(encryption: true).ConfigureAwait(false);
-		}
-	}
-
-	[Fact]
-	public void DataTable_roundtrip_works_issue60()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-		var proxy = client.CreateProxy<ITestService>();
-
-		var dt = new DataTable();
-		dt.TableName = "Issue60";
-		dt.Columns.Add("CODE");
-		dt.Rows.Add(dt.NewRow());
-		dt.AcceptChanges();
-
-		var dt2 = proxy.TestDt(dt, 1);
-		Assert.NotNull(dt2);
-	}
-
-	[Fact]
-	[SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "<Pending>")]
-	public virtual void Large_messages_are_sent_and_received()
-	{
-		// max payload size, in bytes
-		var maxSize = 2 * 1024 * 1024 + 1;
-
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-		var proxy = client.CreateProxy<ITestService>();
-
-		// shouldn't throw exceptions
-		Roundtrip("Payload", maxSize);
-		Roundtrip(new byte[] { 1, 2, 3, 4, 5 }, maxSize);
-		Roundtrip(new int[] { 12345, 67890 }, maxSize);
-
-		void Roundtrip<T>(T payload, int maxSize) where T : class
-		{
-			var lastSize = 0;
-			try
-			{
-				while (true)
-				{
-					// a -> aa -> aaaa ...
-					var (dup, size) = proxy.Duplicate(payload);
-					if (size >= maxSize)
-						break;
-
-					// save the size for error reporting
-					lastSize = size;
-					payload = dup;
-				}
-			}
-			catch (Exception ex)
-			{
-				throw new InvalidOperationException($"Failed to handle " +
-				                                    $"payload larger than {lastSize}: {ex.Message}", ex);
-			}
-		}
-	}
-
-	[Fact]
-	[SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "Not applicable")]
-	public async Task BeforeCall_and_AfterCall_events_are_triggered_on_success()
-	{
-		var beforeCallFired = new AsyncCounter();
-
-		void BeforeCall(object sender, ServerRpcContext e) =>
-			beforeCallFired++;
-
-		var afterCallFired = new AsyncCounter();
-
-		void AfterCall(object sender, ServerRpcContext e) =>
-			afterCallFired++;
-
-		using var ctx = ValidationSyncContext.Install();
-		_serverFixture.Server.BeforeCall += BeforeCall;
-		_serverFixture.Server.AfterCall += AfterCall;
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-			client.Connect();
-
-			// test one-way method
-			var proxy = client.CreateProxy<ITestService>();
-			proxy.OneWayMethod();
-
-			// test normal method
-			Assert.Equal("Hello", proxy.Echo("Hello"));
-
-			await beforeCallFired[2].Timeout(1).ConfigureAwait(false);
-			await afterCallFired[2].Timeout(1).ConfigureAwait(false);
-		}
-		finally
-		{
-			_serverFixture.Server.AfterCall -= AfterCall;
-			_serverFixture.Server.BeforeCall -= BeforeCall;
-		}
-	}
-
-	[Fact]
-	[SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "Not applicable")]
-	public async Task BeforeCall_and_AfterCall_events_are_triggered_on_failures()
-	{
-		var beforeCallFired = new AsyncCounter();
-
-		void BeforeCall(object sender, ServerRpcContext e) =>
-			beforeCallFired++;
-
-		var afterCallFired = new AsyncCounter();
-
-		void AfterCall(object sender, ServerRpcContext e) =>
-			afterCallFired++;
-
-		using var ctx = ValidationSyncContext.Install();
-		_serverFixture.Server.BeforeCall += BeforeCall;
-		_serverFixture.Server.AfterCall += AfterCall;
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-			client.Connect();
-
-			// test failing method
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Throws<RemoteInvocationException>(() => proxy.Error("Bang"));
-
-			await beforeCallFired[1].Timeout(1).ConfigureAwait(false);
-			await afterCallFired[1].Timeout(1).ConfigureAwait(false);
-		}
-		finally
-		{
-			_serverFixture.Server.AfterCall -= AfterCall;
-			_serverFixture.Server.BeforeCall -= BeforeCall;
-		}
-	}
-
-	[Fact]
-	public void BeginCall_event_handler_can_intercept_and_cancel_method_calls()
-	{
-		var counter = 0;
-
-		void InterceptMethodCalls(object sender, ServerRpcContext e)
-		{
-			Interlocked.Increment(ref counter);
-
-			// swap Echo and Reverse methods
-			e.MethodCallMessage.MethodName = e.MethodCallMessage.MethodName switch
-			{
-				"Echo" => "Reverse",
-				"Reverse" => "Echo",
-				var others => others
-			};
-
-			// disable IHobbitService
-			if (e.MethodCallMessage.ServiceName.Contains("IHobbitService"))
-			{
-				e.Cancel = true;
-			}
-		}
-
-		using var ctx = ValidationSyncContext.Install();
-		_serverFixture.Server.BeginCall += InterceptMethodCalls;
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-			client.Connect();
-
-			// try swapped methods
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Equal("321", proxy.Echo("123"));
-			Assert.Equal("Hello", proxy.Reverse("Hello"));
-
-			// try disabled service
-			var hobbit = client.CreateProxy<IHobbitService>();
-			Assert.Throws<RemoteInvocationException>(() =>
-				hobbit.QueryHobbits(h => h.LastName != ""));
-
-			// check interception counter
-			Assert.Equal(3, counter);
-		}
-		finally
-		{
-			_serverFixture.Server.BeginCall -= InterceptMethodCalls;
-		}
-	}
-
-	[Fact]
-	public void Authentication_is_taken_into_account_and_RejectCall_event_is_fired()
-	{
-		var rejectedMethod = string.Empty;
-
-		void RejectCall(object sender, ServerRpcContext e) =>
-			rejectedMethod = e.MethodCallMessage.MethodName;
-
-		var server = _serverFixture.Server;
-		server.RejectCall += RejectCall;
-		server.Config.AuthenticationRequired = true;
-
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<IFailingService>();
-			var ex = Assert.Throws<RemoteInvocationException>(proxy.Hello);
-
-			// Session is not authenticated
-			Assert.Contains("authenticated", ex.Message);
-
-			// Method call was rejected
-			Assert.Equal("Hello", rejectedMethod);
-		}
-		finally
-		{
-			server.Config.AuthenticationRequired = false;
-			server.RejectCall -= RejectCall;
-		}
-	}
-
-	[Fact]
-	public void Authentication_handler_has_access_to_the_current_session()
-	{
-		var server = _serverFixture.Server;
-		var authProvider = server.Config.AuthenticationProvider;
-		server.Config.AuthenticationRequired = true;
-		server.Config.AuthenticationProvider = new FakeAuthProvider
-		{
-			AuthenticateFake = c => RemotingSession.Current != null
-		};
-
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-				Credentials = [new()],
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Equal("123", proxy.Reverse("321"));
-		}
-		finally
-		{
-			server.Config.AuthenticationProvider = authProvider;
-			server.Config.AuthenticationRequired = false;
-		}
-	}
-
-	[Fact]
-	public void Broken_auhentication_handler_doesnt_break_the_server()
-	{
-		var server = _serverFixture.Server;
-		var authProvider = server.Config.AuthenticationProvider;
-		server.Config.AuthenticationRequired = true;
-		server.Config.AuthenticationProvider = new FakeAuthProvider
-		{
-			AuthenticateFake = c => throw new Exception("Broken")
-		};
-
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 3,
-				InvocationTimeout = 3,
-				SendTimeout = 3,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-				Credentials = [new()],
-			});
-
-			var ex = Assert.Throws<SecurityException>(client.Connect);
-
-			Assert.Contains("auth", ex.Message.ToLower());
-			Assert.Contains("failed", ex.Message);
-		}
-		finally
-		{
-			server.Config.AuthenticationProvider = authProvider;
-			server.Config.AuthenticationRequired = false;
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Fact]
-	public virtual void Authentication_handler_can_check_client_address()
-	{
-		var server = _serverFixture.Server;
-		var authProvider = server.Config.AuthenticationProvider;
-		server.Config.AuthenticationRequired = true;
-		server.Config.AuthenticationProvider = new FakeAuthProvider
-		{
-			AuthenticateFake = c =>
-			{
-				var address = RemotingSession.Current?.ClientAddress ??
-				              throw new ArgumentNullException("ClientAddress");
-
-				// allow only localhost connections
-				return address.Contains("127.0.0.1") || // ipv4
-				       address.Contains("[::1]"); // ipv6
-			}
-		};
-
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-				Credentials = [new Credential()],
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Equal("123", proxy.Reverse("321"));
-		}
-		finally
-		{
-			server.Config.AuthenticationProvider = authProvider;
-			server.Config.AuthenticationRequired = false;
-		}
-	}
-
-	[Fact]
-	public virtual void Authentication_can_fail_then_succeed()
-	{
-		var server = _serverFixture.Server;
-		var authProvider = server.Config.AuthenticationProvider;
-		server.Config.AuthenticationRequired = true;
-		server.Config.AuthenticationProvider = new FakeAuthProvider
-		{
-			AuthenticateFake = c => c.Length == 2
-		};
-
-		using var ctx = ValidationSyncContext.Install();
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-				Credentials = [new()],
-			});
-
-			Assert.Throws<SecurityException>(client.Connect);
-
-			client.Config.Credentials = [new(), new()];
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Equal("123", proxy.Reverse("321"));
-		}
-		finally
-		{
-			server.Config.AuthenticationProvider = authProvider;
-			server.Config.AuthenticationRequired = false;
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
-
-	[Fact]
-	public void RemotingClient_can_disconnect_and_connect_again()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		var clientConfig = new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			MessageEncryption = false,
-			Channel = ClientChannel,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		};
-
-		// NamedPipe requires a connection name; provide the server's configured name
-		if (ClientChannel is NamedPipeClientChannel || ServerChannel is NamedPipeServerChannel)
-		{
-			clientConfig.ChannelConnectionName = _serverFixture.Server.Config.ChannelConnectionName ?? "CoreRemoting";
-		}
-
-		var isNamedPipe = ClientChannel is NamedPipeClientChannel || ServerChannel is NamedPipeServerChannel;
-
-		if (isNamedPipe)
-		{
-			// NamedPipe: run a simple connect/disconnect once due to known reconnect instability
-			using var client = new RemotingClient(clientConfig);
-			client.Connect();
-			var proxy = client.CreateProxy<ISessionAwareService>();
-			Assert.NotNull(proxy.ClientAddress);
-			client.Disconnect();
-			return;
-		}
-
-		using (var client = new RemotingClient(clientConfig))
-		{
-			client.Connect();
-			var proxy = client.CreateProxy<ISessionAwareService>();
-			Assert.NotNull(proxy.ClientAddress);
-			client.Disconnect();
-			client.Connect();
-			proxy = client.CreateProxy<ISessionAwareService>();
-			Assert.NotNull(proxy.ClientAddress);
-		}
-	}
-
-	[Fact]
-	public void ServerComponent_can_track_client_network_address()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			MessageEncryption = false,
-			Channel = ClientChannel,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<ISessionAwareService>();
-
-		// what's my address as seen by remote server?
-		Assert.NotNull(proxy.ClientAddress);
-	}
-
-	[Fact]
-	public void Scoped_service_is_resolved_within_the_remote_call_scope()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			MessageEncryption = false,
-			Channel = ClientChannel,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<IServiceWithDeps>();
-		var guid = proxy.ScopedServiceInstanceId;
-
-		// empty Guid means that ServiceWithDeps has got different ScopedService instances
-		// but it should get the same scoped service instances across the whore resolution graph
-		Assert.NotEqual(Guid.Empty, guid);
-
-		// every remote call should produce a new ScopedService instance
-		Assert.NotEqual(guid, proxy.ScopedServiceInstanceId);
-		Assert.NotEqual(proxy.ScopedServiceInstanceId, proxy.ScopedServiceInstanceId);
-	}
-
-	[Fact]
-	[SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "Not applicable")]
-	public async Task Logon_and_logoff_events_are_triggered()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		void CheckSession(string operation)
-		{
-			var rs = RemotingSession.Current;
-			Assert.NotNull(rs);
-			Assert.True(rs?.IsAuthenticated);
-			Assert.NotNull(rs?.ClientAddress);
-			Assert.NotNull(rs?.Identity);
-			Console.WriteLine($"Client {rs.Identity.Name} from {rs.ClientAddress} is {operation}");
-		}
-
-		var logon = new AsyncCounter();
-
-		void Logon(object sender, EventArgs _)
-		{
-			logon++;
-			CheckSession("logged on");
-		}
-
-		var logoff = new AsyncCounter();
-
-		void Logoff(object sender, EventArgs _)
-		{
-			logoff++;
-			CheckSession("logged off");
-		}
-
-		var server = _serverFixture.Server;
-		var authProvider = server.Config.AuthenticationProvider;
-		server.Config.AuthenticationProvider = new FakeAuthProvider();
-
-		server.Logon += Logon;
-		server.Logoff += Logoff;
-		server.Config.AuthenticationRequired = true;
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				Credentials = [new()],
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-			client.Connect();
-
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Equal("Hello", proxy.Echo("Hello"));
-
-			client.Disconnect();
-
-			await logon[1].Timeout(1).ConfigureAwait(false);
-			await logoff[1].Timeout(1).ConfigureAwait(false);
-		}
-		finally
-		{
-			server.Config.AuthenticationProvider = authProvider;
-			server.Config.AuthenticationRequired = false;
-			server.Logoff -= Logoff;
-			server.Logon -= Logon;
-		}
-	}
-
-	[Fact]
-	public void BeginCall_event_handler_can_bypass_authentication_for_chosen_method()
-	{
-		void BypassAuthorizationForEcho(object sender, ServerRpcContext e) =>
-			e.AuthenticationRequired =
-				e.MethodCallMessage.MethodName != "Echo";
-
-		using var ctx = ValidationSyncContext.Install();
-		_serverFixture.Server.Config.AuthenticationRequired = true;
-		_serverFixture.Server.BeginCall += BypassAuthorizationForEcho;
-
-		try
-		{
-			using var client = new RemotingClient(new ClientConfig()
-			{
-				ConnectionTimeout = 0,
-				InvocationTimeout = 0,
-				SendTimeout = 0,
-				Channel = ClientChannel,
-				MessageEncryption = false,
-				ServerPort = _serverFixture.Server.Config.NetworkPort,
-			});
-
-			client.Connect();
-
-			// try allowed method "Echo"
-			var proxy = client.CreateProxy<ITestService>();
-			Assert.Equal("This method is allowed", proxy.Echo("This method is allowed"));
-
-			// try disallowed method "Reverse"
-			var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Reverse("This method is not allowed"));
-			Assert.Contains("auth", ex.Message);
-		}
-		finally
-		{
-			_serverFixture.Server.BeginCall -= BypassAuthorizationForEcho;
-			_serverFixture.Server.Config.AuthenticationRequired = false;
-		}
-	}
-
-	[Fact]
-	public void CreateProxy_methods_should_produce_equivalent_results()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-
-		var proxy1 = client.CreateProxy<IGenericEchoService>();
-		var result1 = proxy1.Echo("Yay");
-		Assert.Equal("Yay", result1);
-
-		var proxy2 = client.CreateProxy(typeof(IGenericEchoService)) as IGenericEchoService;
-		var result2 = proxy2.Echo("Yay");
-		Assert.Equal("Yay", result2);
-
-		var svcref = new ServiceReference(typeof(IGenericEchoService).AssemblyQualifiedName, "");
-		var proxy3 = client.CreateProxy(svcref) as IGenericEchoService;
-		var result3 = proxy3.Echo("Yay");
-		Assert.Equal("Yay", result3);
-
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void Custom_proxy_builder_can_be_used_for_interception()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			Channel = ClientChannel,
-			MessageEncryption = false,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-			ProxyBuilder = new CustomProxyBuilder(),
-		});
-
-		client.Connect();
-
-		var proxy1 = client.CreateProxy<IGenericEchoService>();
-		Assert.Equal("[Yay]", proxy1.Echo("Yay"));
-		Assert.Equal(1, proxy1.Echo(1));
-
-		var proxy2 = client.CreateProxy(typeof(IGenericEchoService)) as IGenericEchoService;
-		Assert.Equal("[Yay]", proxy2.Echo("Yay"));
-		Assert.Equal(1, proxy2.Echo(1));
-
-		var svcref = new ServiceReference(typeof(IGenericEchoService).AssemblyQualifiedName, "");
-		var proxy3 = client.CreateProxy(svcref) as IGenericEchoService;
-		Assert.Equal("[Yay]", proxy3.Echo("Yay"));
-		Assert.Equal(1, proxy3.Echo(1));
-
-		CheckServerErrorCount();
-	}
-
-	[Fact]
-	public void NonDeserializableObject_TriggersException()
-	{
-		using var ctx = ValidationSyncContext.Install();
-
-		using var client = new RemotingClient(new ClientConfig()
-		{
-			ConnectionTimeout = 0,
-			InvocationTimeout = 0,
-			SendTimeout = 0,
-			MessageEncryption = false,
-			Channel = ClientChannel,
-			ServerPort = _serverFixture.Server.Config.NetworkPort,
-		});
-
-		client.Connect();
-
-		var proxy = client.CreateProxy<ITestService>();
-		try
-		{
-			var ex = Assert.Throws<RemoteInvocationException>(() =>
-				proxy.Duplicate(new NonDeserializable(123)));
-
-			Assert.Contains(NonDeserializable.ErrorMessage, ex.Message);
-		}
-		finally
-		{
-			_serverFixture.ServerErrorCount = 0;
-		}
-	}
+    protected readonly ServerFixture _serverFixture;
+    protected readonly ITestOutputHelper _testOutputHelper;
+    protected bool _remoteServiceCalled;
+
+    protected virtual IServerChannel ServerChannel => null;
+
+    protected virtual IClientChannel ClientChannel => null;
+
+    public RpcTests(ServerFixture serverFixture, ITestOutputHelper testOutputHelper)
+    {
+        _serverFixture = serverFixture;
+        _testOutputHelper = testOutputHelper;
+
+        // Allow derived test classes to tweak server configuration before server start
+        ConfigureServer(_serverFixture.ServerConfig);
+
+        _serverFixture.TestService.TestMethodFake = arg =>
+        {
+            _remoteServiceCalled = true;
+            return arg;
+        };
+
+        _serverFixture.Start(ServerChannel);
+
+        // setup event handler invoker
+        EventStub.DelegateInvoker = DelegateInvoker;
+    }
+
+    /// <summary>
+    /// Gives derived tests a chance to configure the server before it starts.
+    /// </summary>
+    /// <param name="config">Server configuration object that will be used to create the server.</param>
+    protected virtual void ConfigureServer(ServerConfig config)
+    {
+    }
+
+    /// <summary>
+    /// Gets the delegate invoker to be used for event handler tests.
+    /// </summary>
+    protected virtual IDelegateInvoker DelegateInvoker => new SafeDynamicInvoker();
+
+    [Fact]
+    public void ValidationSyncContext_is_installed()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        Assert.IsType<ValidationSyncContext>(SynchronizationContext.Current);
+    }
+
+    private void CheckServerErrorCount()
+    {
+        try
+        {
+            Assert.Equal(0, _serverFixture.ServerErrorCount);
+        }
+        finally
+        {
+            if (_serverFixture.ServerErrorCount != 0)
+            {
+                Console.WriteLine($"LastServerError: {_serverFixture.LastServerError}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Call_on_Proxy_should_be_invoked_on_remote_service()
+    {
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
+
+                using var client = new RemotingClient(new ClientConfig()
+                {
+                    ConnectionTimeout = 0,
+                    MessageEncryption = false,
+                    Channel = ClientChannel,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                });
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                client.Connect();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var proxy = client.CreateProxy<ITestService>();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result2 = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+
+                Assert.Equal("test", result);
+                Assert.Equal("test", result2);
+
+                proxy.MethodWithOutParameter(out int methodCallCount);
+
+                Assert.Equal(1, methodCallCount);
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        Assert.True(_remoteServiceCalled);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public virtual void Call_on_Proxy_should_be_invoked_on_remote_service_with_MessageEncryption()
+    {
+        _serverFixture.Server.Config.MessageEncryption = true;
+        // Use a smaller RSA key size for tests to avoid very slow key generation on some platforms
+        var oldKeySize = _serverFixture.Server.Config.KeySize;
+        _serverFixture.Server.Config.KeySize = 1024;
+
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
+
+                using var client = new RemotingClient(new ClientConfig()
+                {
+                    ConnectionTimeout = 0,
+                    Channel = ClientChannel,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                    MessageEncryption = true,
+                    KeySize = 1024,
+                });
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating client took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                client.Connect();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Establishing connection took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var proxy = client.CreateProxy<ITestService>();
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Creating proxy took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+                stopWatch.Reset();
+                stopWatch.Start();
+
+                var result2 = proxy.TestMethod("test");
+
+                stopWatch.Stop();
+                _testOutputHelper.WriteLine($"Second remote method invocation took {stopWatch.ElapsedMilliseconds} ms");
+
+                Assert.Equal("test", result);
+                Assert.Equal("test", result2);
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+            finally
+            {
+                // restore server key size for other tests
+                _serverFixture.Server.Config.KeySize = oldKeySize;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        _serverFixture.Server.Config.MessageEncryption = false;
+
+        Assert.True(_remoteServiceCalled);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public async Task Delegate_invoked_on_server_should_callback_client()
+    {
+        string argumentFromServer = null;
+        var serverCalled = new TaskCompletionSource<bool>();
+
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                using var client = new RemotingClient(
+                    new ClientConfig()
+                    {
+                        ConnectionTimeout = 0,
+                        Channel = ClientChannel,
+                        MessageEncryption = false,
+                        ServerPort = _serverFixture.Server.Config.NetworkPort,
+                    });
+
+                client.Connect();
+
+                var proxy = client.CreateProxy<ITestService>();
+                proxy.TestMethodWithDelegateArg(arg =>
+                {
+                    argumentFromServer = arg;
+                    serverCalled.TrySetResult(true);
+                });
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        await serverCalled.Task.Timeout(1);
+        Assert.Equal("test", argumentFromServer);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public async Task Call_on_Proxy_should_be_executed_asynchronously()
+    {
+        var longRunnigMethodStarted = new AsyncCounter();
+
+        void BeforeCall(object sender, ServerRpcContext e)
+        {
+            if (e.MethodCallMessage.MethodName == "LongRunnigTestMethod")
+                longRunnigMethodStarted++;
+        }
+
+        try
+        {
+            _serverFixture.Server.BeforeCall += BeforeCall;
+            using var client = new RemotingClient(
+                new ClientConfig()
+                {
+                    ConnectionTimeout = 0,
+                    Channel = ClientChannel,
+                    MessageEncryption = false,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var longRun = Task.Run(() => proxy.LongRunnigTestMethod(2000));
+
+            // wait until long-running test method is started on server
+            await longRunnigMethodStarted.WaitForValue(1).Timeout(2);
+
+            // try running another RPC call in parallel
+            proxy.TestMethod("x");
+
+            // if a client is disposed before LongRunningTestMethod rpc result is received,
+            // _serverFixture gets its error counter incremented which breaks other tests
+            await longRun;
+        }
+        catch (Exception e)
+        {
+            _testOutputHelper.WriteLine(e.ToString());
+            throw;
+        }
+        finally
+        {
+            _serverFixture.Server.BeforeCall -= BeforeCall;
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Theory]
+    [InlineData("TestService_Singleton_Service")]
+    [InlineData("TestService_Singleton_Factory")]
+    [InlineData("TestService_SingleCall_Service")]
+    [InlineData("TestService_SingleCall_Factory")]
+    [InlineData("TestService_Scoped_Service")]
+    [InlineData("TestService_Scoped_Factory")]
+    public void Component_lifetime_matches_the_expectation(string serviceName)
+    {
+        using var ctx = ValidationSyncContext.Install();
+        using var client = new RemotingClient(
+            new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<ITestService>(serviceName);
+
+        // check if service lifetime matches the expectations
+        proxy.SaveLastInstance();
+
+        // singleton component should have the same instance
+        var sameInstance = serviceName.Contains("Singleton");
+        Assert.Equal(sameInstance, proxy.CheckLastSavedInstance());
+    }
+
+    [Theory]
+    [InlineData("TestService_Singleton_Service")]
+    [InlineData("TestService_Singleton_Factory")]
+    [InlineData("TestService_SingleCall_Service")]
+    [InlineData("TestService_SingleCall_Factory")]
+    [InlineData("TestService_Scoped_Service")]
+    [InlineData("TestService_Scoped_Factory")]
+    public virtual void Events_should_work_remotely(string serviceName)
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        var serviceEventCallCount = 0;
+        var customDelegateEventCallCount = 0;
+
+        using var client = new RemotingClient(
+            new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<ITestService>(serviceName);
+
+        var serviceEventResetEvent = new ManualResetEventSlim(initialState: false);
+        var customDelegateEventResetEvent = new ManualResetEventSlim(initialState: false);
+
+        proxy.ServiceEvent += () =>
+        {
+            Interlocked.Increment(ref serviceEventCallCount);
+            serviceEventResetEvent.Set();
+        };
+
+        proxy.CustomDelegateEvent += _ =>
+        {
+            Interlocked.Increment(ref customDelegateEventCallCount);
+            customDelegateEventResetEvent.Set();
+        };
+
+        proxy.FireServiceEvent();
+        proxy.FireCustomDelegateEvent();
+
+        serviceEventResetEvent.Wait(1000);
+        customDelegateEventResetEvent.Wait(1000);
+
+        Assert.Equal(1, serviceEventCallCount);
+        Assert.Equal(1, customDelegateEventCallCount);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void External_types_should_work_as_remote_service_parameters()
+    {
+        // Reset server error state to ensure this test only verifies errors produced within its own scope.
+        // Other tests in the shared collection may increment ServerErrorCount on the shared ServerFixture instance.
+        _serverFixture.ServerErrorCount = 0;
+        _serverFixture.LastServerError = null;
+
+        DataClass parameterValue = null;
+
+        _serverFixture.TestService.TestExternalTypeParameterFake = arg =>
+        {
+            _remoteServiceCalled = true;
+            parameterValue = arg;
+        };
+
+        void ClientAction()
+        {
+            using var ctx = ValidationSyncContext.Install();
+
+            try
+            {
+                using var client = new RemotingClient(new ClientConfig()
+                {
+                    ConnectionTimeout = 0,
+                    Channel = ClientChannel,
+                    MessageEncryption = false,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                });
+
+                client.Connect();
+
+                var proxy = client.CreateProxy<ITestService>();
+                proxy.TestExternalTypeParameter(new DataClass() { Value = 42 });
+
+                Assert.Equal(42, parameterValue.Value);
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+        }
+
+        var clientThread = new Thread(ClientAction);
+        clientThread.Start();
+        clientThread.Join();
+
+        Assert.True(_remoteServiceCalled);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Generic_methods_should_be_called_correctly()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<IGenericEchoService>();
+
+        var result = proxy.Echo("Yay");
+
+        Assert.Equal("Yay", result);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Inherited_methods_should_be_called_correctly()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        var result = proxy.BaseMethod();
+
+        Assert.True(result);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Enum_arguments_should_be_passed_correctly()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<IEnumTestService>();
+
+        var resultFirst = proxy.Echo(TestEnum.First);
+        var resultSecond = proxy.Echo(TestEnum.Second);
+
+        Assert.Equal(TestEnum.First, resultFirst);
+        Assert.Equal(TestEnum.Second, resultSecond);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Missing_method_throws_RemoteInvocationException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
+
+        // simulate MissingMethodException
+        var mb = new CustomMessageBuilder
+        {
+            ProcessMethodCallMessage = m =>
+            {
+                if (m.MethodName == "TestMethod")
+                {
+                    m.MethodName = "Missing Method";
+                }
+            }
+        };
+
+        client.MethodCallMessageBuilder = mb;
+        client.Connect();
+
+        var proxy = client.CreateProxy<ITestService>();
+        var ex = Assert.Throws<RemoteInvocationException>(() => proxy.TestMethod(null));
+
+        // a localized message similar to "Method 'Missing method' not found"
+        Assert.NotNull(ex);
+        Assert.Contains("Missing Method", ex.Message);
+
+        _testOutputHelper.WriteLine(_serverFixture.LastServerError.ToString());
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Missing_service_throws_RemoteInvocationException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort
+        });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<IDisposable>();
+        var ex = Assert.Throws<RemoteInvocationException>(proxy.Dispose);
+
+        // a localized message similar to "Service 'System.IDisposable' is not registered"
+        Assert.NotNull(ex);
+        Assert.Contains("IDisposable", ex.Message);
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Error_method_throws_Exception()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                    proxy.Error(nameof(Error_method_throws_Exception)))
+                .GetInnermostException();
+
+            Assert.NotNull(ex);
+            Assert.Equal(nameof(Error_method_throws_Exception), ex.Message);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+    public async Task ErrorAsync_method_throws_Exception()
+    {
+        // using var ctx = ValidationSyncContext.Install(); // fails?
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = (await Assert.ThrowsAsync<RemoteInvocationException>(async () =>
+                {
+                    await proxy.ErrorAsync(nameof(ErrorAsync_method_throws_Exception)).ConfigureAwait(false);
+                })
+                .ConfigureAwait(false)).GetInnermostException();
+
+            Assert.NotNull(ex);
+            Assert.Equal(nameof(ErrorAsync_method_throws_Exception), ex.Message);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void NonSerializableError_method_throws_Exception()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                    proxy.NonSerializableError("Hello", "Serializable", "World"))
+                .GetInnermostException();
+
+            Assert.NotNull(ex);
+            Assert.IsType<SerializableException>(ex);
+
+            if (ex is SerializableException sx)
+            {
+                Assert.Equal("NonSerializable", sx.SourceTypeName);
+                Assert.Equal("Hello", ex.Message);
+
+                // Extract values from Data dictionary, handling JObject-wrapped values from BSON serialization
+                string ExtractDataValue(object value) =>
+                    value is Newtonsoft.Json.Linq.JObject jObj ? jObj["V"]?.ToString() : value?.ToString();
+
+                Assert.Equal("Serializable", ExtractDataValue(ex.Data["Serializable"]));
+                Assert.Equal("World", ExtractDataValue(ex.Data["World"]));
+                Assert.NotNull(ex.StackTrace);
+            }
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void Nonserializable_method_return_value_throws_Exception()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                proxy.NonSerializableReturnValue("Hello"));
+
+            Assert.NotNull(ex);
+            Assert.Contains("Failed to serialize method return value", ex.Message);
+            Assert.NotNull(ex.InnerException);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void AfterCall_event_handler_can_translate_exceptions_to_improve_diagnostics()
+    {
+        // replace cryptic database error report with a user-friendly error message
+        void AfterCall(object sender, ServerRpcContext ctx)
+        {
+            var errorMsg = ctx.Exception?.InnerException?.Message ?? ctx.Exception?.Message ?? string.Empty;
+            if (errorMsg.StartsWith("23503:"))
+                ctx.Exception = new Exception("Deleting clients is not allowed.",
+                    ctx.Exception);
+        }
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.AfterCall += AfterCall;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 5,
+                InvocationTimeout = 5,
+                SendTimeout = 5,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort
+            });
+
+            client.Connect();
+
+            var dbError = "23503: delete from table 'clients' violates " +
+                          "foreign key constraint 'order_client_fk' on table 'orders'";
+
+            // simulate a database error on the server-side
+            var proxy = client.CreateProxy<ITestService>();
+            var ex = Assert.Throws<Exception>(() => proxy.Error(dbError));
+
+            Assert.NotNull(ex);
+            Assert.Equal("Deleting clients is not allowed.", ex.Message);
+            Assert.NotNull(ex.InnerException);
+            Assert.IsType<RemoteInvocationException>(ex.InnerException);
+            Assert.Equal(dbError, ex.InnerException.InnerException.Message);
+        }
+        finally
+        {
+            // reset the error counter for other tests
+            _serverFixture.ServerErrorCount = 0;
+            _serverFixture.Server.AfterCall -= AfterCall;
+        }
+    }
+
+    [Fact]
+    public void Failing_component_constructor_throws_RemoteInvocationException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 3,
+            InvocationTimeout = 3,
+            SendTimeout = 3,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<IFailingService>();
+        var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Hello());
+
+        Assert.NotNull(ex);
+        Assert.Contains("FailingService", ex.Message);
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "<Pending>")]
+    public async Task Disposed_client_subscription_doesnt_break_other_clients()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        async Task Roundtrip(bool encryption)
+        {
+            var oldEncryption = _serverFixture.Server.Config.MessageEncryption;
+            _serverFixture.Server.Config.MessageEncryption = encryption;
+
+            try
+            {
+                RemotingClient CreateClient() => new RemotingClient(new ClientConfig()
+                {
+                    Channel = ClientChannel,
+                    ServerPort = _serverFixture.Server.Config.NetworkPort,
+                    MessageEncryption = encryption,
+                    ConnectionTimeout = encryption ? 0 : 5,
+                    KeySize = 1024
+                });
+
+                using var client1 = CreateClient();
+                using var client2 = CreateClient();
+
+                client1.Connect();
+                client2.Connect();
+
+                var proxy1 = client1.CreateProxy<ITestService>();
+                var fired1 = new TaskCompletionSource<bool>();
+                proxy1.ServiceEvent += () => fired1.TrySetResult(true);
+
+                var proxy2 = client2.CreateProxy<ITestService>();
+                var fired2 = new TaskCompletionSource<bool>();
+                proxy2.ServiceEvent += () => fired2.TrySetResult(true);
+
+                // early disposal, proxy1 subscription isn't canceled
+                client1.Disconnect();
+
+                proxy2.FireServiceEvent();
+                Assert.True(await fired2.Task.ConfigureAwait(false));
+                Assert.True(fired2.Task.IsCompleted);
+                Assert.False(fired1.Task.IsCompleted);
+            }
+            finally
+            {
+                _serverFixture.Server.Config.MessageEncryption = oldEncryption;
+
+                // reset the error counter for other tests
+                _serverFixture.ServerErrorCount = 0;
+            }
+        }
+
+        // works!
+        await Roundtrip(encryption: false).ConfigureAwait(false);
+
+        // For NamedPipe channel, skip encrypted roundtrip due to known hanging issue
+        var isNamedPipe = ClientChannel is NamedPipeClientChannel || ServerChannel is NamedPipeServerChannel;
+        if (!isNamedPipe)
+        {
+            // encrypted roundtrip validated for other channels
+            await Roundtrip(encryption: true).ConfigureAwait(false);
+        }
+    }
+
+    [Fact]
+    public void DataTable_roundtrip_works_issue60()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        var dt = new DataTable();
+        dt.TableName = "Issue60";
+        dt.Columns.Add("CODE");
+        dt.Rows.Add(dt.NewRow());
+        dt.AcceptChanges();
+
+        var dt2 = proxy.TestDt(dt, 1);
+        Assert.NotNull(dt2);
+    }
+
+    [Fact]
+    [SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "<Pending>")]
+    public virtual void Large_messages_are_sent_and_received()
+    {
+        // max payload size, in bytes
+        var maxSize = 2 * 1024 * 1024 + 1;
+
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+        var proxy = client.CreateProxy<ITestService>();
+
+        // shouldn't throw exceptions
+        Roundtrip("Payload", maxSize);
+        Roundtrip(new byte[] { 1, 2, 3, 4, 5 }, maxSize);
+        Roundtrip(new int[] { 12345, 67890 }, maxSize);
+
+        void Roundtrip<T>(T payload, int maxSize) where T : class
+        {
+            var lastSize = 0;
+            try
+            {
+                while (true)
+                {
+                    // a -> aa -> aaaa ...
+                    var (dup, size) = proxy.Duplicate(payload);
+                    if (size >= maxSize)
+                        break;
+
+                    // save the size for error reporting
+                    lastSize = size;
+                    payload = dup;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to handle " +
+                                                    $"payload larger than {lastSize}: {ex.Message}", ex);
+            }
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "Not applicable")]
+    public async Task BeforeCall_and_AfterCall_events_are_triggered_on_success()
+    {
+        var beforeCallFired = new AsyncCounter();
+
+        void BeforeCall(object sender, ServerRpcContext e) =>
+            beforeCallFired++;
+
+        var afterCallFired = new AsyncCounter();
+
+        void AfterCall(object sender, ServerRpcContext e) =>
+            afterCallFired++;
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeforeCall += BeforeCall;
+        _serverFixture.Server.AfterCall += AfterCall;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            // test one-way method
+            var proxy = client.CreateProxy<ITestService>();
+            proxy.OneWayMethod();
+
+            // test normal method
+            Assert.Equal("Hello", proxy.Echo("Hello"));
+
+            await beforeCallFired[2].Timeout(1).ConfigureAwait(false);
+            await afterCallFired[2].Timeout(1).ConfigureAwait(false);
+        }
+        finally
+        {
+            _serverFixture.Server.AfterCall -= AfterCall;
+            _serverFixture.Server.BeforeCall -= BeforeCall;
+        }
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "Not applicable")]
+    public async Task BeforeCall_and_AfterCall_events_are_triggered_on_failures()
+    {
+        var beforeCallFired = new AsyncCounter();
+
+        void BeforeCall(object sender, ServerRpcContext e) =>
+            beforeCallFired++;
+
+        var afterCallFired = new AsyncCounter();
+
+        void AfterCall(object sender, ServerRpcContext e) =>
+            afterCallFired++;
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeforeCall += BeforeCall;
+        _serverFixture.Server.AfterCall += AfterCall;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            // test failing method
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Throws<RemoteInvocationException>(() => proxy.Error("Bang"));
+
+            await beforeCallFired[1].Timeout(1).ConfigureAwait(false);
+            await afterCallFired[1].Timeout(1).ConfigureAwait(false);
+        }
+        finally
+        {
+            _serverFixture.Server.AfterCall -= AfterCall;
+            _serverFixture.Server.BeforeCall -= BeforeCall;
+        }
+    }
+
+    [Fact]
+    public void BeginCall_event_handler_can_intercept_and_cancel_method_calls()
+    {
+        var counter = 0;
+
+        void InterceptMethodCalls(object sender, ServerRpcContext e)
+        {
+            Interlocked.Increment(ref counter);
+
+            // swap Echo and Reverse methods
+            e.MethodCallMessage.MethodName = e.MethodCallMessage.MethodName switch
+            {
+                "Echo" => "Reverse",
+                "Reverse" => "Echo",
+                var others => others
+            };
+
+            // disable IHobbitService
+            if (e.MethodCallMessage.ServiceName.Contains("IHobbitService"))
+            {
+                e.Cancel = true;
+            }
+        }
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeginCall += InterceptMethodCalls;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            // try swapped methods
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("321", proxy.Echo("123"));
+            Assert.Equal("Hello", proxy.Reverse("Hello"));
+
+            // try disabled service
+            var hobbit = client.CreateProxy<IHobbitService>();
+            Assert.Throws<RemoteInvocationException>(() =>
+                hobbit.QueryHobbits(h => h.LastName != ""));
+
+            // check interception counter
+            Assert.Equal(3, counter);
+        }
+        finally
+        {
+            _serverFixture.Server.BeginCall -= InterceptMethodCalls;
+        }
+    }
+
+    [Fact]
+    public void Authentication_is_taken_into_account_and_Connect_method_fails()
+    {
+        var server = _serverFixture.Server;
+        server.Config.AuthenticationRequired = true;
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            Assert.Throws<SecurityException>(client.Connect);
+        }
+        finally
+        {
+            server.Config.AuthenticationRequired = false;
+        }
+    }
+
+    [Fact]
+    public void Authentication_handler_has_access_to_the_current_session()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
+        {
+            AuthenticateFake = c => RemotingSession.Current != null
+        };
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new()],
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("123", proxy.Reverse("321"));
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+        }
+    }
+
+    [Fact]
+    public void Broken_auhentication_handler_doesnt_break_the_server()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
+        {
+            AuthenticateFake = c => throw new Exception("Broken")
+        };
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 3,
+                InvocationTimeout = 3,
+                SendTimeout = 3,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new()],
+            });
+
+            var ex = Assert.Throws<SecurityException>(client.Connect);
+
+            Assert.Contains("auth", ex.Message.ToLower());
+            Assert.Contains("failed", ex.Message);
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public virtual void Authentication_handler_can_check_client_address()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
+        {
+            AuthenticateFake = c =>
+            {
+                var address = RemotingSession.Current?.ClientAddress ??
+                              throw new ArgumentNullException("ClientAddress");
+
+                // allow only localhost connections
+                return address.Contains("127.0.0.1") || // ipv4
+                       address.Contains("[::1]"); // ipv6
+            }
+        };
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new Credential()],
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("123", proxy.Reverse("321"));
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+        }
+    }
+
+    [Fact]
+    public virtual void Authentication_can_fail_then_succeed()
+    {
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationRequired = true;
+        server.Config.AuthenticationProvider = new FakeAuthProvider
+        {
+            AuthenticateFake = c => c.Length == 2
+        };
+
+        using var ctx = ValidationSyncContext.Install();
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+                Credentials = [new()],
+            });
+
+            Assert.Throws<SecurityException>(client.Connect);
+
+            client.Config.Credentials = [new(), new()];
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("123", proxy.Reverse("321"));
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
+
+    [Fact]
+    public void RemotingClient_can_disconnect_and_connect_again()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        var clientConfig = new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            Channel = ClientChannel,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        };
+
+        // NamedPipe requires a connection name; provide the server's configured name
+        if (ClientChannel is NamedPipeClientChannel || ServerChannel is NamedPipeServerChannel)
+        {
+            clientConfig.ChannelConnectionName = _serverFixture.Server.Config.ChannelConnectionName ?? "CoreRemoting";
+        }
+
+        var isNamedPipe = ClientChannel is NamedPipeClientChannel || ServerChannel is NamedPipeServerChannel;
+
+        if (isNamedPipe)
+        {
+            // NamedPipe: run a simple connect/disconnect once due to known reconnect instability
+            using var client = new RemotingClient(clientConfig);
+            client.Connect();
+            var proxy = client.CreateProxy<ISessionAwareService>();
+            Assert.NotNull(proxy.ClientAddress);
+            client.Disconnect();
+            return;
+        }
+
+        using (var client = new RemotingClient(clientConfig))
+        {
+            client.Connect();
+            var proxy = client.CreateProxy<ISessionAwareService>();
+            Assert.NotNull(proxy.ClientAddress);
+            client.Disconnect();
+            client.Connect();
+            proxy = client.CreateProxy<ISessionAwareService>();
+            Assert.NotNull(proxy.ClientAddress);
+        }
+    }
+
+    [Fact]
+    public void ServerComponent_can_track_client_network_address()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            Channel = ClientChannel,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<ISessionAwareService>();
+
+        // what's my address as seen by remote server?
+        Assert.NotNull(proxy.ClientAddress);
+    }
+
+    [Fact]
+    public void Scoped_service_is_resolved_within_the_remote_call_scope()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            Channel = ClientChannel,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<IServiceWithDeps>();
+        var guid = proxy.ScopedServiceInstanceId;
+
+        // empty Guid means that ServiceWithDeps has got different ScopedService instances
+        // but it should get the same scoped service instances across the whore resolution graph
+        Assert.NotEqual(Guid.Empty, guid);
+
+        // every remote call should produce a new ScopedService instance
+        Assert.NotEqual(guid, proxy.ScopedServiceInstanceId);
+        Assert.NotEqual(proxy.ScopedServiceInstanceId, proxy.ScopedServiceInstanceId);
+    }
+
+    [Fact]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait in test method", Justification = "Not applicable")]
+    public async Task Logon_and_logoff_events_are_triggered()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        void CheckSession(string operation)
+        {
+            var rs = RemotingSession.Current;
+            Assert.NotNull(rs);
+            Assert.True(rs?.IsAuthenticated);
+            Assert.NotNull(rs?.ClientAddress);
+            Assert.NotNull(rs?.Identity);
+            Console.WriteLine($"Client {rs.Identity.Name} from {rs.ClientAddress} is {operation}");
+        }
+
+        var logon = new AsyncCounter();
+
+        void Logon(object sender, EventArgs _)
+        {
+            logon++;
+            CheckSession("logged on");
+        }
+
+        var logoff = new AsyncCounter();
+
+        void Logoff(object sender, EventArgs _)
+        {
+            logoff++;
+            CheckSession("logged off");
+        }
+
+        var server = _serverFixture.Server;
+        var authProvider = server.Config.AuthenticationProvider;
+        server.Config.AuthenticationProvider = new FakeAuthProvider();
+
+        server.Logon += Logon;
+        server.Logoff += Logoff;
+        server.Config.AuthenticationRequired = true;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                Credentials = [new()],
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("Hello", proxy.Echo("Hello"));
+
+            client.Disconnect();
+
+            await logon[1].Timeout(1).ConfigureAwait(false);
+            await logoff[1].Timeout(1).ConfigureAwait(false);
+        }
+        finally
+        {
+            server.Config.AuthenticationProvider = authProvider;
+            server.Config.AuthenticationRequired = false;
+            server.Logoff -= Logoff;
+            server.Logon -= Logon;
+        }
+    }
+
+    [Fact(Skip = "This scenario is not supported anymore because client.Connect would throw if authentication is required")]
+    public void BeginCall_event_handler_can_bypass_authentication_for_chosen_method()
+    {
+        void BypassAuthorizationForEcho(object sender, ServerRpcContext e) =>
+            e.AuthenticationRequired =
+                e.MethodCallMessage.MethodName != "Echo";
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.Config.AuthenticationRequired = true;
+        _serverFixture.Server.BeginCall += BypassAuthorizationForEcho;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            // not sure can we establish unauthenticated connection
+            // even if the server says it's required?
+            client.Connect();
+
+            // try allowed method "Echo"
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("This method is allowed", proxy.Echo("This method is allowed"));
+
+            // try disallowed method "Reverse"
+            var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Reverse("This method is not allowed"));
+            Assert.Contains("auth", ex.Message);
+        }
+        finally
+        {
+            _serverFixture.Server.BeginCall -= BypassAuthorizationForEcho;
+            _serverFixture.Server.Config.AuthenticationRequired = false;
+        }
+    }
+
+    [Fact]
+    public void BeginCall_event_handler_can_enforce_authentication_for_chosen_method()
+    {
+        void BypassAuthorizationForEcho(object sender, ServerRpcContext e) =>
+            e.AuthenticationRequired =
+                e.MethodCallMessage.MethodName != "Echo";
+
+        using var ctx = ValidationSyncContext.Install();
+        _serverFixture.Server.BeginCall += BypassAuthorizationForEcho;
+
+        try
+        {
+            using var client = new RemotingClient(new ClientConfig()
+            {
+                ConnectionTimeout = 0,
+                InvocationTimeout = 0,
+                SendTimeout = 0,
+                Channel = ClientChannel,
+                MessageEncryption = false,
+                ServerPort = _serverFixture.Server.Config.NetworkPort,
+            });
+
+            client.Connect();
+
+            // try unauthenticated  method "Echo"
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("This method is allowed", proxy.Echo("This method is allowed"));
+
+            // try authenticated  method "Reverse"
+            var ex = Assert.Throws<RemoteInvocationException>(() => proxy.Reverse("This method is not allowed"));
+            Assert.Contains("auth", ex.Message);
+
+            client.Disconnect();
+
+            // enable optional authentication
+            _serverFixture.Server.Config.AuthenticationProvider = new FakeAuthProvider
+            {
+                AuthenticateFake = c => c.First().Name.StartsWith("foo")
+            };
+
+            client.Config.Credentials = [new() { Name = "foo" }];
+            client.Connect();
+
+            // try unauthenticated method "Echo"
+            proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("Again allowed", proxy.Echo("Again allowed"));
+
+            // try authenticated method "Reverse"
+            var result = proxy.Reverse("look");
+            Assert.Equal("kool", result);
+        }
+        finally
+        {
+            _serverFixture.Server.Config.AuthenticationProvider = null;
+            _serverFixture.Server.BeginCall -= BypassAuthorizationForEcho;
+        }
+    }
+
+    [Fact]
+    public void CreateProxy_methods_should_produce_equivalent_results()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        var proxy1 = client.CreateProxy<IGenericEchoService>();
+        var result1 = proxy1.Echo("Yay");
+        Assert.Equal("Yay", result1);
+
+        var proxy2 = client.CreateProxy(typeof(IGenericEchoService)) as IGenericEchoService;
+        var result2 = proxy2.Echo("Yay");
+        Assert.Equal("Yay", result2);
+
+        var svcref = new ServiceReference(typeof(IGenericEchoService).AssemblyQualifiedName, "");
+        var proxy3 = client.CreateProxy(svcref) as IGenericEchoService;
+        var result3 = proxy3.Echo("Yay");
+        Assert.Equal("Yay", result3);
+
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void Custom_proxy_builder_can_be_used_for_interception()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            Channel = ClientChannel,
+            MessageEncryption = false,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+            ProxyBuilder = new CustomProxyBuilder(),
+        });
+
+        client.Connect();
+
+        var proxy1 = client.CreateProxy<IGenericEchoService>();
+        Assert.Equal("[Yay]", proxy1.Echo("Yay"));
+        Assert.Equal(1, proxy1.Echo(1));
+
+        var proxy2 = client.CreateProxy(typeof(IGenericEchoService)) as IGenericEchoService;
+        Assert.Equal("[Yay]", proxy2.Echo("Yay"));
+        Assert.Equal(1, proxy2.Echo(1));
+
+        var svcref = new ServiceReference(typeof(IGenericEchoService).AssemblyQualifiedName, "");
+        var proxy3 = client.CreateProxy(svcref) as IGenericEchoService;
+        Assert.Equal("[Yay]", proxy3.Echo("Yay"));
+        Assert.Equal(1, proxy3.Echo(1));
+
+        CheckServerErrorCount();
+    }
+
+    [Fact]
+    public void NonDeserializableObject_TriggersException()
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 0,
+            InvocationTimeout = 0,
+            SendTimeout = 0,
+            MessageEncryption = false,
+            Channel = ClientChannel,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        client.Connect();
+
+        var proxy = client.CreateProxy<ITestService>();
+        try
+        {
+            var ex = Assert.Throws<RemoteInvocationException>(() =>
+                proxy.Duplicate(new NonDeserializable(123)));
+
+            Assert.Contains(NonDeserializable.ErrorMessage, ex.Message);
+        }
+        finally
+        {
+            _serverFixture.ServerErrorCount = 0;
+        }
+    }
 }

--- a/CoreRemoting.Tests/SessionTests.cs
+++ b/CoreRemoting.Tests/SessionTests.cs
@@ -58,7 +58,9 @@ public class SessionTests : IClassFixture<ServerFixture>
         }
 
         // There should be no sessions, before both clients connected
-        Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
+        var sessionRepository = _serverFixture.Server.SessionRepository as SessionRepository;
+        Assert.NotNull(sessionRepository);
+        Assert.Empty(sessionRepository.Sessions);
 
         // Start two clients to create two sessions
         var client1 = ClientTask(clientStarted1);
@@ -67,14 +69,14 @@ public class SessionTests : IClassFixture<ServerFixture>
         // Wait for connection of both clients
         await Task.WhenAll(clientStarted1.Task, clientStarted2.Task).Timeout(5).ConfigureAwait(false);
 
-        Assert.Equal(2, _serverFixture.Server.SessionRepository.Sessions.Count());
+        Assert.Equal(2, sessionRepository.Sessions.Count());
 
         clientStopSignal.TrySetResult();
 
         await Task.WhenAll(client1, client2, Task.Delay(100)).Timeout(5).ConfigureAwait(false);
 
         // There should be no sessions left, after both clients disconnected
-        Assert.Empty(_serverFixture.Server.SessionRepository.Sessions);
+        Assert.Empty(sessionRepository.Sessions);
     }
 
     [Fact]

--- a/CoreRemoting.Tests/SourceGeneratorTests.cs
+++ b/CoreRemoting.Tests/SourceGeneratorTests.cs
@@ -1,9 +1,10 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.CodeDom.Compiler;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Castle.Core.Internal;
+using CoreRemoting.Authentication;
 using CoreRemoting.Tests.Tools;
 using CoreRemoting.Toolbox;
 using Xunit;
@@ -12,6 +13,58 @@ namespace CoreRemoting.Tests;
 
 public partial class SourceGeneratorTests
 {
+    partial class LegacyAuthenticationProvider : IAuthenticationProvider
+    {
+        public bool Authenticate(Credential[] credentials, out RemotingIdentity id)
+        {
+            id = credentials.FindByName("login") != "root" ? null : new()
+            {
+                Name = "Administrator"
+            };
+
+            return id != null;
+        }
+    }
+
+    [Fact]
+    public async Task Legacy_AuthenticationProvider_is_automatically_upgraded()
+    {
+        var type = typeof(LegacyAuthenticationProvider);
+
+        // ñheck that the new method exists with the correct signature
+        var newMethod = type.GetMethod(
+            nameof(IAuthenticationProvider.Authenticate),
+            [typeof(AuthenticationRequestMessage)]);
+        Assert.NotNull(newMethod);
+        Assert.Equal(typeof(Task<AuthenticationResponseMessage>), newMethod.ReturnType);
+
+        // ñheck that it has the GeneratedCode attribute
+        var generatedCodeAttr = newMethod.GetCustomAttribute<GeneratedCodeAttribute>();
+        Assert.NotNull(generatedCodeAttr);
+
+        // test the adapter logic
+        var provider = new LegacyAuthenticationProvider();
+
+        // request with valid credentials
+        var validRequest = new AuthenticationRequestMessage
+        {
+            Credentials =
+            [
+                new() { Name = "login", Value = "root" }
+            ]
+        };
+
+        var response = await provider.Authenticate(validRequest);
+        Assert.True(response.IsAuthenticated);
+        Assert.NotNull(response.AuthenticatedIdentity);
+        Assert.Equal("Administrator", response.AuthenticatedIdentity.Name);
+
+        // request with invalid credentials
+        response = await provider.Authenticate(new());
+        Assert.False(response.IsAuthenticated);
+        Assert.Null(response.AuthenticatedIdentity);
+    }
+
     [NotImplemented]
     partial class PartiallyImplementedService : ITestService
     {

--- a/CoreRemoting.Tests/SourceGeneratorTests.cs
+++ b/CoreRemoting.Tests/SourceGeneratorTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Castle.Core.Internal;
+using CoreRemoting.Tests.Tools;
+using CoreRemoting.Toolbox;
+using Xunit;
+
+namespace CoreRemoting.Tests;
+
+public partial class SourceGeneratorTests
+{
+    [NotImplemented]
+    partial class PartiallyImplementedService : ITestService
+    {
+        public string Echo(string text) => text;
+
+        public string Reverse(string text) => new([.. text.Reverse()]);
+    }
+
+    [Fact]
+    public void PartiallyImplementedService_HasAllInterfaceMembers()
+    {
+        var type = typeof(PartiallyImplementedService);
+
+        // this method exists in the code
+        var existingMethod = type.GetMethod(nameof(ITestService.Echo));
+        Assert.NotNull(existingMethod);
+        Assert.Null(existingMethod.GetAttribute<NotImplementedAttribute>());
+
+        // this method doesn't exist in the code
+        var interfaceMap = type.GetInterfaceMap(typeof(ITestService));
+        var interfaceMethod = typeof(ITestService).GetMethod(nameof(ITestService.TestMethodWithDelegateArg));
+        int index = Array.IndexOf(interfaceMap.InterfaceMethods, interfaceMethod);
+        var generatedMethod = interfaceMap.TargetMethods[index];
+        Assert.NotNull(generatedMethod);
+        Assert.Contains(nameof(ITestService.TestMethodWithDelegateArg), generatedMethod.Name);
+        Assert.NotNull(generatedMethod.GetCustomAttribute<NotImplementedAttribute>());
+
+        // this event is also auto-generated
+        var interfaceEvent = typeof(ITestService).GetEvent(nameof(ITestService.ServiceEvent));
+        Assert.NotNull(interfaceEvent);
+
+        // Get the add and remove methods of the event
+        var addMethod = interfaceEvent.GetAddMethod();
+        var removeMethod = interfaceEvent.GetRemoveMethod();
+        Assert.NotNull(addMethod);
+        Assert.NotNull(removeMethod);
+
+        // Find the corresponding target methods via interface map
+        var addIndex = Array.IndexOf(interfaceMap.InterfaceMethods, addMethod);
+        var removeIndex = Array.IndexOf(interfaceMap.InterfaceMethods, removeMethod);
+        var generatedAddMethod = interfaceMap.TargetMethods[addIndex];
+        var generatedRemoveMethod = interfaceMap.TargetMethods[removeIndex];
+
+        Assert.NotNull(generatedAddMethod);
+        Assert.NotNull(generatedRemoveMethod);
+        Assert.Contains("add_", generatedAddMethod.Name);
+        Assert.Contains("remove_", generatedRemoveMethod.Name);
+
+        // add and remove methods don't have the [NotImplemented] attribute
+        Assert.Null(generatedAddMethod.GetCustomAttribute<NotImplementedAttribute>());
+        Assert.Null(generatedRemoveMethod.GetCustomAttribute<NotImplementedAttribute>());
+
+        // find the generated event by filtering all non-public events
+        var allEvents = type.GetEvents(BindingFlags.NonPublic | BindingFlags.Instance);
+        var generatedEvent = allEvents.FirstOrDefault(e =>
+            e.Name.EndsWith("." + interfaceEvent.Name, StringComparison.Ordinal));
+        Assert.NotNull(generatedEvent);
+        Assert.NotNull(generatedEvent.GetCustomAttribute<NotImplementedAttribute>());
+
+        // auto-generated property from base interface (explicit implementation)
+        var baseInterface = typeof(IBaseService);
+        var versionProperty = baseInterface.GetProperty(nameof(IBaseService.Version));
+        Assert.NotNull(versionProperty);
+
+        // Find the generated property by filtering non-public properties
+        var allProperties = type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance);
+        var generatedProperty = allProperties.FirstOrDefault(p =>
+            p.Name.EndsWith("." + versionProperty.Name, StringComparison.Ordinal));
+        Assert.NotNull(generatedProperty);
+        Assert.NotNull(generatedProperty.GetCustomAttribute<NotImplementedAttribute>());
+    }
+}

--- a/CoreRemoting.Tests/SrpAuthenticationTests.cs
+++ b/CoreRemoting.Tests/SrpAuthenticationTests.cs
@@ -35,7 +35,7 @@ public class SrpAuthenticationTests : IAsyncLifetime
         E0FD108E 4B82D120 A93AD2CA FFFFFFFF FFFFFFFF", "05");
 
     private readonly SampleAccountRepository _repository = new();
-    private RemotingServer? _server;
+    private RemotingServer _server;
 
     public async Task InitializeAsync()
     {
@@ -206,12 +206,8 @@ public class SrpAuthenticationTests : IAsyncLifetime
             // No Authenticator
         });
 
-        // TODO: fail on connection?
-        //await Assert.ThrowsAsync<SecurityException>(client.ConnectAsync);
-        await client.ConnectAsync();
-
-        var proxy = client.CreateProxy<ISampleService>();
-        Assert.Throws<RemoteInvocationException>(() => proxy.Echo("Hello"));
+        // fail on connection
+        await Assert.ThrowsAsync<SecurityException>(client.ConnectAsync);
     }
 
     [Fact]

--- a/CoreRemoting.Tests/Tools/IBaseService.cs
+++ b/CoreRemoting.Tests/Tools/IBaseService.cs
@@ -3,4 +3,6 @@ namespace CoreRemoting.Tests.Tools;
 public interface IBaseService
 {
     bool BaseMethod();
+
+    string Version { get; }
 }

--- a/CoreRemoting.Tests/Tools/TestService.cs
+++ b/CoreRemoting.Tests/Tools/TestService.cs
@@ -171,6 +171,8 @@ public class TestService : ITestService
 
     private static TestService LastInstance { get; set; }
 
+    public string Version => "1.0";
+
     public void SaveLastInstance() => LastInstance = this;
 
     public bool CheckLastSavedInstance() => LastInstance == this;

--- a/CoreRemoting.sln
+++ b/CoreRemoting.sln
@@ -45,6 +45,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoginUsingGithubDemo", "Exa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreRemoting.Authentication.SecureRemotePassword", "CoreRemoting.Authentication.SecureRemotePassword\CoreRemoting.Authentication.SecureRemotePassword.csproj", "{963449AE-2169-8B24-93B4-5BE7CB7DFF0C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreRemoting.SourceGenerators", "CoreRemoting.SourceGenerators\CoreRemoting.SourceGenerators.csproj", "{ED33D1F0-B563-851A-5E43-77347CB5D4C6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -119,6 +121,10 @@ Global
 		{963449AE-2169-8B24-93B4-5BE7CB7DFF0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{963449AE-2169-8B24-93B4-5BE7CB7DFF0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{963449AE-2169-8B24-93B4-5BE7CB7DFF0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CoreRemoting/Channels/Null/NullClientChannel.cs
+++ b/CoreRemoting/Channels/Null/NullClientChannel.cs
@@ -44,7 +44,7 @@ public class NullClientChannel : NullTransport, IClientChannel
         ThisEndpoint = NullMessageQueue.Connect(Url, metadata);
         RemoteEndpoint = Url;
 
-        StartListening();
+        _ = StartListening();
         OnConnected();
 
         return Task.CompletedTask;

--- a/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
+++ b/CoreRemoting/Channels/Websocket/WebsocketClientChannel.cs
@@ -72,7 +72,7 @@ public class WebsocketClientChannel : WebsocketTransport, IClientChannel
                 .ConfigureAwait(false);
 
         IsConnected = true;
-        StartListening();
+        _ = StartListening();
 
         await SendMessageAsync([])
             .ConfigureAwait(false);

--- a/CoreRemoting/ISessionRepository.cs
+++ b/CoreRemoting/ISessionRepository.cs
@@ -25,13 +25,6 @@ public interface ISessionRepository : IAsyncDisposable
         IRawMessageTransport rawMessageTransport);
 
     /// <summary>
-    /// Gets a specified session by its ID.
-    /// </summary>
-    /// <param name="sessionId">Session ID</param>
-    /// <returns>The session correlating to the specified session ID</returns>
-    Task<RemotingSession> GetSession(Guid sessionId);
-
-    /// <summary>
     /// Gets a list of all sessions.
     /// </summary>
     IEnumerable<RemotingSession> Sessions { get; }

--- a/CoreRemoting/ISessionRepository.cs
+++ b/CoreRemoting/ISessionRepository.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using CoreRemoting.Channels;
 
@@ -23,11 +22,6 @@ public interface ISessionRepository : IAsyncDisposable
         string clientAddress,
         IRemotingServer server,
         IRawMessageTransport rawMessageTransport);
-
-    /// <summary>
-    /// Gets a list of all sessions.
-    /// </summary>
-    IEnumerable<RemotingSession> Sessions { get; }
 
     /// <summary>
     /// Removes a specified session by its ID.

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -40,6 +40,8 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
     private readonly AsyncLock _channelLock;
     private Dictionary<Guid, ClientRpcContext> _activeCalls;
     private readonly AsyncLock _activeCallsLock;
+    private byte[] _sharedSecret;
+    private bool _authenticationRequired;
     private Guid _sessionId;
     private readonly object _sessionLock;
     private readonly AsyncCountdownEvent _currentlyPendingMessagesCounter;
@@ -73,6 +75,8 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
     {
         MethodCallMessageBuilder = new MethodCallMessageBuilder();
         MessageEncryptionManager = new MessageEncryptionManager();
+        _authenticationRequired = false;
+        _sharedSecret = null;
         _activeCalls = null;
         _activeCallsLock = new();
         _channelLock = new();
@@ -333,11 +337,6 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
             _keepSessionAliveTimer = null;
         }
 
-        var sharedSecret =
-            MessageEncryption
-                 ? sessionId.ToByteArray()
-                 : null;
-
         if (!quiet)
         {
             var goodbyeMessage =
@@ -352,7 +351,7 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
                     serializer: Serializer,
                     serializedMessage: Serializer.Serialize(goodbyeMessage),
                     keyPair: _keyPair,
-                    sharedSecret: sharedSecret);
+                    sharedSecret: _sharedSecret);
 
             var rawData = Serializer.Serialize(wireMessage);
 
@@ -438,36 +437,19 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
         }
     }
 
-    private byte[] SharedSecret()
-    {
-        if (MessageEncryption)
-        {
-            lock (_sessionLock)
-            {
-                return _sessionId.ToByteArray();
-            }
-        }
-        else
-        {
-            return null;
-        }
-    }
-
     #endregion
 
     #region Authentication
 
     async Task<AuthenticationResponseMessage> IAuthenticationProvider.Authenticate(AuthenticationRequestMessage authRequestMessage)
     {
-        var sharedSecret = SharedSecret();
-
         var wireMessage =
             MessageEncryptionManager.CreateWireMessage(
                 messageType: "auth",
                 serializer: Serializer,
                 serializedMessage: Serializer.Serialize(authRequestMessage),
                 keyPair: _keyPair,
-                sharedSecret: sharedSecret);
+                sharedSecret: _sharedSecret);
 
         var rawData = Serializer.Serialize(wireMessage);
 
@@ -492,7 +474,12 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
     {
         if (_config.Credentials is null or { Length: 0 } &&
             _config.Authenticator is null or DefaultAuthenticator)
+        {
+            if (_authenticationRequired)
+                throw new SecurityException("Authentication is required. Please check credentials.");
+
             return;
+        }
 
         if (_authenticationCompletedTaskSource.Task.IsCompleted)
             return;
@@ -587,6 +574,8 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
     /// <param name="message">Deserialized WireMessage that contains a plain or encrypted Session ID</param>
     private void ProcessCompleteHandshakeMessage(WireMessage message)
     {
+        var handshakeBytes = message.Data;
+
         if (MessageEncryption)
         {
             var signedMessageData =
@@ -604,23 +593,21 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
                 signature: signedMessageData.Signature))
                 throw new SecurityException("Verification of message signature failed.");
 
-            lock (_sessionLock)
-            {
-                _sessionId =
-                    new Guid(
-                        RsaKeyExchange.DecryptSecret(
-                            keySize: _config.KeySize,
-                            // ReSharper disable once PossibleNullReferenceException
-                            receiversPrivateKeyBlob: _keyPair.PrivateKey,
-                            encryptedSecret: encryptedSecret));
-            }
-        }
-        else
-        {
-            lock (_sessionLock)
-                _sessionId = new Guid(message.Data);
+            handshakeBytes = RsaKeyExchange.DecryptSecret(
+                keySize: _config.KeySize,
+                // ReSharper disable once PossibleNullReferenceException
+                receiversPrivateKeyBlob: _keyPair.PrivateKey,
+                encryptedSecret: encryptedSecret);
         }
 
+        var handshakeMessage =
+            Serializer.Deserialize<CompleteHandshakeMessage>(handshakeBytes);
+
+        lock (_sessionLock)
+            _sessionId = handshakeMessage.SessionId;
+
+        _authenticationRequired = handshakeMessage.AuthenticationRequired;
+        _sharedSecret = handshakeMessage.SharedSecret;
         _handshakeCompletedTaskSource.TrySetResult(true);
     }
 
@@ -630,15 +617,13 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
     /// <param name="message">Deserialized WireMessage that contains a AuthenticationResponseMessage</param>
     private void ProcessAuthenticationResponseMessage(WireMessage message)
     {
-        var sharedSecret = SharedSecret();
-
         var authResponseMessage =
             Serializer
                 .Deserialize<AuthenticationResponseMessage>(
                     MessageEncryptionManager.GetDecryptedMessageData(
                         message: message,
                         serializer: Serializer,
-                        sharedSecret: sharedSecret,
+                        sharedSecret: _sharedSecret,
                         sendersPublicKeyBlob: _serverPublicKeyBlob,
                         sendersPublicKeySize: _keyPair?.KeySize ?? 0));
 
@@ -677,15 +662,13 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
         if (_goodbyeCompletedEvent.IsSet)
             return;
 
-        var sharedSecret = SharedSecret();
-
         var delegateInvocationMessage =
             Serializer
                 .Deserialize<RemoteDelegateInvocationMessage>(
                     MessageEncryptionManager.GetDecryptedMessageData(
                         message: message,
                         serializer: Serializer,
-                        sharedSecret: sharedSecret,
+                        sharedSecret: _sharedSecret,
                         sendersPublicKeyBlob: _serverPublicKeyBlob,
                         sendersPublicKeySize: _keyPair?.KeySize ?? 0));
 
@@ -709,8 +692,6 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
 
         if (_goodbyeCompletedEvent.IsSet)
             return;
-
-        var sharedSecret = SharedSecret();
 
         Guid unqiueCallKey =
             message.UniqueCallKey == null
@@ -743,7 +724,7 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
                         MessageEncryptionManager.GetDecryptedMessageData(
                             message: message,
                             serializer: Serializer,
-                            sharedSecret: sharedSecret,
+                            sharedSecret: _sharedSecret,
                             sendersPublicKeyBlob: _serverPublicKeyBlob,
                             sendersPublicKeySize: _keyPair?.KeySize ?? 0));
 
@@ -766,7 +747,7 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
                     MessageEncryptionManager.GetDecryptedMessageData(
                         message: message,
                         serializer: Serializer,
-                        sharedSecret: sharedSecret,
+                        sharedSecret: _sharedSecret,
                         sendersPublicKeyBlob: _serverPublicKeyBlob,
                         sendersPublicKeySize: _keyPair?.KeySize ?? 0);
 
@@ -811,8 +792,6 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
             throw new RemoteInvocationException("Client disconnected");
         }
 
-        var sharedSecret = SharedSecret();
-
         using (await _activeCallsLock)
         {
             if (_activeCalls == null)
@@ -831,7 +810,7 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
                 messageType: "rpc",
                 serializer: Serializer,
                 serializedMessage: Serializer.Serialize(methodCallMessage),
-                sharedSecret: sharedSecret,
+                sharedSecret: _sharedSecret,
                 keyPair: _keyPair,
                 uniqueCallKey: clientRpcContext.UniqueCallKey.ToByteArray());
 

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Concurrent;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreRemoting.Authentication;

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreRemoting.Authentication;
@@ -33,6 +35,7 @@ public sealed class RemotingSession : IAsyncDisposable
     private readonly RsaKeyPair _keyPair;
     private readonly int _keySize;
     private readonly Guid _sessionId;
+    private readonly byte[] _sharedSecret;
     private readonly byte[] _clientPublicKeyBlob;
     private readonly string _clientAddress;
     private readonly RemoteDelegateInvocationEventAggregator _remoteDelegateInvocationEventAggregator;
@@ -85,17 +88,16 @@ public sealed class RemotingSession : IAsyncDisposable
 
         MessageEncryption = clientPublicKey != null;
 
+        _sharedSecret = MessageEncryption ?
+            _server.Config.GenerateSharedKey() :
+            null;
+
         _remoteDelegateInvocationEventAggregator.RemoteDelegateInvocationNeeded +=
             async (_, uniqueCallKey, handlerKey, arguments) =>
             {
                 // handle graceful client disconnection
                 if (_isDisposing)
                     return;
-
-                var sharedSecret =
-                    MessageEncryption
-                        ? _sessionId.ToByteArray()
-                        : null;
 
                 var remoteDelegateInvocationMessage =
                     new RemoteDelegateInvocationMessage
@@ -110,7 +112,7 @@ public sealed class RemotingSession : IAsyncDisposable
                         .CreateWireMessage(
                             serializedMessage: _server.Serializer.Serialize(remoteDelegateInvocationMessage),
                             serializer: _server.Serializer,
-                            sharedSecret: sharedSecret,
+                            sharedSecret: _sharedSecret,
                             keyPair: _keyPair,
                             messageType: "invoke");
 
@@ -133,18 +135,27 @@ public sealed class RemotingSession : IAsyncDisposable
 
     internal async Task SendCompleteHandshakeMessageAsync()
     {
-        WireMessage completeHandshakeMessage;
+        var wireMessage = new WireMessage
+        {
+            MessageType = "complete_handshake",
+            Data = _server.Serializer.Serialize(new CompleteHandshakeMessage
+            {
+                AuthenticationRequired = _server.Config.AuthenticationRequired,
+                SessionId = _sessionId,
+                SharedSecret = _sharedSecret,
+            }),
+        };
 
         if (MessageEncryption)
         {
-            var encryptedSessionId =
+            var encryptedHandshakeMessage =
                 RsaKeyExchange.EncryptSecret(
                     keySize: _keySize,
                     receiversPublicKeyBlob: _clientPublicKeyBlob,
-                    secretToEncrypt: _sessionId.ToByteArray(),
+                    secretToEncrypt: wireMessage.Data,
                     sendersPublicKeyBlob: _keyPair.PublicKey);
 
-            var rawContent = _server.Serializer.Serialize(encryptedSessionId);
+            var rawContent = _server.Serializer.Serialize(encryptedHandshakeMessage);
 
             var signedMessageData =
                 new SignedMessageData
@@ -157,27 +168,11 @@ public sealed class RemotingSession : IAsyncDisposable
                             rawData: rawContent)
                 };
 
-            var rawData = _server.Serializer.Serialize(typeof(SignedMessageData), signedMessageData);
-
-            completeHandshakeMessage =
-                new WireMessage
-                {
-                    MessageType = "complete_handshake",
-                    Data = rawData
-                };
-        }
-        else
-        {
-            completeHandshakeMessage =
-                new WireMessage
-                {
-                    MessageType = "complete_handshake",
-                    Data = _sessionId.ToByteArray()
-                };
+            wireMessage.Data = _server.Serializer.Serialize(signedMessageData);
         }
 
         await (_rawMessageTransport?.SendMessageAsync(
-            _server.Serializer.Serialize(completeHandshakeMessage)))
+            _server.Serializer.Serialize(wireMessage)))
                 .ConfigureAwait(false);
     }
 
@@ -311,18 +306,13 @@ public sealed class RemotingSession : IAsyncDisposable
     /// <param name="request">Wire message from client</param>
     private async Task ProcessGoodbyeMessage(WireMessage request)
     {
-        var sharedSecret =
-            MessageEncryption
-                ? SessionId.ToByteArray()
-                : null;
-
         var goodbyeMessage =
             _server.Serializer
                 .Deserialize<GoodbyeMessage>(
                     _server.MessageEncryptionManager.GetDecryptedMessageData(
                         message: request,
                         serializer: _server.Serializer,
-                        sharedSecret: sharedSecret,
+                        sharedSecret: _sharedSecret,
                         sendersPublicKeyBlob: _clientPublicKeyBlob,
                         sendersPublicKeySize: _keyPair?.KeySize ?? 0));
 
@@ -335,7 +325,7 @@ public sealed class RemotingSession : IAsyncDisposable
                 serializedMessage: [],
                 serializer: _server.Serializer,
                 keyPair: _keyPair,
-                sharedSecret: sharedSecret,
+                sharedSecret: _sharedSecret,
                 uniqueCallKey: request.UniqueCallKey);
 
         await _rawMessageTransport.SendMessageAsync(
@@ -359,18 +349,13 @@ public sealed class RemotingSession : IAsyncDisposable
 
         Identity = null;
 
-        var sharedSecret =
-            MessageEncryption
-                ? SessionId.ToByteArray()
-                : null;
-
         var authRequestMessage =
             _server.Serializer
                 .Deserialize<AuthenticationRequestMessage>(
                     _server.MessageEncryptionManager.GetDecryptedMessageData(
                         message: request,
                         serializer: _server.Serializer,
-                        sharedSecret: sharedSecret,
+                        sharedSecret: _sharedSecret,
                         sendersPublicKeyBlob: _clientPublicKeyBlob,
                         sendersPublicKeySize: _keyPair?.KeySize ?? 0));
 
@@ -385,7 +370,7 @@ public sealed class RemotingSession : IAsyncDisposable
             _server.MessageEncryptionManager.CreateWireMessage(
                 serializedMessage: serializedAuthResponse,
                 serializer: _server.Serializer,
-                sharedSecret: sharedSecret,
+                sharedSecret: _sharedSecret,
                 keyPair: _keyPair,
                 messageType: "auth_response");
 
@@ -419,16 +404,11 @@ public sealed class RemotingSession : IAsyncDisposable
                 Session = this
             };
 
-        var sharedSecret =
-            MessageEncryption
-                ? SessionId.ToByteArray()
-                : null;
-
         var decryptedRawMessage =
             _server.MessageEncryptionManager.GetDecryptedMessageData(
                 message: request,
                 serializer: _server.Serializer,
-                sharedSecret: sharedSecret,
+                sharedSecret: _sharedSecret,
                 sendersPublicKeyBlob: _clientPublicKeyBlob,
                 sendersPublicKeySize: _keyPair?.KeySize ?? 0);
 
@@ -620,7 +600,7 @@ public sealed class RemotingSession : IAsyncDisposable
                 serializedMessage: serializedResult,
                 serializer: _server.Serializer,
                 error: serverRpcContext.Exception != null,
-                sharedSecret: sharedSecret,
+                sharedSecret: _sharedSecret,
                 keyPair: _keyPair,
                 messageType: "rpc_result",
                 uniqueCallKey: serverRpcContext.UniqueCallKey.ToByteArray());
@@ -883,16 +863,11 @@ public sealed class RemotingSession : IAsyncDisposable
             .ExpireMs(_server.Config.WaitTimeForCurrentlyProcessedMessagesOnDispose)
                 .ConfigureAwait(false);
 
-        var sharedSecret =
-            MessageEncryption
-                ? _sessionId.ToByteArray()
-                : null;
-
         var wireMessage =
             _server.MessageEncryptionManager.CreateWireMessage(
                 serializedMessage: [],
                 serializer: _server.Serializer,
-                sharedSecret: sharedSecret,
+                sharedSecret: _sharedSecret,
                 keyPair: _keyPair,
                 messageType: "session_closed");
 

--- a/CoreRemoting/RpcMessaging/CompleteHandshakeMessage.cs
+++ b/CoreRemoting/RpcMessaging/CompleteHandshakeMessage.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace CoreRemoting.RpcMessaging;
+
+/// <summary>
+/// Describes a message sent from server to client to complete the handshake.
+/// </summary>
+[DataContract]
+[Serializable]
+public class CompleteHandshakeMessage
+{
+    /// <summary>
+    /// Gets or sets the value indicating whether the authentication is required
+    /// </summary>
+    [DataMember]
+    public bool AuthenticationRequired { get; set; }
+
+    /// <summary>
+    /// Gets or sets the shared secret for symmetric encryption, if message encryption is enabled.
+    /// </summary>
+    [DataMember]
+    public byte[] SharedSecret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the session identity.
+    /// </summary>
+    [DataMember]
+    public Guid SessionId { get; set; }
+}

--- a/CoreRemoting/ServerConfig.cs
+++ b/CoreRemoting/ServerConfig.cs
@@ -39,6 +39,15 @@ public class ServerConfig
     public int KeySize { get; set; } = 4096;
 
     /// <summary>
+    /// Gets or sets the shared key size for the symmetric encryption (only relevant, if message encryption is enabled).
+    /// </summary>
+    /// <remarks>
+    /// Supported values: 128, 192 and 256 bits.
+    /// </remarks>
+    [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
+    public int SharedKeySize { get; set; } = 256;
+
+    /// <summary>
     /// Gets or sets whether messages should be encrypted or not.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]

--- a/CoreRemoting/SessionRepository.cs
+++ b/CoreRemoting/SessionRepository.cs
@@ -134,9 +134,9 @@ public class SessionRepository : ISessionRepository
     }
 
     /// <summary>
-    /// Gets a list of all sessions.
+    /// Gets a list of all sessions (used by unit tests).
     /// </summary>
-    public IEnumerable<RemotingSession> Sessions => _sessions.Values.ToArray();
+    internal IEnumerable<RemotingSession> Sessions => _sessions.Values.ToArray();
 
     /// <summary>
     /// Frees managed resources.

--- a/CoreRemoting/Toolbox/Extensions.cs
+++ b/CoreRemoting/Toolbox/Extensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Reflection;
+using System.Security.Cryptography;
 using CoreRemoting.Authentication;
 
 namespace CoreRemoting.Toolbox;
@@ -141,4 +142,16 @@ public static class Extensions
             .Where(x => x.value != null)
             .Select(x => new Credential { Name = x.p.Name, Value = x.value.ToString() })
             .ToArray());
+
+    /// <summary>
+    /// Generates strong shared key for symmetric encryption according to the server settings.
+    /// </summary>
+    /// <param name="config">Configuration data for the remoting server.</param>
+    public static byte[] GenerateSharedKey(this ServerConfig config)
+    {
+        using var rng = RandomNumberGenerator.Create();
+        var sharedKey = new byte[config.SharedKeySize / 8];
+        rng.GetBytes(sharedKey);
+        return sharedKey;
+    }
 }

--- a/CoreRemoting/Toolbox/NotImplementedAttribute.cs
+++ b/CoreRemoting/Toolbox/NotImplementedAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace CoreRemoting.Toolbox;
+
+/// <summary>
+/// Marks a partial class for automatic generation of interface members
+/// that throw <see cref="NotImplementedException"/>.
+/// Also marks generated members themselves.
+/// </summary>
+[AttributeUsage(NotImplementedAttribute.Targets, Inherited = false, AllowMultiple = false)]
+public sealed class NotImplementedAttribute : Attribute
+{
+    /// <summary>
+    /// Valid targets for this attribute: classes, methods, properties, and events.
+    /// </summary>
+    public const AttributeTargets Targets =
+        AttributeTargets.Class |
+        AttributeTargets.Method |
+        AttributeTargets.Property |
+        AttributeTargets.Event;
+}


### PR DESCRIPTION
1. Created a code generator project for updating legacy authentication providers.
Legacy authentication provides are automatically discovered and augmented, 
so they seamlessly compile and work as before:

```c#
partial class LegacyAuthenticationProvider : IAuthenticationProvider
{
    public bool Authenticate(Credential[] credentials, out RemotingIdentity id)
    {
        id = credentials.FindByName("login") != "root" ? null : new()
        {
            Name = "Administrator"
        };

        return id != null;
    }
}
```

2. Separated SharedKey from SessionId, added server configuration property:

```c#
public class ServerConfig
{
    public int SharedKeySize { get; set; } = 256;
}

// Extension method to generate the shared key:

public static byte[] GenerateSharedKey(this ServerConfig config)
{
    using var rng = RandomNumberGenerator.Create();
    var sharedKey = new byte[config.SharedKeySize / 8];
    rng.GetBytes(sharedKey);
    return sharedKey;
}

// ServerSession constructor uses extension method to generate the shared key:

_sharedSecret = MessageEncryption ?
    _server.Config.GenerateSharedKey() :  null;
```

3. Removed syncronous I/O from RemotingSession constructor
4. Added explicit CompleteHandshakeMessage.
5. Authentication required flag is taken from the server (sent within the handshake message).
6. As a bonus, added a code generator that emits missing interface members for unit test helper classes, i.e.:

```c#
// opt-in using this attribute
[NotImplemented]
partial class PartiallyImplementedService : ITestService
{
    public string Echo(string text) => text;
}

// ...all other members of ITestService and IBaseService are generated like this:
partial class PartiallyImplementedService
{
    object ITestService.TestMethod(object arg)
    {
        throw new NotImplementedException();
    }

    // etc. — useful for unit tests
}
```