### PR TITLE
fix potential leak of SHA256

### DIFF
--- a/CoreRemoting/Encryption/AesEncryption.cs
+++ b/CoreRemoting/Encryption/AesEncryption.cs
@@ -16,7 +16,8 @@ namespace CoreRemoting.Encryption
         /// <returns>SHA-256 hash</returns>
         public static byte[] CreateHash(byte[] value)
         {
-            return SHA256.Create().ComputeHash(value);
+            using var sha = SHA256.Create();
+            return sha.ComputeHash(value);
         }
 
         /// <summary>


### PR DESCRIPTION
For a SHA256 object created using the SHA256.Create() method, you must call Dispose or use the using construct. This is not done for the sake of a checkbox and not just for compatibility with the pattern.

Found by Linux Verification Center (linuxtesting.org) with SVACE.