### PR TITLE
J-PAKE authentication protocol

### DIFF
--- a/CoreRemoting.Authentication.JPake/CoreRemoting.Authentication.JPake.csproj
+++ b/CoreRemoting.Authentication.JPake/CoreRemoting.Authentication.JPake.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>CoreRemoting.Authentication</RootNamespace>
+        <AssemblyName>CoreRemoting.Authentication.JPake</AssemblyName>
+        <PackageVersion>1.2.2</PackageVersion>
+        <Authors>Alexey Yakovlev</Authors>
+        <Description>J-PAKE authentication provider for CoreRemoting</Description>
+        <Copyright>2026 Alexey Yakovlev</Copyright>
+        <PackageProjectUrl>https://github.com/theRainbird/CoreRemoting</PackageProjectUrl>
+        <PackageLicenseUrl></PackageLicenseUrl>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <Title>CoreRemoting.Authentication.LinuxPamAuthProvider</Title>
+        <RepositoryUrl>https://github.com/theRainbird/CoreRemoting.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>Remoting RPC Network Authentication J-PAKE</PackageTags>
+        <AssemblyVersion>1.2.2</AssemblyVersion>
+        <LangVersion>12</LangVersion>
+        <NoWarn>$(NoWarn),NU1701,NU1903</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CoreRemoting\CoreRemoting.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/CoreRemoting.Authentication.JPake/IJPakeAccount.cs
+++ b/CoreRemoting.Authentication.JPake/IJPakeAccount.cs
@@ -1,0 +1,17 @@
+﻿namespace CoreRemoting.Authentication.JPake;
+
+/// <summary>
+/// Represents a J-PAKE account with pre-shared password.
+/// </summary>
+public interface IJPakeAccount
+{
+    /// <summary>
+    /// Gets the name of the user.
+    /// </summary>
+    string UserName { get; }
+
+    /// <summary>
+    /// Gets the password.
+    /// </summary>
+    string Password { get; }
+}

--- a/CoreRemoting.Authentication.JPake/IJPakeAccountRepository.cs
+++ b/CoreRemoting.Authentication.JPake/IJPakeAccountRepository.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+
+namespace CoreRemoting.Authentication.JPake;
+
+/// <summary>
+/// Repository for J-PAKE accounts.
+/// </summary>
+public interface IJPakeAccountRepository
+{
+    /// <summary>
+    /// Finds the user account data by the given username.
+    /// </summary>
+    /// <param name="userName">Name of the user.</param>
+    Task<IJPakeAccount> FindByName(string userName);
+
+    /// <summary>
+    /// Gets the identity for the given user account.
+    /// </summary>
+    /// <param name="account">The account.</param>
+    Task<RemotingIdentity> GetIdentity(IJPakeAccount account);
+}

--- a/CoreRemoting.Authentication.JPake/JPakeAuthenticationProvider.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeAuthenticationProvider.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Org.BouncyCastle.Crypto.Agreement.JPake;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Security;
+using static CoreRemoting.Authentication.JPake.JPakeProtocolConstants;
+
+namespace CoreRemoting.Authentication.JPake;
+
+/// <summary>
+/// Server-side: authentication provider for the J-PAKE protocol.
+/// </summary>
+public class JPakeAuthenticationProvider : IAuthenticationProvider
+{
+    private readonly IJPakeAccountRepository _repository;
+    private readonly JPakePrimeOrderGroup _group;
+    private readonly SecureRandom _random;
+    private readonly string _unknownUserPassword;
+
+    internal ConcurrentDictionary<string, SessionData> PendingAuthentications { get; } = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JPakeAuthenticationProvider"/> class.
+    /// </summary>
+    /// <param name="repository">User account repository.</param>
+    /// <param name="group">Optional J-PAKE prime order group (should match client parameters).</param>
+    public JPakeAuthenticationProvider(IJPakeAccountRepository repository, JPakePrimeOrderGroup group = null)
+    {
+        _repository = repository;
+        _group = group ?? JPakePrimeOrderGroups.NIST_2048;
+        _random = new SecureRandom();
+        _unknownUserPassword = GenerateRandomPassword();
+    }
+
+    /// <summary>
+    /// Session data stored between J-PAKE rounds.
+    /// </summary>
+    internal class SessionData
+    {
+        public IJPakeAccount Account { get; set; }
+        public JPakeParticipant Participant { get; set; }
+    }
+
+    /// <inheritdoc/>
+    public async Task<AuthenticationResponseMessage> Authenticate(AuthenticationRequestMessage authRequest)
+    {
+        // Determine round by message content
+        if (authRequest[USERNAME] != null)
+            return await Round1(authRequest).ConfigureAwait(false);
+
+        if (authRequest[ROUND2_A] != null)
+            return Round2(authRequest);
+
+        if (authRequest[ROUND3_MAC] != null)
+            return await Round3(authRequest).ConfigureAwait(false);
+
+        // Invalid J-PAKE request
+        return Error();
+    }
+
+    private async Task<AuthenticationResponseMessage> Round1(AuthenticationRequestMessage authRequest)
+    {
+        var userName = authRequest[USERNAME];
+        var sessionId = authRequest[OPTIONAL_SESSION_ID] ?? RemotingSession.Current.SessionId.ToString();
+
+        // Find account or use fake password for non-existent users
+        var account = await _repository.FindByName(userName).ConfigureAwait(false);
+        var password = account != null
+            ? account.Password
+            : _unknownUserPassword;
+
+        // Create server's Round 1
+        var serverParticipant = new JPakeParticipant(PARTICIPANT_ID_SERVER, password.ToCharArray(), _group, new Sha256Digest(), _random);
+        var serverRound1 = serverParticipant.CreateRound1PayloadToSend();
+
+        // Process client's Round 1
+        var clientRound1 = new JPakeRound1Payload(
+            PARTICIPANT_ID_CLIENT,
+            JPakeSerializer.Deserialize(authRequest[ROUND1_GX1])[0],
+            JPakeSerializer.Deserialize(authRequest[ROUND1_GX2])[0],
+            JPakeSerializer.Deserialize(authRequest[ROUND1_PROOF_X1]),
+            JPakeSerializer.Deserialize(authRequest[ROUND1_PROOF_X2])
+        );
+
+        serverParticipant.ValidateRound1PayloadReceived(clientRound1);
+
+        // Save session data for subsequent rounds
+        PendingAuthentications[sessionId] = new SessionData
+        {
+            Account = account,
+            Participant = serverParticipant,
+        };
+
+        return new AuthenticationResponseMessage
+        {
+            IsCompleted = false,
+            IsAuthenticated = false,
+            Parameters =
+            [
+                new() { Name = ROUND1_GX1, Value = JPakeSerializer.Serialize(serverRound1.Gx1) },
+                new() { Name = ROUND1_GX2, Value = JPakeSerializer.Serialize(serverRound1.Gx2) },
+                new() { Name = ROUND1_PROOF_X1, Value = JPakeSerializer.Serialize(serverRound1.KnowledgeProofForX1) },
+                new() { Name = ROUND1_PROOF_X2, Value = JPakeSerializer.Serialize(serverRound1.KnowledgeProofForX2) },
+            ],
+        };
+    }
+
+    private AuthenticationResponseMessage Round2(AuthenticationRequestMessage authRequest)
+    {
+        var sessionId = authRequest[OPTIONAL_SESSION_ID] ?? RemotingSession.Current.SessionId.ToString();
+
+        // Session not found or expired
+        if (!PendingAuthentications.TryGetValue(sessionId, out var session))
+            return Error();
+
+        // Create server's Round 2
+        var serverRound2 = session.Participant.CreateRound2PayloadToSend();
+
+        // Process client's Round 2
+        var clientRound2 = new JPakeRound2Payload(
+            PARTICIPANT_ID_CLIENT,
+            JPakeSerializer.Deserialize(authRequest[ROUND2_A])[0],
+            JPakeSerializer.Deserialize(authRequest[ROUND2_PROOF_A])
+        );
+
+        try
+        {
+            session.Participant.ValidateRound2PayloadReceived(clientRound2);
+        }
+        catch (Exception)
+        {
+            // J-PAKE Round 2 validation failed
+            PendingAuthentications.TryRemove(sessionId, out _);
+            return Error();
+        }
+
+        return new AuthenticationResponseMessage
+        {
+            IsCompleted = false,
+            IsAuthenticated = false,
+            Parameters =
+            [
+                new() { Name = ROUND2_A, Value = JPakeSerializer.Serialize(serverRound2.A) },
+                new() { Name = ROUND2_PROOF_A, Value = JPakeSerializer.Serialize(serverRound2.KnowledgeProofForX2s) },
+            ],
+        };
+    }
+
+    private async Task<AuthenticationResponseMessage> Round3(AuthenticationRequestMessage authRequest)
+    {
+        var sessionId = authRequest[OPTIONAL_SESSION_ID] ?? RemotingSession.Current.SessionId.ToString();
+
+        // Session not found or expired
+        if (!PendingAuthentications.TryRemove(sessionId, out var session))
+            return Error();
+
+        // Calculate shared secret key
+        var keyingMaterial = session.Participant.CalculateKeyingMaterial();
+
+        // Create server's Round 3 (confirmation)
+        var serverRound3 = session.Participant.CreateRound3PayloadToSend(keyingMaterial);
+
+        // Process client's Round 3
+        var clientMacTag = JPakeSerializer.Deserialize(authRequest[ROUND3_MAC])[0];
+        var clientRound3 = new JPakeRound3Payload(
+            PARTICIPANT_ID_CLIENT,
+            clientMacTag);
+
+        try
+        {
+            session.Participant.ValidateRound3PayloadReceived(clientRound3, keyingMaterial);
+        }
+        catch (Exception)
+        {
+            return Error();
+        }
+
+        // Verify that account exists
+        if (session.Account == null)
+            return Error();
+
+        var identity = await _repository.GetIdentity(session.Account).ConfigureAwait(false);
+
+        var response = new AuthenticationResponseMessage
+        {
+            IsCompleted = true,
+            IsAuthenticated = true,
+            AuthenticatedIdentity = identity,
+            NegotiatedSharedKey = JPakeSerializer.DeriveSessionKey(keyingMaterial.ToByteArray()),
+            Parameters =
+            [
+                new() { Name = ROUND3_MAC, Value = JPakeSerializer.Serialize(serverRound3.MacTag) },
+            ],
+        };
+
+        return response;
+    }
+
+    /// <summary>
+    /// Generates a random password for unknown users to prevent user enumeration.
+    /// </summary>
+    private static string GenerateRandomPassword(int length = 32)
+    {
+        using var rng = RandomNumberGenerator.Create();
+        var bytesNeeded = (length * 3 + 3) / 4; // ceil(length * 3 / 4)
+        var bytes = new byte[bytesNeeded];
+        rng.GetBytes(bytes);
+        return Convert.ToBase64String(bytes).Substring(0, length);
+    }
+
+    private static AuthenticationResponseMessage Error(string message = "Authentication failed: bad password or user name") => new()
+    {
+        IsCompleted = true,
+        IsAuthenticated = false,
+        ErrorMessage = message,
+    };
+}

--- a/CoreRemoting.Authentication.JPake/JPakeAuthenticator.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeAuthenticator.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Security;
+using System.Threading.Tasks;
+using CoreRemoting.Toolbox;
+using Org.BouncyCastle.Crypto.Agreement.JPake;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Security;
+using static CoreRemoting.Authentication.JPake.JPakeProtocolConstants;
+
+namespace CoreRemoting.Authentication.JPake;
+
+/// <summary>
+/// Client-side: authentication using the J-PAKE protocol.
+/// </summary>
+public class JPakeAuthenticator : IAuthenticator
+{
+    private readonly JPakePrimeOrderGroup _group;
+    private readonly SecureRandom _random;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JPakeAuthenticator"/> class.
+    /// </summary>
+    /// <param name="group">Optional J-PAKE prime order group (should match server parameters).</param>
+    public JPakeAuthenticator(JPakePrimeOrderGroup group = null)
+    {
+        _group = group ?? JPakePrimeOrderGroups.NIST_2048;
+        _random = new SecureRandom();
+    }
+
+    /// <inheritdoc/>
+    public async Task<AuthenticationResponseMessage> Authenticate(Credential[] credentials, IAuthenticationProvider authProxy)
+    {
+        var userName = credentials.FindByName(USERNAME);
+        var password = credentials.FindByName(PASSWORD);
+        var sessionId = credentials.FindByName(OPTIONAL_SESSION_ID);
+
+        if (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password))
+            throw new InvalidOperationException("Username and password credentials are required for J-PAKE authentication.");
+
+        var participant = new JPakeParticipant(PARTICIPANT_ID_CLIENT, password.ToCharArray(), _group, new Sha256Digest(), _random);
+
+        // === Round 1 ===
+        // Client -> Server: gx1, gx2, proofX1, proofX2
+        var clientRound1 = participant.CreateRound1PayloadToSend();
+
+        var request1 = new AuthenticationRequestMessage
+        {
+            Credentials =
+            [
+                new() { Name = USERNAME, Value = userName },
+                new() { Name = ROUND1_GX1, Value = JPakeSerializer.Serialize(clientRound1.Gx1) },
+                new() { Name = ROUND1_GX2, Value = JPakeSerializer.Serialize(clientRound1.Gx2) },
+                new() { Name = ROUND1_PROOF_X1, Value = JPakeSerializer.Serialize(clientRound1.KnowledgeProofForX1) },
+                new() { Name = ROUND1_PROOF_X2, Value = JPakeSerializer.Serialize(clientRound1.KnowledgeProofForX2) },
+                new() { Name = OPTIONAL_SESSION_ID, Value = sessionId },
+            ],
+        };
+
+        // Server -> Client: gx3, gx4, proofX3, proofX4
+        var response1 = await authProxy.Authenticate(request1).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(response1.ErrorMessage))
+            throw new SecurityException(response1.ErrorMessage);
+
+        var serverRound1 = new JPakeRound1Payload(
+            PARTICIPANT_ID_SERVER,
+            JPakeSerializer.Deserialize(response1[ROUND1_GX1])[0],
+            JPakeSerializer.Deserialize(response1[ROUND1_GX2])[0],
+            JPakeSerializer.Deserialize(response1[ROUND1_PROOF_X1]),
+            JPakeSerializer.Deserialize(response1[ROUND1_PROOF_X2])
+        );
+
+        participant.ValidateRound1PayloadReceived(serverRound1);
+
+        // === Round 2 ===
+        // Client -> Server: A, proofA
+        var clientRound2 = participant.CreateRound2PayloadToSend();
+
+        var request2 = new AuthenticationRequestMessage
+        {
+            Credentials =
+            [
+                new() { Name = ROUND2_A, Value = JPakeSerializer.Serialize(clientRound2.A) },
+                new() { Name = ROUND2_PROOF_A, Value = JPakeSerializer.Serialize(clientRound2.KnowledgeProofForX2s) },
+                new() { Name = OPTIONAL_SESSION_ID, Value = sessionId },
+            ],
+        };
+
+        // Server -> Client: B, proofB
+        var response2 = await authProxy.Authenticate(request2).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(response2.ErrorMessage))
+            throw new SecurityException(response2.ErrorMessage);
+
+        var serverRound2 = new JPakeRound2Payload(
+            PARTICIPANT_ID_SERVER,
+            JPakeSerializer.Deserialize(response2[ROUND2_A])[0],
+            JPakeSerializer.Deserialize(response2[ROUND2_PROOF_A])
+        );
+
+        participant.ValidateRound2PayloadReceived(serverRound2);
+
+        // === Round 3 ===
+        // Client -> Server: MAC
+        var keyingMaterial = participant.CalculateKeyingMaterial();
+        var clientRound3 = participant.CreateRound3PayloadToSend(keyingMaterial);
+
+        var request3 = new AuthenticationRequestMessage
+        {
+            Credentials =
+            [
+                new() { Name = ROUND3_MAC, Value = JPakeSerializer.Serialize(clientRound3.MacTag) },
+                new() { Name = OPTIONAL_SESSION_ID, Value = sessionId },
+            ],
+        };
+
+        // Server -> Client: MAC + final response
+        var response3 = await authProxy.Authenticate(request3).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(response3.ErrorMessage))
+            throw new SecurityException(response3.ErrorMessage);
+
+        var serverMacTag = JPakeSerializer.Deserialize(response3[ROUND3_MAC])[0];
+        var serverRound3 = new JPakeRound3Payload(
+            PARTICIPANT_ID_SERVER,
+            serverMacTag);
+        participant.ValidateRound3PayloadReceived(serverRound3, keyingMaterial);
+
+        // Derive negotiated shared key
+        response3.NegotiatedSharedKey = JPakeSerializer.DeriveSessionKey(keyingMaterial.ToByteArray());
+        return response3;
+    }
+}

--- a/CoreRemoting.Authentication.JPake/JPakeProtocolConstants.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeProtocolConstants.cs
@@ -1,0 +1,29 @@
+﻿namespace CoreRemoting.Authentication.JPake;
+
+/// <summary>
+/// Protocol constants for J-PAKE message parameters.
+/// </summary>
+public class JPakeProtocolConstants
+{
+    // Participant identifiers
+    public const string PARTICIPANT_ID_CLIENT = "client";
+    public const string PARTICIPANT_ID_SERVER = "server";
+
+    // Message parameter names
+    public const string USERNAME = "I";
+    public const string PASSWORD = "P";
+    public const string OPTIONAL_SESSION_ID = "X";
+
+    // Round 1 parameters
+    public const string ROUND1_GX1 = "gx1";
+    public const string ROUND1_GX2 = "gx2";
+    public const string ROUND1_PROOF_X1 = "proofX1";
+    public const string ROUND1_PROOF_X2 = "proofX2";
+
+    // Round 2 parameters
+    public const string ROUND2_A = "A";
+    public const string ROUND2_PROOF_A = "proofA";
+
+    // Round 3 parameters
+    public const string ROUND3_MAC = "MAC";
+}

--- a/CoreRemoting.Authentication.JPake/JPakeSerializer.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeSerializer.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Org.BouncyCastle.Math;
+
+namespace CoreRemoting.Authentication.JPake;
+
+/// <summary>
+/// Helper for serializing and deserializing BigInteger values in J-PAKE protocol,
+/// and for deriving session keys from keying material.
+/// </summary>
+public static class JPakeSerializer
+{
+    /// <summary>
+    /// Serializes one or more BigInteger values to a Base64-encoded string.
+    /// </summary>
+    public static string Serialize(params BigInteger[] values)
+    {
+        if (values == null || values.Length == 0)
+            return string.Empty;
+
+        if (values.Any(v => v == null))
+            throw new ArgumentException("One or more BigInteger values are null.", nameof(values));
+
+        return string.Join(",", values.Select(v => Convert.ToBase64String(v.ToByteArray())));
+    }
+
+    /// <summary>
+    /// Deserializes a Base64-encoded string to an array of BigInteger values.
+    /// </summary>
+    public static BigInteger[] Deserialize(string serialized)
+    {
+        if (string.IsNullOrEmpty(serialized))
+            return Array.Empty<BigInteger>();
+
+        return serialized
+            .Split(',')
+            .Select(s => new BigInteger(Convert.FromBase64String(s)))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Derives a fixed-length session key from the J-PAKE keying material using HKDF-SHA256.
+    /// This ensures the negotiated shared key always has the correct length for AES encryption.
+    /// </summary>
+    /// <param name="keyingMaterial">Raw keying material from J-PAKE participant.CalculateKeyingMaterial().ToByteArray()</param>
+    /// <param name="length">Desired key length in bytes (default 32 for AES-256).</param>
+    public static byte[] DeriveSessionKey(byte[] keyingMaterial, int length = 32)
+    {
+        if (keyingMaterial == null || keyingMaterial.Length == 0)
+            throw new ArgumentException("Keying material is empty.", nameof(keyingMaterial));
+
+        if (length <= 0)
+            throw new ArgumentOutOfRangeException(nameof(length), "Key length must be positive.");
+
+        var info = Encoding.UTF8.GetBytes("JPake-SessionKey");
+        return HkdfSha256(keyingMaterial, info, length);
+    }
+
+    /// <summary>
+    /// HKDF implementation based on SHA-256, compatible with all .NET versions.
+    /// Compliant with RFC 5869.
+    /// </summary>
+    private static byte[] HkdfSha256(byte[] ikm, byte[] info, int length)
+    {
+        const int hashLen = 32; // SHA-256 output length
+
+        // Step 1: Extract — PRK = HMAC-SHA256(salt, IKM)
+        // If salt is not provided, use a string of HashLen zeros (RFC 5869, Section 2.2)
+        byte[] salt = new byte[hashLen];
+        byte[] prk;
+        using (var hmac = new HMACSHA256(salt))
+        {
+            prk = hmac.ComputeHash(ikm);
+        }
+
+        // Step 2: Expand — T(0) = empty, T(i) = HMAC-SHA256(PRK, T(i-1) || info || i)
+        int n = (length + hashLen - 1) / hashLen;
+        byte[] result = new byte[n * hashLen];
+        byte[] prev = Array.Empty<byte>();
+
+        using var hmac2 = new HMACSHA256(prk);
+        for (int i = 1; i <= n; i++)
+        {
+            var input = new byte[prev.Length + info.Length + 1];
+            Buffer.BlockCopy(prev, 0, input, 0, prev.Length);
+            Buffer.BlockCopy(info, 0, input, prev.Length, info.Length);
+            input[input.Length - 1] = (byte)i;
+
+            prev = hmac2.ComputeHash(input);
+            Buffer.BlockCopy(prev, 0, result, (i - 1) * hashLen, hashLen);
+        }
+
+        Array.Resize(ref result, length);
+        return result;
+    }
+}

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -53,6 +53,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\CoreRemoting.Authentication.JPake\CoreRemoting.Authentication.JPake.csproj" />
       <ProjectReference Include="..\CoreRemoting.Authentication.SecureRemotePassword\CoreRemoting.Authentication.SecureRemotePassword.csproj" />
       <ProjectReference Include="..\CoreRemoting.Channels.WebsocketSharp\CoreRemoting.Channels.WebsocketSharp.csproj" />
       <ProjectReference Include="..\CoreRemoting.Serialization.Binary\CoreRemoting.Serialization.Binary.csproj" />

--- a/CoreRemoting.Tests/Encryption/HkdfTests.cs
+++ b/CoreRemoting.Tests/Encryption/HkdfTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Xunit;
+
+namespace CoreRemoting.Tests.Encryption;
+
+public class HkdfTests
+{
+    [Fact]
+    public void DeriveKey_Sha256_Rfc5869_TestCase1()
+    {
+        // Arrange
+        var hkdf = Hkdf.Sha256;
+        byte[] ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        byte[] salt = HexToBytes("000102030405060708090a0b0c");
+        byte[] info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        int length = 42;
+
+        // Expected OKM from RFC 5869
+        byte[] expected = HexToBytes(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865");
+
+        // Act
+        byte[] result = hkdf.DeriveKey(ikm, length, salt, info);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DeriveKey_Sha512_Rfc5869_TestCase1()
+    {
+        // Arrange
+        var hkdf = Hkdf.Sha512;
+        byte[] ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        byte[] salt = HexToBytes("000102030405060708090a0b0c");
+        byte[] info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        int length = 42;
+
+        // Expected OKM (SHA-512 variant from community test vectors)
+        byte[] expected = HexToBytes(
+            "832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb");
+
+        // Act
+        byte[] result = hkdf.DeriveKey(ikm, length, salt, info);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    // Test Case 2 — longer inputs
+    [Fact]
+    public void DeriveKey_Sha256_Rfc5869_TestCase2()
+    {
+        var hkdf = Hkdf.Sha256;
+        byte[] ikm = HexToBytes(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f");
+        byte[] salt = HexToBytes(
+            "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+        byte[] info = HexToBytes(
+            "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+        int length = 82;
+
+        byte[] expected = HexToBytes(
+            "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca41db71ed4af2");
+
+        byte[] result = hkdf.DeriveKey(ikm, length, salt, info);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DeriveKey_WithNullSalt_Works()
+    {
+        var hkdf = Hkdf.Sha256;
+        byte[] ikm = new byte[] { 0x01, 0x02, 0x03 };
+
+        byte[] result = hkdf.DeriveKey(ikm, 16);
+
+        Assert.NotNull(result);
+        Assert.Equal(16, result.Length);
+    }
+
+    [Fact]
+    public void DeriveKey_WithNullInfo_Works()
+    {
+        var hkdf = Hkdf.Sha256;
+        byte[] ikm = new byte[] { 0x01, 0x02, 0x03 };
+        byte[] salt = new byte[32];
+
+        byte[] result = hkdf.DeriveKey(ikm, 16, salt);
+
+        Assert.NotNull(result);
+        Assert.Equal(16, result.Length);
+    }
+
+    [Fact]
+    public void DeriveKey_ThrowsOnEmptyIkm()
+    {
+        var hkdf = Hkdf.Sha256;
+
+        Assert.Throws<ArgumentException>(() => hkdf.DeriveKey(Array.Empty<byte>(), 16));
+        Assert.Throws<ArgumentException>(() => hkdf.DeriveKey(null, 16));
+    }
+
+    [Fact]
+    public void DeriveKey_ThrowsOnInvalidLength()
+    {
+        var hkdf = Hkdf.Sha256;
+        byte[] ikm = new byte[] { 0x01, 0x02, 0x03 };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => hkdf.DeriveKey(ikm, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => hkdf.DeriveKey(ikm, -1));
+    }
+
+    private static byte[] HexToBytes(string hex)
+    {
+        hex = hex.Replace(" ", "").Replace("\n", "").Replace("\r", "");
+        int length = hex.Length / 2;
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < length; i++)
+            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        return bytes;
+    }
+}

--- a/CoreRemoting.Tests/Encryption/HkdfTests.cs
+++ b/CoreRemoting.Tests/Encryption/HkdfTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Cryptography;
+using System.Text;
 using Xunit;
 
 namespace CoreRemoting.Tests.Encryption;
@@ -288,6 +289,134 @@ public class HkdfTests
         var actual = Hkdf.Sha256.DeriveKey(inkm, length, salt, info);
 
         Assert.Equal(expected, actual);
+    }
+
+    // Extension Methods: Guid salt + string info
+
+    /// <summary>
+    /// Guid salt is converted via <see cref="Guid.ToByteArray"/> and info is UTF-8 encoded.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_WithGuidSalt_AndStringInfo_Works()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = Guid.Parse("12345678-1234-1234-1234-123456789abc");
+        var info = "test-context";
+
+        var result = Hkdf.Sha256.DeriveKey(ikm, 32, salt, info);
+
+        Assert.NotNull(result);
+        Assert.Equal(32, result.Length);
+    }
+
+    /// <summary>
+    /// <see cref="Guid.Empty"/> is treated as an absent salt (equivalent to null byte[]).
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_EmptyGuid_EqualsNullSalt()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var info = "test-context";
+
+        var withEmptyGuid = Hkdf.Sha256.DeriveKey(ikm, 32, Guid.Empty, info);
+        var withNoSalt = Hkdf.Sha256.DeriveKey(ikm, 32, salt: null, info: Encoding.UTF8.GetBytes(info));
+
+        Assert.Equal(withNoSalt, withEmptyGuid);
+    }
+
+    /// <summary>
+    /// Extension with explicit Guid matches an explicit call with Guid.ToByteArray() and UTF-8 info.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_MatchesExplicitCall()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = Guid.Parse("12345678-1234-1234-1234-123456789abc");
+        var info = "my-context";
+
+        var extension = Hkdf.Sha256.DeriveKey(ikm, 32, salt, info);
+        var explicitCall = Hkdf.Sha256.DeriveKey(ikm, 32, salt.ToByteArray(), Encoding.UTF8.GetBytes(info));
+
+        Assert.Equal(explicitCall, extension);
+    }
+
+    // Extension Methods: string info only (no salt)
+
+    /// <summary>
+    /// Overload with only a string info produces a valid derived key.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_WithStringInfoOnly_Works()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var info = "session-context-v1";
+
+        var result = Hkdf.Sha256.DeriveKey(ikm, 32, info);
+
+        Assert.NotNull(result);
+        Assert.Equal(32, result.Length);
+    }
+
+    /// <summary>
+    /// String-info-only extension matches an explicit call with null salt and UTF-8 encoded info.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_StringInfoOnly_MatchesExplicitCall()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var info = "my-context";
+
+        var extension = Hkdf.Sha256.DeriveKey(ikm, 32, info);
+        var explicitCall = Hkdf.Sha256.DeriveKey(ikm, 32, null, Encoding.UTF8.GetBytes(info));
+
+        Assert.Equal(explicitCall, extension);
+    }
+
+    /// <summary>
+    /// Empty string info is treated the same as null (both map to empty byte array).
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_EmptyStringInfo_EqualsNullInfo()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+
+        var withNull = Hkdf.Sha256.DeriveKey(ikm, 32, (string)null);
+        var withEmpty = Hkdf.Sha256.DeriveKey(ikm, 32, "");
+
+        Assert.Equal(withNull, withEmpty);
+    }
+
+    // Extension Methods: null provider fallback
+
+    /// <summary>
+    /// Extension methods on a null provider fall back to <see cref="Hkdf.Default"/> (SHA-256).
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_NullProvider_UsesDefault()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        IHkdfProvider nullProvider = null;
+
+        var viaNull = nullProvider.DeriveKey(ikm, 32, "ctx");
+        var viaDefault = Hkdf.Default.DeriveKey(ikm, 32, "ctx");
+
+        Assert.Equal(viaDefault, viaNull);
+    }
+
+    /// <summary>
+    /// Extension with Guid on a null provider also falls back to <see cref="Hkdf.Default"/>.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Extension_WithGuid_NullProvider_UsesDefault()
+    {
+        var ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = Guid.NewGuid();
+        IHkdfProvider nullProvider = null;
+
+        var viaNull = nullProvider.DeriveKey(ikm, 32, salt, "ctx");
+        var viaDefault = Hkdf.Default.DeriveKey(ikm, 32, salt, "ctx");
+
+        Assert.Equal(viaDefault, viaNull);
     }
 
     // HashLength Property

--- a/CoreRemoting.Tests/Encryption/HkdfTests.cs
+++ b/CoreRemoting.Tests/Encryption/HkdfTests.cs
@@ -1,98 +1,208 @@
 ﻿using System;
+using System.Security.Cryptography;
 using Xunit;
 
 namespace CoreRemoting.Tests.Encryption;
 
+[Collection("CoreRemoting")]
 public class HkdfTests
 {
+    // RFC 5869 Test Vectors
+
+    /// <summary>
+    /// Source: RFC 5869 Appendix A.1 — Test Case 1 for SHA-256 (basic test with salt and info).
+    /// </summary>
     [Fact]
-    public void DeriveKey_Sha256_Rfc5869_TestCase1()
+    public void DeriveKey_Sha256_Rfc5869_ShortPayload()
     {
-        // Arrange
         var hkdf = Hkdf.Sha256;
-        byte[] ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
-        byte[] salt = HexToBytes("000102030405060708090a0b0c");
-        byte[] info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
-        int length = 42;
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 42;
 
-        // Expected OKM from RFC 5869
-        byte[] expected = HexToBytes(
-            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865");
-
-        // Act
-        byte[] result = hkdf.DeriveKey(ikm, length, salt, info);
-
-        // Assert
+        var expected = HexToBytes("3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865");
+        var result = hkdf.DeriveKey(inkm, length, salt, info);
         Assert.Equal(expected, result);
     }
 
+    /// <summary>
+    /// Source: RFC 5869 Appendix A.2 — Test Case 2 for SHA-256 (long inputs and outputs).
+    /// </summary>
     [Fact]
-    public void DeriveKey_Sha512_Rfc5869_TestCase1()
+    public void DeriveKey_Sha256_Rfc5869_LongPayload()
     {
-        // Arrange
+        var hkdf = Hkdf.Sha256;
+        var inkm = HexToBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f");
+        var salt = HexToBytes("606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+        var info = HexToBytes("b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+        var length = 82;
+
+        var expected = HexToBytes("b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87");
+        var result = hkdf.DeriveKey(inkm, length, salt, info);
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Source: RFC 5869 Appendix A.3 — Test Case 3 for SHA-256 (zero-length salt and info).
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Sha256_Rfc5869_EmptySaltAndInfo()
+    {
+        var hkdf = Hkdf.Sha256;
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var length = 42;
+
+        var expected = HexToBytes("8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8");
+        var result = hkdf.DeriveKey(inkm, length, Array.Empty<byte>(), Array.Empty<byte>());
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Source: OpenSSL evpkdf_hkdf.txt / Google Wycheproof hkdf_sha512_test.json —
+    /// equivalent of RFC 5869 Test Case 1 for SHA-512.
+    /// (RFC 5869 itself does not include SHA-512 test vectors.)
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Sha512_KnownVector()
+    {
         var hkdf = Hkdf.Sha512;
-        byte[] ikm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
-        byte[] salt = HexToBytes("000102030405060708090a0b0c");
-        byte[] info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
-        int length = 42;
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 42;
 
-        // Expected OKM (SHA-512 variant from community test vectors)
-        byte[] expected = HexToBytes(
-            "832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb");
-
-        // Act
-        byte[] result = hkdf.DeriveKey(ikm, length, salt, info);
-
-        // Assert
+        var expected = HexToBytes("832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb");
+        var result = hkdf.DeriveKey(inkm, length, salt, info);
         Assert.Equal(expected, result);
     }
 
-    // Test Case 2 — longer inputs
+    // Reference Implementation Comparison
+
+    /// <summary>
+    /// Bit-for-bit comparison with System.Security.Cryptography.HKDF (.NET 5+ reference implementation) for SHA-256.
+    /// </summary>
     [Fact]
-    public void DeriveKey_Sha256_Rfc5869_TestCase2()
+    public void DeriveKey_Sha256_MatchesBuiltInNetImplementation()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 42;
+
+        var expected = System.Security.Cryptography.HKDF.DeriveKey(
+            HashAlgorithmName.SHA256, inkm, length, salt, info);
+
+        var result = Hkdf.Sha256.DeriveKey(inkm, length, salt, info);
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Bit-for-bit comparison with System.Security.Cryptography.HKDF (.NET 5+ reference implementation) for SHA-384.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Sha384_MatchesBuiltInNetImplementation()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 48;
+
+        var expected = System.Security.Cryptography.HKDF.DeriveKey(
+            HashAlgorithmName.SHA384, inkm, length, salt, info);
+
+        var result = Hkdf.Sha384.DeriveKey(inkm, length, salt, info);
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Bit-for-bit comparison with System.Security.Cryptography.HKDF (.NET 5+ reference implementation) for SHA-512.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Sha512_MatchesBuiltInNetImplementation()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 64;
+
+        var expected = System.Security.Cryptography.HKDF.DeriveKey(
+            HashAlgorithmName.SHA512, inkm, length, salt, info);
+
+        var result = Hkdf.Sha512.DeriveKey(inkm, length, salt, info);
+        Assert.Equal(expected, result);
+    }
+
+    // RFC 5869 Default Behavior (null/empty semantics)
+
+    /// <summary>
+    /// Source: RFC 5869 Section 2.2 — if salt is not provided,
+    /// it is set to a string of HashLen zeros.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Sha256_NullSalt_UsesZerosOfHashLength()
     {
         var hkdf = Hkdf.Sha256;
-        byte[] ikm = HexToBytes(
-            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f");
-        byte[] salt = HexToBytes(
-            "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
-        byte[] info = HexToBytes(
-            "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
-        int length = 82;
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var length = 42;
 
-        byte[] expected = HexToBytes(
-            "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca41db71ed4af2");
+        var nullResult = hkdf.DeriveKey(inkm, length, null, Array.Empty<byte>());
+        var explicitZeros = hkdf.DeriveKey(inkm, length, new byte[hkdf.HashLength], Array.Empty<byte>());
 
-        byte[] result = hkdf.DeriveKey(ikm, length, salt, info);
-
-        Assert.Equal(expected, result);
+        Assert.Equal(explicitZeros, nullResult);
     }
 
+    /// <summary>
+    /// Source: RFC 5869 Section 2.3 — info is optional and defaults to empty byte array.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_Sha256_NullInfo_UsesEmptyArray()
+    {
+        var hkdf = Hkdf.Sha256;
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var length = 42;
+
+        var nullResult = hkdf.DeriveKey(inkm, length, salt, null);
+        var explicitEmpty = hkdf.DeriveKey(inkm, length, salt, Array.Empty<byte>());
+
+        Assert.Equal(explicitEmpty, nullResult);
+    }
+
+    /// <summary>
+    /// Source: RFC 5869 Section 2.2 — call with null salt and null info should succeed.
+    /// </summary>
     [Fact]
     public void DeriveKey_WithNullSalt_Works()
     {
         var hkdf = Hkdf.Sha256;
-        byte[] ikm = new byte[] { 0x01, 0x02, 0x03 };
-
-        byte[] result = hkdf.DeriveKey(ikm, 16);
+        var inkm = new byte[] { 0x01, 0x02, 0x03 };
+        var result = hkdf.DeriveKey(inkm, 16);
 
         Assert.NotNull(result);
         Assert.Equal(16, result.Length);
     }
 
+    /// <summary>
+    /// Source: RFC 5869 Section 2.3 — call with null info should succeed.
+    /// </summary>
     [Fact]
     public void DeriveKey_WithNullInfo_Works()
     {
         var hkdf = Hkdf.Sha256;
-        byte[] ikm = new byte[] { 0x01, 0x02, 0x03 };
-        byte[] salt = new byte[32];
-
-        byte[] result = hkdf.DeriveKey(ikm, 16, salt);
+        var inkm = new byte[] { 0x01, 0x02, 0x03 };
+        var salt = new byte[32];
+        var result = hkdf.DeriveKey(inkm, 16, salt);
 
         Assert.NotNull(result);
         Assert.Equal(16, result.Length);
     }
 
+    // Validation Tests
+
+    /// <summary>
+    /// Source: implementation contract — empty or null IKM must be rejected.
+    /// </summary>
     [Fact]
     public void DeriveKey_ThrowsOnEmptyIkm()
     {
@@ -102,23 +212,125 @@ public class HkdfTests
         Assert.Throws<ArgumentException>(() => hkdf.DeriveKey(null, 16));
     }
 
+    /// <summary>
+    /// Source: implementation contract — non-positive output length must be rejected.
+    /// </summary>
     [Fact]
     public void DeriveKey_ThrowsOnInvalidLength()
     {
         var hkdf = Hkdf.Sha256;
-        byte[] ikm = new byte[] { 0x01, 0x02, 0x03 };
+        var inkm = new byte[] { 0x01, 0x02, 0x03 };
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => hkdf.DeriveKey(ikm, 0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => hkdf.DeriveKey(ikm, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => hkdf.DeriveKey(inkm, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => hkdf.DeriveKey(inkm, -1));
     }
+
+    /// <summary>
+    /// Source: RFC 5869 Section 2.3 — OKM length must not exceed 255 * HashLen bytes.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_ExcessiveLength_ThrowsArgumentOutOfRangeException()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var maxLength = 255 * Hkdf.Sha256.HashLength;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Hkdf.Sha256.DeriveKey(inkm, maxLength + 1));
+    }
+
+    /// <summary>
+    /// Source: RFC 5869 Section 2.3 — boundary value 255 * HashLen must succeed.
+    /// </summary>
+    [Fact]
+    public void DeriveKey_MaximumAllowedLength_Works()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var maxLength = 255 * Hkdf.Sha256.HashLength;
+
+        var result = Hkdf.Sha256.DeriveKey(inkm, maxLength);
+        Assert.Equal(maxLength, result.Length);
+    }
+
+    // API Consistency
+
+    /// <summary>
+    /// Verifies that <see cref="Hkdf{THmac}.Provider"/> produces the same result
+    /// as the static <see cref="Hkdf{THmac}.DeriveKey"/> method.
+    /// </summary>
+    [Fact]
+    public void Provider_ProducesSameResultAsStaticMethod()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 42;
+
+        var expected = Hkdf.Sha256.DeriveKey(inkm, length, salt, info);
+        IHkdfProvider provider = new Hkdf<HMACSHA256>.Provider();
+        var actual = provider.DeriveKey(inkm, length, salt, info);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="Hkdf.Sha256"/> shortcut produces the same result
+    /// as the direct generic call <see cref="Hkdf{HMACSHA256}.DeriveKey"/>.
+    /// </summary>
+    [Fact]
+    public void Hkdf_Sha256_Shortcut_MatchesDirectCall()
+    {
+        var inkm = HexToBytes("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = HexToBytes("000102030405060708090a0b0c");
+        var info = HexToBytes("f0f1f2f3f4f5f6f7f8f9");
+        var length = 42;
+
+        var expected = Hkdf<HMACSHA256>.DeriveKey(inkm, length, salt, info);
+        var actual = Hkdf.Sha256.DeriveKey(inkm, length, salt, info);
+
+        Assert.Equal(expected, actual);
+    }
+
+    // HashLength Property
+
+    /// <summary>
+    /// Source: FIPS 180-4 — SHA-256 output size is 256 bits = 32 bytes.
+    /// </summary>
+    [Fact]
+    public void HashLength_Sha256_Returns32()
+    {
+        Assert.Equal(32, Hkdf.Sha256.HashLength);
+    }
+
+    /// <summary>
+    /// Source: FIPS 180-4 — SHA-384 output size is 384 bits = 48 bytes.
+    /// </summary>
+    [Fact]
+    public void HashLength_Sha384_Returns48()
+    {
+        Assert.Equal(48, Hkdf.Sha384.HashLength);
+    }
+
+    /// <summary>
+    /// Source: FIPS 180-4 — SHA-512 output size is 512 bits = 64 bytes.
+    /// </summary>
+    [Fact]
+    public void HashLength_Sha512_Returns64()
+    {
+        Assert.Equal(64, Hkdf.Sha512.HashLength);
+    }
+
+    // Helpers
 
     private static byte[] HexToBytes(string hex)
     {
+        if (string.IsNullOrWhiteSpace(hex))
+            return [];
+
         hex = hex.Replace(" ", "").Replace("\n", "").Replace("\r", "");
-        int length = hex.Length / 2;
-        byte[] bytes = new byte[length];
-        for (int i = 0; i < length; i++)
+        var bytes = new byte[hex.Length / 2];
+        for (var i = 0; i < bytes.Length; i++)
             bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+
         return bytes;
     }
 }

--- a/CoreRemoting.Tests/JPakeAuthenticationTests.cs
+++ b/CoreRemoting.Tests/JPakeAuthenticationTests.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Security;
+using System.Threading.Tasks;
+using CoreRemoting.Authentication;
+using CoreRemoting.Authentication.JPake;
+using Xunit;
+
+namespace CoreRemoting.Tests;
+
+using static JPakeProtocolConstants;
+
+public class JPakeAuthenticationTests : IAsyncLifetime
+{
+    private const string UserName = "bozo";
+    private const string Password = "h4ck3r";
+    private const int ServerPort = 9192;
+
+    private readonly SampleAccountRepository _repository = new();
+    private RemotingServer _server;
+
+    public async Task InitializeAsync()
+    {
+        _server = new RemotingServer(new()
+        {
+            HostName = "localhost",
+            NetworkPort = ServerPort,
+            MessageEncryption = false,
+            AuthenticationProvider = new JPakeAuthenticationProvider(_repository),
+            AuthenticationRequired = true,
+            RegisterServicesAction = container =>
+                container.RegisterService<ISampleService, SampleService>()
+        });
+
+        _server.Start();
+
+        await Task.Delay(100);
+    }
+
+    public Task DisposeAsync()
+    {
+        if (_server != null)
+        {
+            _server.Stop();
+            _server.Dispose();
+            _server = null;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task AuthenticationWithWrongPasswordFails()
+    {
+        var authProvider = new JPakeAuthenticationProvider(_repository);
+        var authenticator = new JPakeAuthenticator();
+
+        var credentials = new[]
+        {
+            new Credential { Name = USERNAME, Value = UserName },
+            new Credential { Name = PASSWORD, Value = Password + "1" },
+            new Credential { Name = OPTIONAL_SESSION_ID, Value = Guid.NewGuid().ToString() },
+        };
+
+        await Assert.ThrowsAsync<SecurityException>(async () =>
+            await authenticator.Authenticate(credentials, authProvider));
+    }
+
+    [Fact]
+    public async Task UnknownUsernameFailsToAuthenticate()
+    {
+        var authProvider = new JPakeAuthenticationProvider(_repository);
+        var authenticator = new JPakeAuthenticator();
+
+        // Attempt to authenticate with unknown user
+        // Provider uses a fake password, so authentication will fail at Round 3
+        var credentials = new[]
+        {
+            new Credential { Name = USERNAME, Value = UserName + "1" },
+            new Credential { Name = PASSWORD, Value = Password },
+            new Credential { Name = OPTIONAL_SESSION_ID, Value = Guid.NewGuid().ToString() },
+        };
+
+        // Expect SecurityException due to MAC mismatch in Round 3
+        await Assert.ThrowsAsync<SecurityException>(async () =>
+            await authenticator.Authenticate(credentials, authProvider));
+    }
+
+    [Fact]
+    public async Task AuthenticationProviderSetsAuthenticatedIdentity()
+    {
+        var authProvider = new JPakeAuthenticationProvider(_repository);
+        var authenticator = new JPakeAuthenticator();
+
+        var credentials = new[]
+        {
+            new Credential { Name = USERNAME, Value = UserName },
+            new Credential { Name = PASSWORD, Value = Password },
+            new Credential { Name = OPTIONAL_SESSION_ID, Value = Guid.NewGuid().ToString() },
+        };
+
+        // Full authentication via public API
+        var response = await authenticator.Authenticate(credentials, authProvider);
+
+        Assert.NotNull(response);
+        Assert.True(response.IsCompleted);
+        Assert.True(response.IsAuthenticated);
+        Assert.NotNull(response.AuthenticatedIdentity);
+        Assert.Equal(UserName, response.AuthenticatedIdentity.Name);
+        Assert.NotNull(response.NegotiatedSharedKey);
+
+        // Verify that the key has correct length (32 bytes for AES-256)
+        Assert.Equal(32, response.NegotiatedSharedKey.Length);
+    }
+
+    [Fact]
+    public async Task ValidLoginUsingTcpChannel()
+    {
+        using var client = CreateClient(UserName, Password);
+        await client.ConnectAsync();
+
+        var proxy = client.CreateProxy<ISampleService>();
+        var result = proxy.Echo("Hello");
+        Assert.Equal("Hello", result);
+
+        await client.DisposeAsync();
+
+        using var client2 = CreateClient(UserName, Password);
+        await client2.ConnectAsync();
+
+        var proxy2 = client2.CreateProxy<ISampleService>();
+        result = proxy2.Echo("World");
+        Assert.Equal("World", result);
+    }
+
+    [Fact]
+    public async Task InvalidLogin_NoAuthenticator()
+    {
+        using var client = new RemotingClient(new()
+        {
+            ServerHostName = "localhost",
+            ServerPort = ServerPort,
+            MessageEncryption = false
+        });
+
+        await Assert.ThrowsAsync<SecurityException>(client.ConnectAsync);
+    }
+
+    [Fact]
+    public async Task InvalidLogin_WrongUsername()
+    {
+        var client = CreateClient(UserName + "1", Password);
+        await Assert.ThrowsAsync<SecurityException>(client.ConnectAsync);
+    }
+
+    [Fact]
+    public async Task InvalidLogin_WrongPassword()
+    {
+        var client = CreateClient(UserName, Password + "1");
+        await Assert.ThrowsAsync<SecurityException>(client.ConnectAsync);
+    }
+
+    [Fact]
+    public async Task AuthenticationRound1WasNotPerformed()
+    {
+        var brokenAuthenticator = new BrokenJPakeAuthenticator();
+        var client = new RemotingClient(new()
+        {
+            ServerHostName = "localhost",
+            ServerPort = ServerPort,
+            MessageEncryption = false,
+            Authenticator = brokenAuthenticator
+        });
+
+        await Assert.ThrowsAsync<SecurityException>(client.ConnectAsync);
+    }
+
+    private RemotingClient CreateClient(string username, string password)
+    {
+        return new RemotingClient(new()
+        {
+            ServerHostName = "localhost",
+            ServerPort = ServerPort,
+            MessageEncryption = false,
+            Authenticator = new JPakeAuthenticator(),
+            Credentials =
+            [
+                new() { Name = USERNAME, Value = username },
+                new() { Name = PASSWORD, Value = password }
+            ]
+        });
+    }
+
+    private class SampleAccountRepository : IJPakeAccountRepository
+    {
+        private readonly JPakeAccount _sampleAccount;
+
+        public SampleAccountRepository()
+        {
+            _sampleAccount = new JPakeAccount
+            {
+                UserName = UserName,
+                Password = Password
+            };
+        }
+
+        public Task<IJPakeAccount> FindByName(string userName)
+        {
+            if (_sampleAccount.UserName == userName)
+                return Task.FromResult<IJPakeAccount>(_sampleAccount);
+
+            return Task.FromResult<IJPakeAccount>(null);
+        }
+
+        public Task<RemotingIdentity> GetIdentity(IJPakeAccount account)
+        {
+            return Task.FromResult(new RemotingIdentity
+            {
+                Name = account.UserName,
+                IsAuthenticated = true
+            });
+        }
+
+        private class JPakeAccount : IJPakeAccount
+        {
+            public string UserName { get; init; }
+            public string Password { get; init; }
+        }
+    }
+
+    public interface ISampleService
+    {
+        string Echo(string message);
+    }
+
+    public class SampleService : ISampleService
+    {
+        public string Echo(string message) => message;
+    }
+
+    private class BrokenJPakeAuthenticator : IAuthenticator
+    {
+        public async Task<AuthenticationResponseMessage> Authenticate(Credential[] credentials, IAuthenticationProvider authProxy)
+        {
+            // Skip Round 1, directly send Round 2 with fake data
+            await authProxy.Authenticate(new AuthenticationRequestMessage
+            {
+                Credentials =
+                [
+                    new() { Name = ROUND2_A, Value = "fake" },
+                    new() { Name = ROUND2_PROOF_A, Value = "fake" }
+                ]
+            });
+
+            return new();
+        }
+    }
+}

--- a/CoreRemoting.Tests/JPakeNegotiatedKeyTests.cs
+++ b/CoreRemoting.Tests/JPakeNegotiatedKeyTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreRemoting.Authentication;
+using CoreRemoting.Authentication.JPake;
+using CoreRemoting.DependencyInjection;
+using CoreRemoting.Tests.Tools;
+using Xunit;
+
+namespace CoreRemoting.Tests;
+
+using static JPakeProtocolConstants;
+
+[Collection("CoreRemoting")]
+public class JPakeNegotiatedKeyTests
+{
+    private const string UserName = "bozo";
+    private const string Password = "h4ck3r";
+
+    private const int ServerPort_Negotiated = 9203;
+
+    [Fact]
+    public async Task Client_and_server_should_rekey_session_with_jpake_key_after_authentication()
+    {
+        var serverErrorCount = 0;
+        Exception lastServerError = null;
+
+        var server = StartJPakeServer(
+            networkPort: ServerPort_Negotiated,
+            onServerError: (s, ex) =>
+            {
+                Interlocked.Increment(ref serverErrorCount);
+                lastServerError = ex;
+            });
+
+        try
+        {
+            using var client = CreateClient(ServerPort_Negotiated);
+
+            await client.ConnectAsync();
+
+            Assert.True(client.HasSession);
+            Assert.Single(server.SessionRepository.Sessions);
+
+            var session = server.SessionRepository.Sessions.Single();
+
+            // Server must have re-keyed the session with the J-PAKE derived key
+            Assert.NotNull(session.SharedSecret);
+            // J-PAKE with NIST_2048 produces a key of specific length (depends on hash used)
+            Assert.True(session.SharedSecret.Length > 0);
+            Assert.False(
+                session.SessionId.ToByteArray().SequenceEqual(session.SharedSecret),
+                "Re-keyed session must not use the session ID anymore");
+
+            // RPC with message encryption works after re-keying on both sides
+            var proxy = client.CreateProxy<ITestService>();
+            Assert.Equal("test", proxy.TestMethod("test"));
+        }
+        finally
+        {
+            await Task.Delay(500);
+
+            if (lastServerError != null)
+                throw new Exception($"Unexpected server error: {lastServerError}");
+
+            Assert.Equal(0, serverErrorCount);
+
+            server.Stop();
+        }
+    }
+
+    private static RemotingClient CreateClient(int serverPort) => new(new ClientConfig()
+    {
+        ConnectionTimeout = 0,
+        MessageEncryption = true,
+        KeySize = 1024,
+        ServerHostName = "localhost",
+        ServerPort = serverPort,
+        Authenticator = new JPakeAuthenticator(),
+        Credentials =
+        [
+            new() { Name = USERNAME, Value = UserName },
+            new() { Name = PASSWORD, Value = Password }
+        ]
+    });
+
+    private static RemotingServer StartJPakeServer(
+        int networkPort,
+        EventHandler<Exception> onServerError)
+    {
+        var config = new ServerConfig()
+        {
+            IsDefault = false,
+            UniqueServerInstanceName = $"JPakeNegotiatedKeyTestServer_{networkPort}",
+            MessageEncryption = true,
+            KeySize = 1024,
+            NetworkPort = networkPort,
+            AuthenticationRequired = true,
+            AuthenticationProvider = new JPakeAuthenticationProvider(new SampleAccountRepository()),
+            RegisterServicesAction = container =>
+            {
+                var testService = new TestService()
+                {
+                    TestMethodFake = arg => arg
+                };
+
+                container.RegisterService<ITestService>(
+                    factoryDelegate: () => testService,
+                    lifetime: ServiceLifetime.Singleton);
+            }
+        };
+
+        var server = new RemotingServer(config);
+        server.Error += onServerError;
+        server.Start();
+
+        var deadline = DateTime.Now.AddSeconds(10);
+        while (!server.Channel.IsListening && DateTime.Now < deadline)
+            Thread.Sleep(20);
+
+        if (!server.Channel.IsListening)
+            throw new Exception($"Server on port {networkPort} did not start listening in time.");
+
+        return server;
+    }
+
+    private class SampleAccountRepository : IJPakeAccountRepository
+    {
+        private readonly JPakeAccount _sampleAccount;
+
+        public SampleAccountRepository()
+        {
+            _sampleAccount = new JPakeAccount
+            {
+                UserName = UserName,
+                Password = Password
+            };
+        }
+
+        public Task<IJPakeAccount> FindByName(string userName)
+        {
+            if (_sampleAccount.UserName == userName)
+                return Task.FromResult<IJPakeAccount>(_sampleAccount);
+
+            return Task.FromResult<IJPakeAccount>(null);
+        }
+
+        public Task<RemotingIdentity> GetIdentity(IJPakeAccount account)
+        {
+            return Task.FromResult(new RemotingIdentity
+            {
+                Name = account.UserName,
+                IsAuthenticated = true
+            });
+        }
+
+        private class JPakeAccount : IJPakeAccount
+        {
+            public string UserName { get; init; }
+            public string Password { get; init; }
+        }
+    }
+}

--- a/CoreRemoting.Tests/SourceGeneratorTests.cs
+++ b/CoreRemoting.Tests/SourceGeneratorTests.cs
@@ -31,14 +31,14 @@ public partial class SourceGeneratorTests
     {
         var type = typeof(LegacyAuthenticationProvider);
 
-        // ñheck that the new method exists with the correct signature
+        // check that the new method exists with the correct signature
         var newMethod = type.GetMethod(
             nameof(IAuthenticationProvider.Authenticate),
             [typeof(AuthenticationRequestMessage)]);
         Assert.NotNull(newMethod);
         Assert.Equal(typeof(Task<AuthenticationResponseMessage>), newMethod.ReturnType);
 
-        // ñheck that it has the GeneratedCode attribute
+        // check that it has the GeneratedCode attribute
         var generatedCodeAttr = newMethod.GetCustomAttribute<GeneratedCodeAttribute>();
         Assert.NotNull(generatedCodeAttr);
 

--- a/CoreRemoting.sln
+++ b/CoreRemoting.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreRemoting.Authentication
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreRemoting.SourceGenerators", "CoreRemoting.SourceGenerators\CoreRemoting.SourceGenerators.csproj", "{ED33D1F0-B563-851A-5E43-77347CB5D4C6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreRemoting.Authentication.JPake", "CoreRemoting.Authentication.JPake\CoreRemoting.Authentication.JPake.csproj", "{6B6C4E5B-4FD7-4DA1-2F7D-3B0502983C19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,10 @@ Global
 		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED33D1F0-B563-851A-5E43-77347CB5D4C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B6C4E5B-4FD7-4DA1-2F7D-3B0502983C19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B6C4E5B-4FD7-4DA1-2F7D-3B0502983C19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B6C4E5B-4FD7-4DA1-2F7D-3B0502983C19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B6C4E5B-4FD7-4DA1-2F7D-3B0502983C19}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CoreRemoting/Encryption/AesEncryption.cs
+++ b/CoreRemoting/Encryption/AesEncryption.cs
@@ -2,112 +2,111 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
-namespace CoreRemoting.Encryption
+namespace CoreRemoting.Encryption;
+
+/// <summary>
+/// Provides methods to implement symmetric AES encryption.
+/// </summary>
+public static class AesEncryption
 {
     /// <summary>
-    /// Provides methods to implement symmetric AES encryption.
+    /// Creates a SHA-256 hash of a specified value.
     /// </summary>
-    public static class AesEncryption
+    /// <param name="value">Value to be hashed</param>
+    /// <returns>SHA-256 hash</returns>
+    public static byte[] CreateHash(byte[] value)
     {
-        /// <summary>
-        /// Creates a SHA-256 hash of a specified value.
-        /// </summary>
-        /// <param name="value">Value to be hashed</param>
-        /// <returns>SHA-256 hash</returns>
-        public static byte[] CreateHash(byte[] value)
-        {
-            return SHA256.Create().ComputeHash(value);
-        }
+        return SHA256.Create().ComputeHash(value);
+    }
 
-        /// <summary>
-        /// Generates an initialization vector.
-        /// </summary>
-        /// <returns>Initialization vector</returns>
-        /// <exception cref="NotSupportedException">Thrown if AES is not supported by the current system environment</exception>
-        public static byte[] GenerateIv()
-        {
-            using var aes = Aes.Create();
-            
-            if (aes == null)
-                throw new NotSupportedException();
+    /// <summary>
+    /// Generates an initialization vector.
+    /// </summary>
+    /// <returns>Initialization vector</returns>
+    /// <exception cref="NotSupportedException">Thrown if AES is not supported by the current system environment</exception>
+    public static byte[] GenerateIv()
+    {
+        using var aes = Aes.Create();
 
-            aes.Mode = CipherMode.CBC;
-            aes.Padding = PaddingMode.PKCS7;
-            aes.GenerateIV();
-            
-            return aes.IV;
-        }
+        if (aes == null)
+            throw new NotSupportedException();
 
-        /// <summary>
-        /// Encrypts raw data with AES.
-        /// </summary>
-        /// <param name="dataToEncrypt">Raw data to encrypt</param>
-        /// <param name="sharedSecret">Shared secret</param>
-        /// <param name="iv">Initialization vector</param>
-        /// <returns>Encrypted data</returns>
-        /// <exception cref="NotSupportedException">Thrown if AES is not supported by the current system environment</exception>
-        public static byte[] Encrypt(byte[] dataToEncrypt, byte[] sharedSecret, byte[] iv)
-        {
-            using var aes = Aes.Create();
-            
-            if (aes == null)
-                throw new NotSupportedException();
-            
-            aes.Key = CreateHash(sharedSecret);
-            aes.IV = iv;
-            aes.Mode = CipherMode.CBC;
-            aes.Padding = PaddingMode.PKCS7;
-  
-            var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+        aes.GenerateIV();
 
-            using var memoryStream = new MemoryStream();
-            using var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write);
-            
-            cryptoStream.Write(dataToEncrypt, 0, dataToEncrypt.Length);
-            cryptoStream.FlushFinalBlock();
-            
-            var encryptedData = memoryStream.ToArray();
+        return aes.IV;
+    }
 
-            cryptoStream.Close();
-            memoryStream.Close();
-            
-            return encryptedData;
-        }
+    /// <summary>
+    /// Encrypts raw data with AES.
+    /// </summary>
+    /// <param name="dataToEncrypt">Raw data to encrypt</param>
+    /// <param name="sharedSecret">Shared secret</param>
+    /// <param name="iv">Initialization vector</param>
+    /// <returns>Encrypted data</returns>
+    /// <exception cref="NotSupportedException">Thrown if AES is not supported by the current system environment</exception>
+    public static byte[] Encrypt(byte[] dataToEncrypt, byte[] sharedSecret, byte[] iv)
+    {
+        using var aes = Aes.Create();
 
-        /// <summary>
-        /// Decrypts raw data with AES.
-        /// </summary>
-        /// <param name="encryptedData">Encrypted raw data</param>
-        /// <param name="sharedSecret">Shared secret</param>
-        /// <param name="iv">Initialization vector</param>
-        /// <returns>Decrypted raw data</returns>
-        /// <exception cref="NotSupportedException">Thrown if AES is not supported by the current system environment</exception>
-        public static byte[] Decrypt(byte[] encryptedData, byte[] sharedSecret, byte[] iv)
-        {
-            using Aes aes = Aes.Create();
-            
-            if (aes == null)
-                throw new NotSupportedException();
-            
-            aes.Key = CreateHash(sharedSecret);
-            aes.IV = iv;
-            aes.Mode = CipherMode.CBC;
-            aes.Padding = PaddingMode.PKCS7;
-            
-            var decryptor = aes.CreateDecryptor(aes.Key, aes.IV);
+        if (aes == null)
+            throw new NotSupportedException();
 
-            using var memoryStream = new MemoryStream(encryptedData);
-            using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
-            using var decryptedStream = new MemoryStream();
-            
-            cryptoStream.CopyTo(decryptedStream);
-            byte[] decryptedBytes = decryptedStream.ToArray();
-            
-            cryptoStream.Close();
-            memoryStream.Close();
-            decryptedStream.Close();
-            
-            return decryptedBytes;
-        }
+        aes.Key = CreateHash(sharedSecret);
+        aes.IV = iv;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+
+        var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+
+        using var memoryStream = new MemoryStream();
+        using var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write);
+
+        cryptoStream.Write(dataToEncrypt, 0, dataToEncrypt.Length);
+        cryptoStream.FlushFinalBlock();
+
+        var encryptedData = memoryStream.ToArray();
+
+        cryptoStream.Close();
+        memoryStream.Close();
+
+        return encryptedData;
+    }
+
+    /// <summary>
+    /// Decrypts raw data with AES.
+    /// </summary>
+    /// <param name="encryptedData">Encrypted raw data</param>
+    /// <param name="sharedSecret">Shared secret</param>
+    /// <param name="iv">Initialization vector</param>
+    /// <returns>Decrypted raw data</returns>
+    /// <exception cref="NotSupportedException">Thrown if AES is not supported by the current system environment</exception>
+    public static byte[] Decrypt(byte[] encryptedData, byte[] sharedSecret, byte[] iv)
+    {
+        using Aes aes = Aes.Create();
+
+        if (aes == null)
+            throw new NotSupportedException();
+
+        aes.Key = CreateHash(sharedSecret);
+        aes.IV = iv;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+
+        var decryptor = aes.CreateDecryptor(aes.Key, aes.IV);
+
+        using var memoryStream = new MemoryStream(encryptedData);
+        using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
+        using var decryptedStream = new MemoryStream();
+
+        cryptoStream.CopyTo(decryptedStream);
+        byte[] decryptedBytes = decryptedStream.ToArray();
+
+        cryptoStream.Close();
+        memoryStream.Close();
+        decryptedStream.Close();
+
+        return decryptedBytes;
     }
 }

--- a/CoreRemoting/Encryption/EncryptedSecret.cs
+++ b/CoreRemoting/Encryption/EncryptedSecret.cs
@@ -1,46 +1,45 @@
 using System;
 
-namespace CoreRemoting.Encryption
+namespace CoreRemoting.Encryption;
+
+/// <summary>
+/// Describes an encrypted secret.
+/// </summary>
+[Serializable]
+public class EncryptedSecret
 {
     /// <summary>
-    /// Describes an encrypted secret.
+    /// Creates a new instance of the EncryptedSecret class.
     /// </summary>
-    [Serializable]
-    public class EncryptedSecret
+    /// <param name="encryptedSessionKey">Encrypted session key</param>
+    /// <param name="iv">Initialization vector</param>
+    /// <param name="encryptedMessage">Encrypted message</param>
+    /// <param name="sendersPublicKeyBlob">Public key of the sender</param>
+    public EncryptedSecret(byte[] encryptedSessionKey, byte[] iv, byte[] encryptedMessage, byte[] sendersPublicKeyBlob)
     {
-        /// <summary>
-        /// Creates a new instance of the EncryptedSecret class.
-        /// </summary>
-        /// <param name="encryptedSessionKey">Encrypted session key</param>
-        /// <param name="iv">Initialization vector</param>
-        /// <param name="encryptedMessage">Encrypted message</param>
-        /// <param name="sendersPublicKeyBlob">Public key of the sender</param>
-        public EncryptedSecret(byte[] encryptedSessionKey, byte[] iv, byte[] encryptedMessage, byte[] sendersPublicKeyBlob)
-        {
-            Iv = iv;
-            EncryptedMessage = encryptedMessage;
-            EncryptedSessionKey = encryptedSessionKey;
-            SendersPublicKeyBlob = sendersPublicKeyBlob;
-        }
-        
-        /// <summary>
-        /// Gets the encrypted session key.
-        /// </summary>
-        public byte[] EncryptedSessionKey { get; private set; }
-        
-        /// <summary>
-        /// Gets the encrypted message.
-        /// </summary>
-        public byte[] EncryptedMessage { get; private set; }
-        
-        /// <summary>
-        /// Gets the initialization vector.
-        /// </summary>
-        public byte[] Iv { get; private set; }
-        
-        /// <summary>
-        /// Gets the public key of the sender.
-        /// </summary>
-        public byte[] SendersPublicKeyBlob { get; private set; }
+        Iv = iv;
+        EncryptedMessage = encryptedMessage;
+        EncryptedSessionKey = encryptedSessionKey;
+        SendersPublicKeyBlob = sendersPublicKeyBlob;
     }
+
+    /// <summary>
+    /// Gets the encrypted session key.
+    /// </summary>
+    public byte[] EncryptedSessionKey { get; private set; }
+
+    /// <summary>
+    /// Gets the encrypted message.
+    /// </summary>
+    public byte[] EncryptedMessage { get; private set; }
+
+    /// <summary>
+    /// Gets the initialization vector.
+    /// </summary>
+    public byte[] Iv { get; private set; }
+
+    /// <summary>
+    /// Gets the public key of the sender.
+    /// </summary>
+    public byte[] SendersPublicKeyBlob { get; private set; }
 }

--- a/CoreRemoting/Encryption/Hkdf.cs
+++ b/CoreRemoting/Encryption/Hkdf.cs
@@ -1,0 +1,32 @@
+﻿using System.Security.Cryptography;
+
+/// <summary>
+/// Provides ready-to-use <see cref="IHkdfProvider"/> instances for common HMAC algorithms.
+/// </summary>
+public static class Hkdf
+{
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA256.
+    /// </summary>
+    public static IHkdfProvider Sha256 { get; } = new Hkdf<HMACSHA256>.Provider();
+
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA384.
+    /// </summary>
+    public static IHkdfProvider Sha384 { get; } = new Hkdf<HMACSHA384>.Provider();
+
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA512.
+    /// </summary>
+    public static IHkdfProvider Sha512 { get; } = new Hkdf<HMACSHA512>.Provider();
+
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA1. Provided for legacy scenarios only.
+    /// </summary>
+    public static IHkdfProvider Sha1 { get; } = new Hkdf<HMACSHA1>.Provider();
+
+    /// <summary>
+    /// Default HKDF provider (currently <see cref="Sha256"/>).
+    /// </summary>
+    public static IHkdfProvider Default => Sha256;
+}

--- a/CoreRemoting/Encryption/Hkdf.cs
+++ b/CoreRemoting/Encryption/Hkdf.cs
@@ -1,7 +1,10 @@
-﻿using System.Security.Cryptography;
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
 
 /// <summary>
-/// Provides ready-to-use <see cref="IHkdfProvider"/> instances for common HMAC algorithms.
+/// Provides ready-to-use <see cref="IHkdfProvider"/> instances for common HMAC algorithms,
+/// as well as extension methods for convenient key derivation.
 /// </summary>
 public static class Hkdf
 {
@@ -25,8 +28,58 @@ public static class Hkdf
     /// </summary>
     public static IHkdfProvider Sha1 { get; } = new Hkdf<HMACSHA1>.Provider();
 
+#if NET8_0_OR_GREATER
+
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA3-256.
+    /// </summary>
+    public static IHkdfProvider Sha3_256 { get; } = new Hkdf<HMACSHA3_256>.Provider();
+
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA3-384.
+    /// </summary>
+    public static IHkdfProvider Sha3_384 { get; } = new Hkdf<HMACSHA3_384>.Provider();
+
+    /// <summary>
+    /// HKDF provider based on HMAC-SHA3-512.
+    /// </summary>
+    public static IHkdfProvider Sha3_512 { get; } = new Hkdf<HMACSHA3_512>.Provider();
+
+#endif
+
     /// <summary>
     /// Default HKDF provider (currently <see cref="Sha256"/>).
     /// </summary>
-    public static IHkdfProvider Default => Sha256;
+    public static IHkdfProvider Default => Sha512;
+
+    // Extension Methods
+
+    /// <summary>
+    /// Derives a key using a <see cref="Guid"/> as salt (encoded via <see cref="Guid.ToByteArray()"/>)
+    /// and a UTF-8 encoded string as info. If <paramref name="hkdf"/> is null,
+    /// <see cref="Default"/> is used. <see cref="Guid.Empty"/> and null/empty info
+    /// are treated as absent.
+    /// </summary>
+    public static byte[] DeriveKey(this IHkdfProvider hkdf,
+        byte[] ikm, int outputLength, Guid salt, string info = null)
+    {
+        hkdf ??= Default;
+
+        var saltBytes = salt == Guid.Empty ? null : salt.ToByteArray();
+        var infoBytes = string.IsNullOrEmpty(info) ? null : Encoding.UTF8.GetBytes(info);
+        return hkdf.DeriveKey(ikm, outputLength, saltBytes, infoBytes);
+    }
+
+    /// <summary>
+    /// Derives a key without salt, using a UTF-8 encoded string as info.
+    /// If <paramref name="hkdf"/> is null, <see cref="Default"/> is used.
+    /// </summary>
+    public static byte[] DeriveKey(this IHkdfProvider hkdf,
+        byte[] ikm, int outputLength, string info)
+    {
+        hkdf ??= Default;
+
+        var infoBytes = string.IsNullOrEmpty(info) ? null : Encoding.UTF8.GetBytes(info);
+        return hkdf.DeriveKey(ikm, outputLength, null, infoBytes);
+    }
 }

--- a/CoreRemoting/Encryption/HkdfHmac.cs
+++ b/CoreRemoting/Encryption/HkdfHmac.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Security.Cryptography;
+
+/// <summary>
+/// HKDF (RFC 5869) implementation parameterized by HMAC type.
+/// </summary>
+/// <typeparam name="THmac">HMAC algorithm type (e.g. <see cref="HMACSHA256"/>, <see cref="HMACSHA512"/>).</typeparam>
+public static class Hkdf<THmac> where THmac : HMAC, new()
+{
+    /// <summary>
+    /// Gets the hash output length in bytes for the configured HMAC algorithm.
+    /// </summary>
+    public static int HashLength { get; } = GetHashLength();
+
+    private static int GetHashLength()
+    {
+        using var hmac = new THmac();
+        var len = hmac.HashSize / 8;
+        if (len <= 0)
+            throw new NotSupportedException($"{typeof(THmac).Name} has invalid HashSize.");
+        return len;
+    }
+
+    /// <summary>
+    /// Derives a key of the specified length from the input keying material.
+    /// </summary>
+    /// <param name="ikm">Input keying material.</param>
+    /// <param name="outputLength">Required key length in bytes.</param>
+    /// <param name="salt">Optional salt (defaults to zero-filled array of <see cref="HashLength"/>).</param>
+    /// <param name="info">Optional context and application-specific information.</param>
+    /// <returns>Derived key of the requested length.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="ikm"/> is null or empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="outputLength"/> is non-positive or exceeds 255 * <see cref="HashLength"/>.</exception>
+    public static byte[] DeriveKey(byte[] ikm, int outputLength, byte[] salt = null, byte[] info = null)
+    {
+        if (ikm == null || ikm.Length == 0)
+            throw new ArgumentException("IKM cannot be null or empty.", nameof(ikm));
+        if (outputLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outputLength), "Length must be positive.");
+        if (outputLength > 255 * HashLength)
+            throw new ArgumentOutOfRangeException(nameof(outputLength), $"Maximum length is {255 * HashLength} bytes.");
+
+        salt ??= new byte[HashLength];
+        info ??= Array.Empty<byte>();
+
+        // Extract: PRK = HMAC-Hash(salt, IKM)
+        byte[] prk;
+        using (var hmac = new THmac { Key = salt })
+        {
+            prk = hmac.ComputeHash(ikm);
+        }
+
+        // Expand: OKM = T(1) || T(2) || ... || T(N)
+        var n = (outputLength + HashLength - 1) / HashLength;
+        var result = new byte[n * HashLength];
+        var prev = Array.Empty<byte>();
+
+        using (var hmac = new THmac { Key = prk })
+        {
+            for (var i = 1; i <= n; i++)
+            {
+                var input = new byte[prev.Length + info.Length + 1];
+                Buffer.BlockCopy(prev, 0, input, 0, prev.Length);
+                Buffer.BlockCopy(info, 0, input, prev.Length, info.Length);
+                input[input.Length - 1] = (byte)i;
+
+                prev = hmac.ComputeHash(input);
+                Buffer.BlockCopy(prev, 0, result, (i - 1) * HashLength, HashLength);
+            }
+        }
+
+        Array.Resize(ref result, outputLength);
+        return result;
+    }
+
+    /// <summary>
+    /// Provides an <see cref="IHkdfProvider"/> implementation backed by <see cref="Hkdf{THmac}"/>.
+    /// </summary>
+    public sealed class Provider : IHkdfProvider
+    {
+        /// <inheritdoc/>
+        public int HashLength => Hkdf<THmac>.HashLength;
+
+        /// <inheritdoc/>
+        public byte[] DeriveKey(byte[] ikm, int outputLength, byte[] salt = null, byte[] info = null) =>
+            Hkdf<THmac>.DeriveKey(ikm, outputLength, salt, info);
+    }
+}

--- a/CoreRemoting/Encryption/HkdfHmac.cs
+++ b/CoreRemoting/Encryption/HkdfHmac.cs
@@ -41,7 +41,7 @@ public static class Hkdf<THmac> where THmac : HMAC, new()
             throw new ArgumentOutOfRangeException(nameof(outputLength), $"Maximum length is {255 * HashLength} bytes.");
 
         salt ??= new byte[HashLength];
-        info ??= Array.Empty<byte>();
+        info ??= [];
 
         // Extract: PRK = HMAC-Hash(salt, IKM)
         byte[] prk;

--- a/CoreRemoting/Encryption/IHkdfProvider.cs
+++ b/CoreRemoting/Encryption/IHkdfProvider.cs
@@ -1,0 +1,20 @@
+﻿/// <summary>
+/// Interface for HKDF (RFC 5869) key derivation providers.
+/// </summary>
+public interface IHkdfProvider
+{
+    /// <summary>
+    /// Gets the hash output length in bytes.
+    /// </summary>
+    int HashLength { get; }
+
+    /// <summary>
+    /// Derives a key of the specified length from the input keying material.
+    /// </summary>
+    /// <param name="ikm">Input keying material.</param>
+    /// <param name="outputLength">Required key length in bytes.</param>
+    /// <param name="salt">Optional salt (defaults to zero-filled array of <see cref="HashLength"/>).</param>
+    /// <param name="info">Optional context and application-specific information.</param>
+    /// <returns>Derived key of the requested length.</returns>
+    byte[] DeriveKey(byte[] ikm, int outputLength, byte[] salt = null, byte[] info = null);
+}

--- a/CoreRemoting/Encryption/RsaKeyExchange.cs
+++ b/CoreRemoting/Encryption/RsaKeyExchange.cs
@@ -1,73 +1,72 @@
 using System.Security.Cryptography;
 using System.IO;
 
-namespace CoreRemoting.Encryption
+namespace CoreRemoting.Encryption;
+
+/// <summary>
+/// Provides methods to perform a RSA key exchange.
+/// </summary>
+public static class RsaKeyExchange
 {
     /// <summary>
-    /// Provides methods to perform a RSA key exchange.
+    /// Encrypts a secret with asymmetric RSA algorithm.
     /// </summary>
-    public static class RsaKeyExchange
+    /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
+    /// <param name="receiversPublicKeyBlob">Public key of the receiver</param>
+    /// <param name="secretToEncrypt">Secret to encrypt</param>
+    /// <param name="sendersPublicKeyBlob">Public key of the sender (It's not needed to encrypt the secret, but to transfer the sender's public key to the receiver)</param>
+    /// <returns>Encrypted secret</returns>
+    public static EncryptedSecret EncryptSecret(int keySize, byte[] receiversPublicKeyBlob, byte[] secretToEncrypt, byte[] sendersPublicKeyBlob)
     {
-        /// <summary>
-        /// Encrypts a secret with asymmetric RSA algorithm.
-        /// </summary>
-        /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
-        /// <param name="receiversPublicKeyBlob">Public key of the receiver</param>
-        /// <param name="secretToEncrypt">Secret to encrypt</param>
-        /// <param name="sendersPublicKeyBlob">Public key of the sender (It's not needed to encrypt the secret, but to transfer the sender's public key to the receiver)</param>
-        /// <returns>Encrypted secret</returns>
-        public static EncryptedSecret EncryptSecret(int keySize, byte[] receiversPublicKeyBlob, byte[] secretToEncrypt, byte[] sendersPublicKeyBlob)
-        {
-            using var receiversPublicKey = new RSACryptoServiceProvider(dwKeySize: keySize);
-            receiversPublicKey.ImportCspBlob(receiversPublicKeyBlob);
-            
-            using Aes aes = Aes.Create();
+        using var receiversPublicKey = new RSACryptoServiceProvider(dwKeySize: keySize);
+        receiversPublicKey.ImportCspBlob(receiversPublicKeyBlob);
 
-            // Encrypt the session key
-            var keyFormatter = new RSAPKCS1KeyExchangeFormatter(receiversPublicKey);
-            
-            // Encrypt the secret
-            using MemoryStream ciphertext = new MemoryStream();
-            using CryptoStream stream = new CryptoStream(ciphertext, aes.CreateEncryptor(), CryptoStreamMode.Write);
-            
-            stream.Write(secretToEncrypt, 0, secretToEncrypt.Length);
-            stream.FlushFinalBlock();
-            stream.Close();
-            
-            return new EncryptedSecret(
-                encryptedSessionKey: keyFormatter.CreateKeyExchange(aes.Key, typeof(Aes)),
-                iv: aes.IV, 
-                encryptedMessage: ciphertext.ToArray(),
-                sendersPublicKeyBlob: sendersPublicKeyBlob);
-        }
+        using Aes aes = Aes.Create();
 
-        /// <summary>
-        /// Decrypts a secret with asymmetric RSA algorithm.
-        /// </summary>
-        /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
-        /// <param name="receiversPrivateKeyBlob">Private key of the receiver</param>
-        /// <param name="encryptedSecret">Encrypted secret</param>
-        /// <returns>Decrypted secret</returns>
-        public static byte[] DecryptSecret(int keySize, byte[] receiversPrivateKeyBlob, EncryptedSecret encryptedSecret)
-        {
-            using var receiversPrivateKey = new RSACryptoServiceProvider(dwKeySize: keySize);
-            receiversPrivateKey.ImportCspBlob(receiversPrivateKeyBlob);
+        // Encrypt the session key
+        var keyFormatter = new RSAPKCS1KeyExchangeFormatter(receiversPublicKey);
 
-            using Aes aes = Aes.Create();
-            aes.IV = encryptedSecret.Iv;
+        // Encrypt the secret
+        using MemoryStream ciphertext = new MemoryStream();
+        using CryptoStream stream = new CryptoStream(ciphertext, aes.CreateEncryptor(), CryptoStreamMode.Write);
 
-            // Decrypt the session key
-            RSAPKCS1KeyExchangeDeformatter keyDeformatter = new RSAPKCS1KeyExchangeDeformatter(receiversPrivateKey);
-            aes.Key = keyDeformatter.DecryptKeyExchange(encryptedSecret.EncryptedSessionKey);
+        stream.Write(secretToEncrypt, 0, secretToEncrypt.Length);
+        stream.FlushFinalBlock();
+        stream.Close();
 
-            // Decrypt the message
-            using MemoryStream stream = new MemoryStream();
-            using CryptoStream cryptoStream = new CryptoStream(stream, aes.CreateDecryptor(), CryptoStreamMode.Write);
-            cryptoStream.Write(encryptedSecret.EncryptedMessage, 0, encryptedSecret.EncryptedMessage.Length);
-            cryptoStream.FlushFinalBlock();
-            cryptoStream.Close();
+        return new EncryptedSecret(
+            encryptedSessionKey: keyFormatter.CreateKeyExchange(aes.Key, typeof(Aes)),
+            iv: aes.IV,
+            encryptedMessage: ciphertext.ToArray(),
+            sendersPublicKeyBlob: sendersPublicKeyBlob);
+    }
 
-            return stream.ToArray();
-        }
+    /// <summary>
+    /// Decrypts a secret with asymmetric RSA algorithm.
+    /// </summary>
+    /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
+    /// <param name="receiversPrivateKeyBlob">Private key of the receiver</param>
+    /// <param name="encryptedSecret">Encrypted secret</param>
+    /// <returns>Decrypted secret</returns>
+    public static byte[] DecryptSecret(int keySize, byte[] receiversPrivateKeyBlob, EncryptedSecret encryptedSecret)
+    {
+        using var receiversPrivateKey = new RSACryptoServiceProvider(dwKeySize: keySize);
+        receiversPrivateKey.ImportCspBlob(receiversPrivateKeyBlob);
+
+        using Aes aes = Aes.Create();
+        aes.IV = encryptedSecret.Iv;
+
+        // Decrypt the session key
+        RSAPKCS1KeyExchangeDeformatter keyDeformatter = new RSAPKCS1KeyExchangeDeformatter(receiversPrivateKey);
+        aes.Key = keyDeformatter.DecryptKeyExchange(encryptedSecret.EncryptedSessionKey);
+
+        // Decrypt the message
+        using MemoryStream stream = new MemoryStream();
+        using CryptoStream cryptoStream = new CryptoStream(stream, aes.CreateDecryptor(), CryptoStreamMode.Write);
+        cryptoStream.Write(encryptedSecret.EncryptedMessage, 0, encryptedSecret.EncryptedMessage.Length);
+        cryptoStream.FlushFinalBlock();
+        cryptoStream.Close();
+
+        return stream.ToArray();
     }
 }

--- a/CoreRemoting/Encryption/RsaKeyPair.cs
+++ b/CoreRemoting/Encryption/RsaKeyPair.cs
@@ -2,56 +2,55 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
-namespace CoreRemoting.Encryption
+namespace CoreRemoting.Encryption;
+
+/// <summary>
+/// Describes an RSA key pair.
+/// </summary>
+public class RsaKeyPair : IDisposable
 {
+    private readonly RSACryptoServiceProvider _rsa;
+
     /// <summary>
-    /// Describes an RSA key pair.
+    /// Creates a new instance of the RsaKeyPair.
     /// </summary>
-    public class RsaKeyPair : IDisposable
+    /// <param name="keySize">Key size</param>
+    public RsaKeyPair(int keySize)
     {
-        private readonly RSACryptoServiceProvider _rsa;   
-        
-        /// <summary>
-        /// Creates a new instance of the RsaKeyPair.
-        /// </summary>
-        /// <param name="keySize">Key size</param>
-        public RsaKeyPair(int keySize)
-        {
-            _rsa = new RSACryptoServiceProvider(dwKeySize: keySize);
-        }
+        _rsa = new RSACryptoServiceProvider(dwKeySize: keySize);
+    }
 
-        /// <summary>
-        /// Creates a new instance of the RsaKeyPair.
-        /// </summary>
-        /// <param name="keySize">Key size</param>
-        /// <param name="privateKey">Private key to import</param>
-        [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        public RsaKeyPair(int keySize, byte[] privateKey) : this(keySize)
-        {
-            _rsa.ImportCspBlob(privateKey);
-        }
+    /// <summary>
+    /// Creates a new instance of the RsaKeyPair.
+    /// </summary>
+    /// <param name="keySize">Key size</param>
+    /// <param name="privateKey">Private key to import</param>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public RsaKeyPair(int keySize, byte[] privateKey) : this(keySize)
+    {
+        _rsa.ImportCspBlob(privateKey);
+    }
 
-        /// <summary>
-        /// Gets the private RSA key.
-        /// </summary>
-        public byte[] PrivateKey => _rsa.ExportCspBlob(includePrivateParameters: true);
-        
-        /// <summary>
-        /// Gets the public RSA key.
-        /// </summary>
-        public byte[] PublicKey => _rsa.ExportCspBlob(includePrivateParameters: false);
+    /// <summary>
+    /// Gets the private RSA key.
+    /// </summary>
+    public byte[] PrivateKey => _rsa.ExportCspBlob(includePrivateParameters: true);
 
-        /// <summary>
-        /// Gets the key size.
-        /// </summary>
-        public int KeySize => _rsa.KeySize;
-        
-        /// <summary>
-        /// Frees managed resources.
-        /// </summary>
-        public void Dispose()
-        {
-            _rsa?.Dispose();
-        }
+    /// <summary>
+    /// Gets the public RSA key.
+    /// </summary>
+    public byte[] PublicKey => _rsa.ExportCspBlob(includePrivateParameters: false);
+
+    /// <summary>
+    /// Gets the key size.
+    /// </summary>
+    public int KeySize => _rsa.KeySize;
+
+    /// <summary>
+    /// Frees managed resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _rsa?.Dispose();
     }
 }

--- a/CoreRemoting/Encryption/RsaSignature.cs
+++ b/CoreRemoting/Encryption/RsaSignature.cs
@@ -1,67 +1,66 @@
 using System.Security.Cryptography;
 
-namespace CoreRemoting.Encryption
+namespace CoreRemoting.Encryption;
+
+/// <summary>
+/// Provides methods to create and verify RSA signatures.
+/// </summary>
+public static class RsaSignature
 {
     /// <summary>
-    /// Provides methods to create and verify RSA signatures.
+    /// Creates a signature from the SHA256 hash value of the specified raw data.
+    /// The private key of the provided key pair is used to create the signature.
     /// </summary>
-    public static class RsaSignature
+    /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
+    /// <param name="sendersPrivateKeyBlob">Private key of the sender</param>
+    /// <param name="rawData">Raw data to create a signature of</param>
+    /// <returns>Signature</returns>
+    public static byte[] CreateSignature(int keySize, byte[] sendersPrivateKeyBlob, byte[] rawData)
     {
-        /// <summary>
-        /// Creates a signature from the SHA256 hash value of the specified raw data.
-        /// The private key of the provided key pair is used to create the signature.
-        /// </summary>
-        /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
-        /// <param name="sendersPrivateKeyBlob">Private key of the sender</param>
-        /// <param name="rawData">Raw data to create a signature of</param>
-        /// <returns>Signature</returns>
-        public static byte[] CreateSignature(int keySize, byte[] sendersPrivateKeyBlob, byte[] rawData)
-        {
-            // Create SHA256 hash of the raw data
-            using var sha256 = SHA256.Create();
-            var hash = sha256.ComputeHash(rawData);
+        // Create SHA256 hash of the raw data
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(rawData);
 
-            // Import the sender's private key
-            using var sendersPrivateKey = new RSACryptoServiceProvider(dwKeySize: keySize);
-            sendersPrivateKey.ImportCspBlob(sendersPrivateKeyBlob);
+        // Import the sender's private key
+        using var sendersPrivateKey = new RSACryptoServiceProvider(dwKeySize: keySize);
+        sendersPrivateKey.ImportCspBlob(sendersPrivateKeyBlob);
 
-            // Create an RSAPKCS1SignatureFormatter object and pass it the RSA instance to transfer the private key.
-            var signatureFormatter = new RSAPKCS1SignatureFormatter(sendersPrivateKey);
+        // Create an RSAPKCS1SignatureFormatter object and pass it the RSA instance to transfer the private key.
+        var signatureFormatter = new RSAPKCS1SignatureFormatter(sendersPrivateKey);
 
-            // Set the hash algorithm to SHA256
-            signatureFormatter.SetHashAlgorithm("SHA256");
+        // Set the hash algorithm to SHA256
+        signatureFormatter.SetHashAlgorithm("SHA256");
 
-            // Create signature from the hash
-            return signatureFormatter.CreateSignature(hash);   
-        }
+        // Create signature from the hash
+        return signatureFormatter.CreateSignature(hash);
+    }
 
-        /// <summary>
-        /// Verifies a signature with the public key of the sender for the provided raw data.   
-        /// </summary>
-        /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
-        /// <param name="sendersPublicKeyBlob">Public key of the sender</param>
-        /// <param name="rawData">Raw data which signature of should be verified</param>
-        /// <param name="signature">The signature to verify</param>
-        /// <returns>True is the signature is valid, otherwise false</returns>
-        public static bool VerifySignature(int keySize, byte[] sendersPublicKeyBlob, byte[] rawData, byte[] signature)
-        {
-            // Create SHA256 hash of the raw data
-            using var sha256 = SHA256.Create();
-            var hash = sha256.ComputeHash(rawData);
-            
-            // Import the sender's public key
-            using var sendersPublicKey = new RSACryptoServiceProvider(keySize);
-            sendersPublicKey.PersistKeyInCsp = false;
-            sendersPublicKey.ImportCspBlob(sendersPublicKeyBlob);
+    /// <summary>
+    /// Verifies a signature with the public key of the sender for the provided raw data.
+    /// </summary>
+    /// <param name="keySize">Key size (1024, 2048, 4096, ...)</param>
+    /// <param name="sendersPublicKeyBlob">Public key of the sender</param>
+    /// <param name="rawData">Raw data which signature of should be verified</param>
+    /// <param name="signature">The signature to verify</param>
+    /// <returns>True is the signature is valid, otherwise false</returns>
+    public static bool VerifySignature(int keySize, byte[] sendersPublicKeyBlob, byte[] rawData, byte[] signature)
+    {
+        // Create SHA256 hash of the raw data
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(rawData);
 
-            // Create an RSAPKCS1SignatureDeformatter object and pass it the RSA instance to transfer the public key.
-            var signatureDeformatter = new RSAPKCS1SignatureDeformatter(sendersPublicKey);
-            
-            // Set the hash algorithm to SHA256
-            signatureDeformatter.SetHashAlgorithm("SHA256");
+        // Import the sender's public key
+        using var sendersPublicKey = new RSACryptoServiceProvider(keySize);
+        sendersPublicKey.PersistKeyInCsp = false;
+        sendersPublicKey.ImportCspBlob(sendersPublicKeyBlob);
 
-            // Verify the signature using the computed hash
-            return signatureDeformatter.VerifySignature(hash, signature);
-        }
+        // Create an RSAPKCS1SignatureDeformatter object and pass it the RSA instance to transfer the public key.
+        var signatureDeformatter = new RSAPKCS1SignatureDeformatter(sendersPublicKey);
+
+        // Set the hash algorithm to SHA256
+        signatureDeformatter.SetHashAlgorithm("SHA256");
+
+        // Verify the signature using the computed hash
+        return signatureDeformatter.VerifySignature(hash, signature);
     }
 }

--- a/CoreRemoting/Encryption/SignedMessageData.cs
+++ b/CoreRemoting/Encryption/SignedMessageData.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace CoreRemoting.Encryption
+namespace CoreRemoting.Encryption;
+
+/// <summary>
+/// Container for raw message data and its RSA signature.
+/// </summary>
+[Serializable]
+public class SignedMessageData
 {
     /// <summary>
-    /// Container for raw message data and its RSA signature.
+    /// Gets or sets the unencrypted raw message data.
     /// </summary>
-    [Serializable]
-    public class SignedMessageData
-    {
-        /// <summary>
-        /// Gets or sets the unencrypted raw message data.
-        /// </summary>
-        public byte[] MessageRawData { get; set; }
-        
-        /// <summary>
-        /// Get or sets the RSA signature.
-        /// </summary>
-        public byte[] Signature { get; set; }
-    }
+    public byte[] MessageRawData { get; set; }
+
+    /// <summary>
+    /// Get or sets the RSA signature.
+    /// </summary>
+    public byte[] Signature { get; set; }
 }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -547,7 +547,7 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
         // Both endpoints switch to the negotiated key right after this final response,
         // so the next message is already encrypted with it on both sides.
         var authResponseMessage = await authResponse.ConfigureAwait(false);
-        if (authResponseMessage?.NegotiatedSharedKey is not null and { Length: > 0 })
+        if (MessageEncryption && authResponseMessage?.NegotiatedSharedKey is not null and { Length: > 0 })
         {
             lock (_sessionLock)
                 _sharedSecret = authResponseMessage.NegotiatedSharedKey;


### PR DESCRIPTION
Added J-PAKE protocol via BouncyCastle.Cryptography.
It's less secure than SRP but easier to implement on server.
Like SRP, J-PAKE generates shared session key.

TODO:
- [x] J-PAKE implementation
- [x] Unit tests
- [x] Ignore negotiated keys if encryption is disabled
- [x] Use HKDF to ensure required shared key length for all authenticators