### PR TITLE
Add .NET 9.0 tests + ClientConfig.SharedKeySize issue

### DIFF
--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
         <IsPackable>false</IsPackable>
         <NoWarn>$(NoWarn),NU1701,NU1903</NoWarn>
     </PropertyGroup>
 
     <!-- Exclude the unnecessary tests to save Github Actions time -->
-    <!-- WatsonTcp is the default channel, WebSocketSharp is optional, Quic is .net9 only -->
+    <!-- WatsonTcp is the default channel, WebSocketSharp is optional, BinaryFormatter is .net8 only, Quic is .net9 only -->
     <ItemGroup>
+        <Compile Remove="BinarySerializationTests.cs" />
         <Compile Remove="InvokerTests.cs" />
         <Compile Remove="InvokerTestsSafe.cs" />
         <Compile Remove="QuicHandshakeMessageTests.cs" />
@@ -21,13 +22,15 @@
         <Compile Remove="SessionResumeTestsQuic.cs" />
     </ItemGroup>
 
-    <!-- .NET 9.0 only: skip BinaryFormatter -->
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-        <Compile Remove="BinarySerializationTests.cs" />
+    <!-- .NET 8.0 only: include BinaryFormatter and a small bunch of other tests -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <Compile Remove="*.cs" />
+        <Compile Include="BinarySerializationTests.cs" />
+        <Compile Include="SourceGeneratorTests.cs" />
     </ItemGroup>
 
     <!-- .NET 9.0 only: include Quic channel -->
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' And '$(OS)' == 'Windows_NT' ">
         <Compile Include="QuicHandshakeMessageTests.cs" />
         <Compile Include="RpcTests_Quic.cs">
             <DependentUpon>RpcTests.cs</DependentUpon>
@@ -41,10 +44,12 @@
     <ItemGroup>
         <PackageReference Include="DryIoc.MefAttributedModel.dll" Version="7.0.2" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
-        <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
         <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/CoreRemoting/ClientConfig.cs
+++ b/CoreRemoting/ClientConfig.cs
@@ -65,15 +65,6 @@ public class ClientConfig
     public int KeySize { get; set; } = 4096;
 
     /// <summary>
-    /// Gets or sets the shared key size for the symmetric encryption (only relevant, if message encryption is enabled).
-    /// </summary>
-    /// <remarks>
-    /// Supported values: 128, 192 and 256 bits.
-    /// </remarks>
-    [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
-    public int SharedKeySize { get; set; } = 256;
-
-    /// <summary>
     /// Gets or sets whether messages should be encrypted or not.
     /// </summary>
     public bool MessageEncryption { get; set; } = true;

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -586,8 +586,7 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
         if (MessageEncryption && authResponseMessage is { NegotiatedSharedKey.ContainsKeyMaterial: true })
         {
             var inputKeyMaterial = authResponseMessage.NegotiatedSharedKey.InputKeyMaterial;
-            var secretLength = _config.SharedKeySize / 8;
-            var derivedSharedKey = _config.HkdfProvider.DeriveKey(inputKeyMaterial, secretLength, _sessionId, nameof(CoreRemoting));
+            var derivedSharedKey = _config.HkdfProvider.DeriveKey(inputKeyMaterial, _sharedSecretLength, _sessionId, nameof(CoreRemoting));
             lock (_sessionLock)
                 _sharedSecret = derivedSharedKey;
         }


### PR DESCRIPTION
1. Enabled both .NET 8.0 and 9.0 targets in unit tests (8.0 version includes a small subset)
2. ClientConfig.SharedKeySize setting unnecessarily duplicates ServerConfig.SharedKeySize

Not sure how to deal with §2 properly: if client uses another SharedKeySize than server, encryption would fail.
During the handshake, server already reports its current shared key size, so I use it instead.
But I'm not 100% sure it's the perfect solution.

The current server setup allows both encrypted and unencrypted incoming connections.
The client determines which level of security is required.

Perhaps the client should also specify what shared key size it would like to use.
Looks like it can be another handshake metadata item: "SharedKeySize" = "256" bits.

UPD. Which suggests another thing to discuss: transport-agnostic connection metadata.
Currently, every channel determines which settings to send and receive during the handshake.
Websocket uses cookies, WatsonTcp uses Dictionary<string, string> metadata, etc.

Every channel knows high-level details about encryption, client public key, and so on.
But channel's task is not about encryption, it's about sending and receiving data packets.
Introducing new handshake parameters shouldn't imply updating all existing channels.