### PR TITLE
Explicit control over negotiated shared key transfer

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,15 +31,27 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: | 
           8.0.x
           9.0.x
+
+    - name: Install libmsquic (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libmsquic
+        # verify the installation
+        ldconfig -p | grep libmsquic || echo "libmsquic not found in ldconfig"
+
     - name: Restore dependencies
       run: dotnet restore
+
     - name: Build
       run: dotnet build --no-restore
+
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -60,7 +60,7 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal -- -parallel none
+      run: dotnet test --no-build --verbosity normal
       env:
         QUIC_LOG_FILE: ${{ runner.temp }}/quic/quic.log
         QUIC_LOG_LEVEL: 5

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -60,7 +60,7 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal -- -parallel none
       env:
         QUIC_LOG_FILE: ${{ runner.temp }}/quic/quic.log
         QUIC_LOG_LEVEL: 5

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,8 +44,14 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libmsquic
-        # verify the installation
         ldconfig -p | grep libmsquic || echo "libmsquic not found in ldconfig"
+
+    - name: Prepare QUIC log directory (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        mkdir -p ${{ runner.temp }}/quic
+        touch ${{ runner.temp }}/quic/quic.log
+        chmod 666 ${{ runner.temp }}/quic/quic.log
 
     - name: Restore dependencies
       run: dotnet restore
@@ -55,3 +61,17 @@ jobs:
 
     - name: Test
       run: dotnet test --no-build --verbosity normal
+      env:
+        QUIC_LOG_FILE: ${{ runner.temp }}/quic/quic.log
+        QUIC_LOG_LEVEL: 5
+
+    - name: Upload QUIC log on failure
+      if: failure() && runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      with:
+        name: quic-log-${{ matrix.os }}
+        path: ${{ runner.temp }}/quic/quic.log
+
+    - name: Show QUIC log on failure (optional)
+      if: failure() && runner.os == 'Linux'
+      run: cat ${{ runner.temp }}/quic/quic.log || echo "No log file found"

--- a/CoreRemoting.Authentication.JPake/JPakeAuthenticationProvider.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeAuthenticationProvider.cs
@@ -14,11 +14,11 @@ namespace CoreRemoting.Authentication.JPake;
 /// </summary>
 public class JPakeAuthenticationProvider : IAuthenticationProvider
 {
-    private readonly IJPakeAccountRepository _repository;
-    private readonly JPakePrimeOrderGroup _group;
-    private readonly SecureRandom _random;
-    private readonly string _unknownUserPassword;
-
+    private IJPakeAccountRepository Repository { get; }
+    private JPakePrimeOrderGroup Group { get; }
+    private SecureRandom Random { get; }
+    private string UnknownUserPassword { get; }
+    private bool UseNegotiatedSessionKey { get; }
     internal ConcurrentDictionary<string, SessionData> PendingAuthentications { get; } = new();
 
     /// <summary>
@@ -26,12 +26,16 @@ public class JPakeAuthenticationProvider : IAuthenticationProvider
     /// </summary>
     /// <param name="repository">User account repository.</param>
     /// <param name="group">Optional J-PAKE prime order group (should match client parameters).</param>
-    public JPakeAuthenticationProvider(IJPakeAccountRepository repository, JPakePrimeOrderGroup group = null)
+    /// <param name="useNegotiatedSessionKey">If true, the derived SRP session key is sent to the client as the
+    /// negotiated shared key and both endpoints use it for symmetric message encryption after successful
+    /// authentication (replaces the default session key from the handshake). Default is true.</param>
+    public JPakeAuthenticationProvider(IJPakeAccountRepository repository, JPakePrimeOrderGroup group = null, bool useNegotiatedSessionKey = true)
     {
-        _repository = repository;
-        _group = group ?? JPakePrimeOrderGroups.NIST_2048;
-        _random = new SecureRandom();
-        _unknownUserPassword = GenerateRandomPassword();
+        Repository = repository;
+        Group = group ?? JPakePrimeOrderGroups.NIST_2048;
+        Random = new();
+        UnknownUserPassword = GenerateRandomPassword();
+        UseNegotiatedSessionKey = useNegotiatedSessionKey;
     }
 
     /// <summary>
@@ -66,13 +70,13 @@ public class JPakeAuthenticationProvider : IAuthenticationProvider
         var sessionId = authRequest[OPTIONAL_SESSION_ID] ?? RemotingSession.Current.SessionId.ToString();
 
         // Find account or use fake password for non-existent users
-        var account = await _repository.FindByName(userName).ConfigureAwait(false);
+        var account = await Repository.FindByName(userName).ConfigureAwait(false);
         var password = account != null
             ? account.Password
-            : _unknownUserPassword;
+            : UnknownUserPassword;
 
         // Create server's Round 1
-        var serverParticipant = new JPakeParticipant(PARTICIPANT_ID_SERVER, password.ToCharArray(), _group, new Sha256Digest(), _random);
+        var serverParticipant = new JPakeParticipant(PARTICIPANT_ID_SERVER, password.ToCharArray(), Group, new Sha256Digest(), Random);
         var serverRound1 = serverParticipant.CreateRound1PayloadToSend();
 
         // Process client's Round 1
@@ -181,19 +185,23 @@ public class JPakeAuthenticationProvider : IAuthenticationProvider
         if (session.Account == null)
             return Error();
 
-        var identity = await _repository.GetIdentity(session.Account).ConfigureAwait(false);
+        var identity = await Repository.GetIdentity(session.Account).ConfigureAwait(false);
 
         var response = new AuthenticationResponseMessage
         {
             IsCompleted = true,
             IsAuthenticated = true,
             AuthenticatedIdentity = identity,
-            NegotiatedSharedKey = new(keyingMaterial.ToByteArray()),
             Parameters =
             [
                 new() { Name = ROUND3_MAC, Value = JPakeSerializer.Serialize(serverRound3.MacTag) },
             ],
         };
+
+        // optionally negotiate the shared key for message encryption
+        if (UseNegotiatedSessionKey)
+            response.NegotiatedSharedKey =
+                new(keyingMaterial.ToByteArray());
 
         return response;
     }

--- a/CoreRemoting.Authentication.JPake/JPakeAuthenticationProvider.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeAuthenticationProvider.cs
@@ -188,7 +188,7 @@ public class JPakeAuthenticationProvider : IAuthenticationProvider
             IsCompleted = true,
             IsAuthenticated = true,
             AuthenticatedIdentity = identity,
-            NegotiatedSharedKey = keyingMaterial.ToByteArray(),
+            NegotiatedSharedKey = new(keyingMaterial.ToByteArray()),
             Parameters =
             [
                 new() { Name = ROUND3_MAC, Value = JPakeSerializer.Serialize(serverRound3.MacTag) },

--- a/CoreRemoting.Authentication.JPake/JPakeAuthenticator.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeAuthenticator.cs
@@ -124,7 +124,7 @@ public class JPakeAuthenticator : IAuthenticator
         participant.ValidateRound3PayloadReceived(serverRound3, keyingMaterial);
 
         // Derive negotiated shared key
-        response3.NegotiatedSharedKey = keyingMaterial.ToByteArray();
+        response3.NegotiatedSharedKey = new(keyingMaterial.ToByteArray());
         return response3;
     }
 }

--- a/CoreRemoting.Authentication.JPake/JPakeAuthenticator.cs
+++ b/CoreRemoting.Authentication.JPake/JPakeAuthenticator.cs
@@ -124,7 +124,14 @@ public class JPakeAuthenticator : IAuthenticator
         participant.ValidateRound3PayloadReceived(serverRound3, keyingMaterial);
 
         // Derive negotiated shared key
-        response3.NegotiatedSharedKey = new(keyingMaterial.ToByteArray());
+        if (response3.NegotiatedSharedKey is {} key)
+        {
+            if (key.ContainsKeyMaterial && authProxy is not JPakeAuthenticationProvider)
+                throw new SecurityException("Negotiated shared key is compromised.");
+
+            response3.NegotiatedSharedKey = new(keyingMaterial.ToByteArray());
+        }
+
         return response3;
     }
 }

--- a/CoreRemoting.Authentication.Oidc/OidcAuthenticationProvider.cs
+++ b/CoreRemoting.Authentication.Oidc/OidcAuthenticationProvider.cs
@@ -169,7 +169,7 @@ public class OidcAuthenticationProvider : IOidcAuthenticationProvider
             var sessionKey = new byte[32];
             using var randomGenerator = RandomNumberGenerator.Create();
             randomGenerator.GetBytes(sessionKey);
-            response.NegotiatedSharedKey = sessionKey;
+            response.NegotiatedSharedKey = new(sessionKey, isSerialized: true);
         }
 
         return response;

--- a/CoreRemoting.Authentication.SecureRemotePassword/SrpAuthenticationProvider.cs
+++ b/CoreRemoting.Authentication.SecureRemotePassword/SrpAuthenticationProvider.cs
@@ -147,7 +147,7 @@ public class SrpAuthenticationProvider : IAuthenticationProvider
         // optionally negotiate the derived SRP session key as the new shared secret for message encryption
         if (UseNegotiatedSessionKey)
             response.NegotiatedSharedKey =
-                SrpInteger.FromHex(serverSessionKey).ToByteArray();
+                new(SrpInteger.FromHex(serverSessionKey).ToByteArray());
 
         return response;
     }

--- a/CoreRemoting.Authentication.SecureRemotePassword/SrpAuthenticator.cs
+++ b/CoreRemoting.Authentication.SecureRemotePassword/SrpAuthenticator.cs
@@ -61,10 +61,16 @@ public class SrpAuthenticator : IAuthenticator
         var serverSessionProof = response2[SERVER_SESSION_PROOF];
         SrpClient.VerifySession(clientEphemeral.Public, clientSession, serverSessionProof);
 
-        // restore the negotiated SRP session key using the locally derived key
-        if (response2.NegotiatedSharedKey is not null)
+        // if shared key is negotiated, check that keying material wasn't sent over the wire
+        if (response2.NegotiatedSharedKey is {} key)
+        {
+            if (key.ContainsKeyMaterial)
+                throw new SecurityException("Negotiated shared key is compromised.");
+
+            // restore the negotiated SRP session key using the locally derived key
             response2.NegotiatedSharedKey =
                 new(SrpInteger.FromHex(clientSession.Key).ToByteArray());
+        }
 
         return response2;
     }

--- a/CoreRemoting.Authentication.SecureRemotePassword/SrpAuthenticator.cs
+++ b/CoreRemoting.Authentication.SecureRemotePassword/SrpAuthenticator.cs
@@ -64,7 +64,7 @@ public class SrpAuthenticator : IAuthenticator
         // restore the negotiated SRP session key using the locally derived key
         if (response2.NegotiatedSharedKey is not null)
             response2.NegotiatedSharedKey =
-                SrpInteger.FromHex(clientSession.Key).ToByteArray();
+                new(SrpInteger.FromHex(clientSession.Key).ToByteArray());
 
         return response2;
     }

--- a/CoreRemoting.Channels.Quic/CertificateHelper.cs
+++ b/CoreRemoting.Channels.Quic/CertificateHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
@@ -16,17 +17,28 @@ internal class CertificateHelper
     {
         // generate a new certificate
         var now = DateTimeOffset.UtcNow;
-        SubjectAlternativeNameBuilder sanBuilder = new();
+        var sanBuilder = new SubjectAlternativeNameBuilder();
         sanBuilder.AddDnsName(hostName);
+
+        // TODO: add related IP addresses explicitly
+        if ("localhost".Equals(hostName, StringComparison.OrdinalIgnoreCase))
+        {
+            sanBuilder.AddIpAddress(IPAddress.Loopback);
+            sanBuilder.AddIpAddress(IPAddress.IPv6Loopback);
+        }
 
         using var ec = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         CertificateRequest req = new($"CN={hostName}", ec, HashAlgorithmName.SHA256);
 
+        // RSA should also work but slower
+        // using var rsa = RSA.Create(2048);
+        // CertificateRequest req = new($"CN={hostName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
         // Adds purpose
-        req.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection
-        {
-            new("1.3.6.1.5.5.7.3.1") // serverAuth
-		},
+        req.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension([
+            new("1.3.6.1.5.5.7.3.1"), // serverAuth
+            new("1.3.6.1.5.5.7.3.2")  // clientAuth (optional)
+        ],
         false));
 
         // Adds usage

--- a/CoreRemoting.Channels.Quic/QuicTransport.cs
+++ b/CoreRemoting.Channels.Quic/QuicTransport.cs
@@ -154,10 +154,14 @@ public abstract class QuicTransport : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            LastException = ex as NetworkException ??
-                new NetworkException(ex.Message, ex);
+            // treat ConnectionAborted error as normal behavior
+            if (ex is not QuicException qx || qx.QuicError != QuicError.ConnectionAborted)
+            {
+                LastException = ex as NetworkException ??
+                    new NetworkException(ex.Message, ex);
 
-            OnErrorOccured(ex.Message, LastException);
+                OnErrorOccured(ex.Message, LastException);
+            }
         }
         finally
         {

--- a/CoreRemoting.Channels.Quic/QuicTransport.cs
+++ b/CoreRemoting.Channels.Quic/QuicTransport.cs
@@ -154,14 +154,14 @@ public abstract class QuicTransport : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            // treat ConnectionAborted error as normal behavior
-            if (ex is not QuicException qx || qx.QuicError != QuicError.ConnectionAborted)
-            {
-                LastException = ex as NetworkException ??
-                    new NetworkException(ex.Message, ex);
+            // treat ConnectionAborted error signal as normal behavior
+            if (ex is QuicException qx && qx.QuicError == QuicError.ConnectionAborted)
+                return;
 
-                OnErrorOccured(ex.Message, LastException);
-            }
+            LastException = ex as NetworkException ??
+                new NetworkException(ex.Message, ex);
+
+            OnErrorOccured(ex.Message, LastException);
         }
         finally
         {

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <!-- Run .NET 9.0 specific tests only on Windows -->
+        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFrameworks>
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <IsPackable>false</IsPackable>
         <NoWarn>$(NoWarn),NU1701,NU1903</NoWarn>

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- Run .NET 9.0 specific tests only on Windows -->
-        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net9.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <IsPackable>false</IsPackable>
         <NoWarn>$(NoWarn),NU1701,NU1903</NoWarn>

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <IsPackable>false</IsPackable>
         <NoWarn>$(NoWarn),NU1701,NU1903</NoWarn>

--- a/CoreRemoting.Tests/Encryption/SessionKeyPairBenchmarkTests.cs
+++ b/CoreRemoting.Tests/Encryption/SessionKeyPairBenchmarkTests.cs
@@ -41,8 +41,8 @@ public class SessionKeyPairBenchmarkTests
     /// Key generation is FORCED by accessing PrivateKey, because RSACryptoServiceProvider
     /// uses lazy generation (the key is not actually created until first use).
     /// </summary>
-    [Fact]
-    public void Benchmark_RsaVsEcdsa_Performance()
+    // [Fact]
+    internal void Benchmark_RsaVsEcdsa_Performance()
     {
         const int genIterations = 5;
         const int signIterations = 500;
@@ -208,8 +208,8 @@ public class SessionKeyPairBenchmarkTests
     /// without the caching behavior of RSACryptoServiceProvider.
     /// Includes both RSA.Create() and ECDsa.Create() for an honest comparison.
     /// </summary>
-    [Fact]
-    public void Benchmark_ModernApi_NoCaching()
+    // [Fact]
+    internal void Benchmark_ModernApi_NoCaching()
     {
         const int iterations = 5;
 

--- a/CoreRemoting.Tests/JPakeAuthenticationTests.cs
+++ b/CoreRemoting.Tests/JPakeAuthenticationTests.cs
@@ -106,7 +106,8 @@ public class JPakeAuthenticationTests : IAsyncLifetime
         Assert.NotNull(response.AuthenticatedIdentity);
         Assert.Equal(UserName, response.AuthenticatedIdentity.Name);
         Assert.NotNull(response.NegotiatedSharedKey);
-        Assert.NotEmpty(response.NegotiatedSharedKey);
+        Assert.NotNull(response.NegotiatedSharedKey.InputKeyMaterial);
+        Assert.NotEmpty(response.NegotiatedSharedKey.InputKeyMaterial);
     }
 
     [Fact]

--- a/CoreRemoting.Tests/OidcAuthenticationTests.cs
+++ b/CoreRemoting.Tests/OidcAuthenticationTests.cs
@@ -494,7 +494,7 @@ public class OidcAuthenticationTests
             throw lastServerError;
     }
 
-    [Fact(Skip = "Not ready yet")]
+    [Fact]
     public async Task Session_key_should_be_renegotiated_when_enabled()
     {
         var key = RSA.Create(2048);

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -83,7 +83,9 @@ public class RpcTests : IClassFixture<ServerFixture>
         {
             if (_serverFixture.ServerErrorCount != 0)
             {
-                Console.WriteLine($"LastServerError: {_serverFixture.LastServerError}");
+                var msg = $"LastServerError: {_serverFixture.LastServerError}";
+                _testOutputHelper.WriteLine(msg);
+                Console.WriteLine(msg);
             }
         }
     }

--- a/CoreRemoting.Tests/RpcTests_Quic.cs
+++ b/CoreRemoting.Tests/RpcTests_Quic.cs
@@ -1,17 +1,17 @@
 using CoreRemoting.Channels;
 using CoreRemoting.Channels.Quic;
+using Xunit;
 using Xunit.Abstractions;
 
-namespace CoreRemoting.Tests
+namespace CoreRemoting.Tests;
+
+public class RpcTests_Quic : RpcTests
 {
-    public class RpcTests_Quic : RpcTests
+    protected override IServerChannel ServerChannel => new QuicServerChannel();
+
+    protected override IClientChannel ClientChannel => new QuicClientChannel();
+
+    public RpcTests_Quic(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
     {
-        protected override IServerChannel ServerChannel => new QuicServerChannel();
-
-        protected override IClientChannel ClientChannel => new QuicClientChannel();
-
-        public RpcTests_Quic(ServerFixture fixture, ITestOutputHelper helper) : base(fixture, helper)
-        {
-        }
     }
 }

--- a/CoreRemoting.Tests/SessionResumeTestsQuic.cs
+++ b/CoreRemoting.Tests/SessionResumeTestsQuic.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Net.Quic;
 using CoreRemoting.Channels;
 using CoreRemoting.Channels.Quic;
 using Xunit;
@@ -15,19 +13,4 @@ public class SessionResumeTestsQuic : SessionResumeTests
     protected override bool MessageEncryption => false;
 
     protected override bool AuthenticationRequiredForResumeTests => false;
-
-    protected override void CheckServerErrorCount()
-    {
-        if (lastServerError is not null)
-        {
-            while (lastServerError.InnerException is Exception ex)
-                lastServerError = ex;
-
-            if (lastServerError is not QuicException)
-                throw new Exception($"Unexpected server error: {lastServerError}");
-        }
-
-        // error 'Connection aborted by peer (12).' is expected
-        Assert.True(serverErrorCount <= 2);
-    }
 }

--- a/CoreRemoting/Authentication/AuthenticationResponseMessage.cs
+++ b/CoreRemoting/Authentication/AuthenticationResponseMessage.cs
@@ -47,7 +47,7 @@ public class AuthenticationResponseMessage
     /// authentication is completed, replacing the default session key from the handshake.
     /// </summary>
     [DataMember(IsRequired = false)]
-    public byte[] NegotiatedSharedKey { get; set; }
+    public NegotiatedSharedKey NegotiatedSharedKey { get; set; }
 
     /// <summary>
     /// Gets the value of the given parameter, or null.

--- a/CoreRemoting/Authentication/NegotiatedSharedKey.cs
+++ b/CoreRemoting/Authentication/NegotiatedSharedKey.cs
@@ -48,8 +48,7 @@ public class NegotiatedSharedKey
     /// <summary>
     /// Gets a value indicating whether input keying material exists.
     /// </summary>
-    public bool ContainsKeyMaterial =>
-        InputKeyMaterial is not null and { Length: > 0 };
+    public bool ContainsKeyMaterial => InputKeyMaterial is { Length: > 0 };
 
     /// <summary>
     /// Clones the current instance of the negotiated shared key for serialization.

--- a/CoreRemoting/Authentication/NegotiatedSharedKey.cs
+++ b/CoreRemoting/Authentication/NegotiatedSharedKey.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace CoreRemoting.Authentication;
+
+/// <summary>
+/// Describes the negotiated shared key data.
+/// </summary>
+[DataContract]
+[Serializable]
+public class NegotiatedSharedKey
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NegotiatedSharedKey"/> class.
+    /// </summary>
+    public NegotiatedSharedKey()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NegotiatedSharedKey"/> class.
+    /// </summary>
+    /// <param name="keyingMaterial">Gets or sets keying material used for session key derivation.</param>
+    /// <param name="isSerialized">Gets or sets a value indicating whether the keying material should be serialized.</param>
+    public NegotiatedSharedKey(byte[] keyingMaterial, bool isSerialized = false)
+    {
+        InputKeyMaterial = keyingMaterial;
+        IsSerialized = isSerialized;
+    }
+
+    /// <summary>
+    /// Gets or sets an optional shared key negotiated during authentication (e.g., the session key derived by SRP).
+    /// If set, both endpoints switch to this key for symmetric message encryption as soon as the
+    /// authentication is completed, replacing the default session key from the handshake.
+    /// </summary>
+    [DataMember]
+    public byte[] InputKeyMaterial { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the shared key should be serialized and sent over the wire.
+    /// </summary>
+    /// <remarks>
+    /// Authentication protocols like SRP and J-PAKE require that shared key is derived independently by client and server.
+    /// </remarks>
+    [DataMember]
+    public bool IsSerialized { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether input keying material exists.
+    /// </summary>
+    public bool ContainsKeyMaterial =>
+        InputKeyMaterial is not null and { Length: > 0 };
+
+    /// <summary>
+    /// Clones the current instance of the negotiated shared key for serialization.
+    /// If input keying material shouldn't be serialized, it will be excluded.
+    /// </summary>
+    public NegotiatedSharedKey GetSerializableCopy() =>
+        new NegotiatedSharedKey(IsSerialized ? InputKeyMaterial : null);
+}

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -583,9 +583,9 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
         // Both endpoints switch to the negotiated key right after this final response,
         // so the next message is already encrypted with it on both sides.
         var authResponseMessage = await authResponse.ConfigureAwait(false);
-        if (MessageEncryption && authResponseMessage?.NegotiatedSharedKey is not null and { Length: > 0 })
+        if (MessageEncryption && authResponseMessage is { NegotiatedSharedKey.ContainsKeyMaterial: true })
         {
-            var inputKeyMaterial = authResponseMessage.NegotiatedSharedKey;
+            var inputKeyMaterial = authResponseMessage.NegotiatedSharedKey.InputKeyMaterial;
             var secretLength = _config.SharedKeySize / 8;
             var derivedSharedKey = _config.HkdfProvider.DeriveKey(inputKeyMaterial, secretLength, _sessionId, nameof(CoreRemoting));
             lock (_sessionLock)

--- a/CoreRemoting/RemotingSession.cs
+++ b/CoreRemoting/RemotingSession.cs
@@ -564,10 +564,10 @@ public sealed class RemotingSession : IAsyncDisposable
         var canRekey = 
             MessageEncryption && 
             !_server.Config.UseLegacySessionKeyDerivation;
-        
+
         var negotiatedSharedKey = 
             canRekey 
-                ? authResponseMessage.NegotiatedSharedKey 
+                ? authResponseMessage.NegotiatedSharedKey
                 : null;
 
         // the negotiated shared key travels encrypted inside the auth response, so it does not leak
@@ -575,7 +575,7 @@ public sealed class RemotingSession : IAsyncDisposable
         // so the client can derive the very same new shared secret; null it otherwise.
         authResponseMessage.NegotiatedSharedKey = 
             canRekey 
-                ? negotiatedSharedKey 
+                ? negotiatedSharedKey?.GetSerializableCopy()
                 : null;
 
         var serializedAuthResponse = _server.Serializer.Serialize(authResponseMessage);
@@ -595,9 +595,9 @@ public sealed class RemotingSession : IAsyncDisposable
         // if the authentication protocol negotiated a new shared key, re-key the session.
         // Both endpoints switch to the negotiated key right after this final response,
         // so the next message is already encrypted with it on both sides.
-        if (_isAuthenticated && negotiatedSharedKey is not null and { Length: > 0 })
+        if (_isAuthenticated && negotiatedSharedKey is { ContainsKeyMaterial: true })
         {
-            var inputKeyMaterial = negotiatedSharedKey;
+            var inputKeyMaterial = negotiatedSharedKey.InputKeyMaterial;
             var config = _server.Config;
             var secretLength = config.SharedKeySize / 8;
             var derivedSharedKey = config.HkdfProvider.DeriveKey(inputKeyMaterial, secretLength, _sessionId, nameof(CoreRemoting));


### PR DESCRIPTION
Modern authentication protocols require that shared session key is derived independently on client and server.
The idea is to provide security even if authentication is performed over unencrypted channel.

But some authentication protocols like OIDC need to transfer negotiated key from server.
This PR enables both scenarios and makes the serialization option explicit:

```c#
// OIDC provider
response.NegotiatedSharedKey = new(sessionKey, isSerialized: true);

// SRP/J-PAKE providers
response.NegotiatedSharedKey = new(sessionKey, isSerialized: false);
```

Also, this PR contains minor improvements to the Quic channel to make all tests pass on Windows.
However I didn't switch the test project to .NET 9.0 target because it would skip BinaryFormatter tests.

And I don't really like the idea to run the tests twice as long if both .NET 8.0 and 9.0 are enabled.
Perhaps we can extract 9.0+-specific tests to a separate project later to run on Gitlab CI.