### PR TITLE
Added missing channel combinations to the benchmark

### DIFF
--- a/CoreRemoting.Benchmark/CoreRemoting.Benchmark.csproj
+++ b/CoreRemoting.Benchmark/CoreRemoting.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>

--- a/CoreRemoting.Benchmark/RpcBenchmark.cs
+++ b/CoreRemoting.Benchmark/RpcBenchmark.cs
@@ -3,34 +3,11 @@ using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
-using CoreRemoting.Channels;
-using CoreRemoting.Channels.NamedPipe;
-using CoreRemoting.Channels.Null;
-using CoreRemoting.Channels.Tcp;
-using CoreRemoting.Channels.Websocket;
-
-#if NET9_0_OR_GREATER
-using CoreRemoting.Channels.Quic;
-#endif
-
 using Perfolizer.Horology;
 using Perfolizer.Metrology;
+using static CoreRemoting.Benchmark.Setup;
 
 namespace CoreRemoting.Benchmark;
-
-public enum RpcChannel
-{
-    Null,
-    NullEncr,
-    NPipe,
-    NPipeEncr,
-    Quic,
-    QuicEncr,
-    Wsock,
-    WsockEncr,
-    Tcp,
-    TcpEncr
-}
 
 [MemoryDiagnoser]
 [Config(typeof(Config))]
@@ -40,13 +17,7 @@ public class RpcBenchmark
     {
         public Config()
         {
-            AddJob(
-                Job.Default
-            //    Job.ShortRun
-            //        .WithWarmupCount(2)
-            //        .WithIterationCount(5)
-            //        .WithId("Fast")
-            );
+            AddJob(Job.Default);
 
             HideColumns(Column.StdDev, Column.Error);
 
@@ -60,53 +31,32 @@ public class RpcBenchmark
     private RemotingClient _mainClient = null!;
     private ITestService _proxy = null!;
 
-    private bool _encryption;
-    private string? _pipeName;
-
-    [Params(
-        RpcChannel.Null,
-        RpcChannel.NullEncr,
-        RpcChannel.NPipe,
-        RpcChannel.NPipeEncr,
-        RpcChannel.Wsock,
-        RpcChannel.WsockEncr,
-#if NET9_0_OR_GREATER
-        RpcChannel.Quic,
-        RpcChannel.QuicEncr,
-#endif
-        RpcChannel.Tcp,
-        RpcChannel.TcpEncr
-    )]
-    public RpcChannel Channel { get; set; }
+    [ParamsSource(typeof(Setup), nameof(Scenarios))]
+    public ICase Setup { get; set; } = null!;
 
     [GlobalSetup]
-    public void Setup()
+    public void SetupServer()
     {
-        var serverChannel = CreateServerChannel(Channel);
-        var clientChannel = CreateClientChannel(Channel);
-        _encryption = IsEncryptionEnabled(Channel);
-        _pipeName = Channel == RpcChannel.NPipe ? "BenchmarkPipe" : null;
-
         _server = new RemotingServer(new ServerConfig
         {
-            Channel = serverChannel,
+            Channel = Setup.CreateServer(),
             NetworkPort = 9192,
             HostName = "localhost",
-            MessageEncryption = _encryption,
+            MessageEncryption = Setup.Encrypted,
             KeySize = 512,
-            ChannelConnectionName = _pipeName,
+            ChannelConnectionName = Setup.ConnectionName,
             RegisterServicesAction = c => c.RegisterService<ITestService, TestService>()
         });
         _server.Start();
 
         _mainClient = new RemotingClient(new ClientConfig
         {
-            Channel = clientChannel,
+            Channel = Setup.CreateClient(),
             ServerHostName = "localhost",
             ServerPort = 9192,
-            MessageEncryption = _encryption,
+            MessageEncryption = Setup.Encrypted,
             KeySize = 512,
-            ChannelConnectionName = _pipeName
+            ChannelConnectionName = Setup.ConnectionName
         });
         _mainClient.Connect();
         _proxy = _mainClient.CreateProxy<ITestService>();
@@ -125,12 +75,12 @@ public class RpcBenchmark
     {
         var config = new ClientConfig
         {
-            Channel = CreateClientChannel(Channel),
+            Channel = Setup.CreateClient(),
             ServerHostName = "localhost",
             ServerPort = 9192,
-            MessageEncryption = _encryption,
+            MessageEncryption = Setup.Encrypted,
             KeySize = 512,
-            ChannelConnectionName = _pipeName,
+            ChannelConnectionName = Setup.ConnectionName
         };
 
         using var client = new RemotingClient(config);
@@ -145,42 +95,6 @@ public class RpcBenchmark
 
     [Benchmark]
     public void FireEvent() => _proxy.FireServiceEvent();
-
-    private static IServerChannel CreateServerChannel(RpcChannel scenario) => scenario switch
-    {
-        RpcChannel.Null or RpcChannel.NullEncr => new NullServerChannel(),
-        RpcChannel.NPipe or RpcChannel.NPipeEncr => new NamedPipeServerChannel(),
-#if NET9_0_OR_GREATER
-        RpcChannel.Quic or RpcChannel.QuicEncr => new QuicServerChannel(),
-#endif
-        RpcChannel.Wsock or RpcChannel.WsockEncr => new WebsocketServerChannel(),
-        RpcChannel.Tcp or RpcChannel.TcpEncr => new TcpServerChannel(),
-        _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null)
-    };
-
-    private static IClientChannel CreateClientChannel(RpcChannel scenario) => scenario switch
-    {
-        RpcChannel.Null or RpcChannel.NullEncr => new NullClientChannel(),
-        RpcChannel.NPipe or RpcChannel.NPipeEncr => new NamedPipeClientChannel(),
-#if NET9_0_OR_GREATER
-        RpcChannel.Quic or RpcChannel.QuicEncr => new QuicClientChannel(),
-#endif
-        RpcChannel.Wsock or RpcChannel.WsockEncr => new WebsocketClientChannel(),
-        RpcChannel.Tcp or RpcChannel.TcpEncr => new TcpClientChannel(),
-        _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null)
-    };
-
-    private static bool IsEncryptionEnabled(RpcChannel scenario) => scenario switch
-    {
-#if NET9_0_OR_GREATER
-        RpcChannel.QuicEncr => true,
-#endif
-        RpcChannel.WsockEncr => true,
-        RpcChannel.TcpEncr => true,
-        RpcChannel.NullEncr => true,
-        RpcChannel.NPipeEncr => true,
-        _ => false
-    };
 }
 
 public interface ITestService

--- a/CoreRemoting.Benchmark/RpcBenchmark.cs
+++ b/CoreRemoting.Benchmark/RpcBenchmark.cs
@@ -32,7 +32,7 @@ public class RpcBenchmark
     private ITestService _proxy = null!;
 
     [ParamsSource(typeof(Setup), nameof(Scenarios))]
-    public ICase Setup { get; set; } = null!;
+    public IScenario Setup { get; set; } = null!;
 
     [GlobalSetup]
     public void SetupServer()
@@ -42,11 +42,12 @@ public class RpcBenchmark
             Channel = Setup.CreateServer(),
             NetworkPort = 9192,
             HostName = "localhost",
-            MessageEncryption = Setup.Encrypted,
+            MessageEncryption = Setup.MessageEncryption,
             KeySize = 512,
             ChannelConnectionName = Setup.ConnectionName,
             RegisterServicesAction = c => c.RegisterService<ITestService, TestService>()
         });
+
         _server.Start();
 
         _mainClient = new RemotingClient(new ClientConfig
@@ -54,10 +55,11 @@ public class RpcBenchmark
             Channel = Setup.CreateClient(),
             ServerHostName = "localhost",
             ServerPort = 9192,
-            MessageEncryption = Setup.Encrypted,
+            MessageEncryption = Setup.MessageEncryption,
             KeySize = 512,
             ChannelConnectionName = Setup.ConnectionName
         });
+
         _mainClient.Connect();
         _proxy = _mainClient.CreateProxy<ITestService>();
     }
@@ -70,21 +72,34 @@ public class RpcBenchmark
         _server?.Dispose();
     }
 
-    [Benchmark]
-    public void Connect()
+    [IterationSetup(Target = nameof(Connect))]
+    public void SetupConnect()
     {
         var config = new ClientConfig
         {
             Channel = Setup.CreateClient(),
             ServerHostName = "localhost",
             ServerPort = 9192,
-            MessageEncryption = Setup.Encrypted,
+            MessageEncryption = Setup.MessageEncryption,
             KeySize = 512,
             ChannelConnectionName = Setup.ConnectionName
         };
 
-        using var client = new RemotingClient(config);
-        client.Connect();
+        _clientForConnect = new RemotingClient(config);
+    }
+
+    [IterationCleanup(Target = nameof(Connect))]
+    public void CleanupConnect()
+    {
+        _clientForConnect?.Dispose();
+    }
+
+    private RemotingClient? _clientForConnect;
+
+    [Benchmark]
+    public void Connect()
+    {
+        _clientForConnect!.Connect();
     }
 
     [Benchmark]

--- a/CoreRemoting.Benchmark/RpcBenchmark.cs
+++ b/CoreRemoting.Benchmark/RpcBenchmark.cs
@@ -21,12 +21,14 @@ namespace CoreRemoting.Benchmark;
 public enum RpcChannel
 {
     Null,
-    NamedPipe,
-    QuicPlain,
+    NullEncr,
+    NPipe,
+    NPipeEncr,
+    Quic,
     QuicEncr,
-    WsockPlain,
+    Wsock,
     WsockEncr,
-    TcpPlain,
+    Tcp,
     TcpEncr
 }
 
@@ -63,14 +65,16 @@ public class RpcBenchmark
 
     [Params(
         RpcChannel.Null,
-        RpcChannel.NamedPipe,
-        RpcChannel.WsockPlain,
+        RpcChannel.NullEncr,
+        RpcChannel.NPipe,
+        RpcChannel.NPipeEncr,
+        RpcChannel.Wsock,
         RpcChannel.WsockEncr,
 #if NET9_0_OR_GREATER
-        RpcChannel.QuicPlain,
+        RpcChannel.Quic,
         RpcChannel.QuicEncr,
 #endif
-        RpcChannel.TcpPlain,
+        RpcChannel.Tcp,
         RpcChannel.TcpEncr
     )]
     public RpcChannel Channel { get; set; }
@@ -81,7 +85,7 @@ public class RpcBenchmark
         var serverChannel = CreateServerChannel(Channel);
         var clientChannel = CreateClientChannel(Channel);
         _encryption = IsEncryptionEnabled(Channel);
-        _pipeName = Channel == RpcChannel.NamedPipe ? "BenchmarkPipe" : null;
+        _pipeName = Channel == RpcChannel.NPipe ? "BenchmarkPipe" : null;
 
         _server = new RemotingServer(new ServerConfig
         {
@@ -144,25 +148,25 @@ public class RpcBenchmark
 
     private static IServerChannel CreateServerChannel(RpcChannel scenario) => scenario switch
     {
-        RpcChannel.Null => new NullServerChannel(),
-        RpcChannel.NamedPipe => new NamedPipeServerChannel(),
+        RpcChannel.Null or RpcChannel.NullEncr => new NullServerChannel(),
+        RpcChannel.NPipe or RpcChannel.NPipeEncr => new NamedPipeServerChannel(),
 #if NET9_0_OR_GREATER
-        RpcChannel.QuicPlain or RpcChannel.QuicEncr => new QuicServerChannel(),
+        RpcChannel.Quic or RpcChannel.QuicEncr => new QuicServerChannel(),
 #endif
-        RpcChannel.WsockPlain or RpcChannel.WsockEncr => new WebsocketServerChannel(),
-        RpcChannel.TcpPlain or RpcChannel.TcpEncr => new TcpServerChannel(),
+        RpcChannel.Wsock or RpcChannel.WsockEncr => new WebsocketServerChannel(),
+        RpcChannel.Tcp or RpcChannel.TcpEncr => new TcpServerChannel(),
         _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null)
     };
 
     private static IClientChannel CreateClientChannel(RpcChannel scenario) => scenario switch
     {
-        RpcChannel.Null => new NullClientChannel(),
-        RpcChannel.NamedPipe => new NamedPipeClientChannel(),
+        RpcChannel.Null or RpcChannel.NullEncr => new NullClientChannel(),
+        RpcChannel.NPipe or RpcChannel.NPipeEncr => new NamedPipeClientChannel(),
 #if NET9_0_OR_GREATER
-        RpcChannel.QuicPlain or RpcChannel.QuicEncr => new QuicClientChannel(),
+        RpcChannel.Quic or RpcChannel.QuicEncr => new QuicClientChannel(),
 #endif
-        RpcChannel.WsockPlain or RpcChannel.WsockEncr => new WebsocketClientChannel(),
-        RpcChannel.TcpPlain or RpcChannel.TcpEncr => new TcpClientChannel(),
+        RpcChannel.Wsock or RpcChannel.WsockEncr => new WebsocketClientChannel(),
+        RpcChannel.Tcp or RpcChannel.TcpEncr => new TcpClientChannel(),
         _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null)
     };
 
@@ -173,6 +177,8 @@ public class RpcBenchmark
 #endif
         RpcChannel.WsockEncr => true,
         RpcChannel.TcpEncr => true,
+        RpcChannel.NullEncr => true,
+        RpcChannel.NPipeEncr => true,
         _ => false
     };
 }

--- a/CoreRemoting.Benchmark/RpcBenchmark.cs
+++ b/CoreRemoting.Benchmark/RpcBenchmark.cs
@@ -72,8 +72,8 @@ public class RpcBenchmark
         _server?.Dispose();
     }
 
-    [IterationSetup(Target = nameof(Connect))]
-    public void SetupConnect()
+    [Benchmark]
+    public void Connect()
     {
         var config = new ClientConfig
         {
@@ -85,21 +85,8 @@ public class RpcBenchmark
             ChannelConnectionName = Setup.ConnectionName
         };
 
-        _clientForConnect = new RemotingClient(config);
-    }
-
-    [IterationCleanup(Target = nameof(Connect))]
-    public void CleanupConnect()
-    {
-        _clientForConnect?.Dispose();
-    }
-
-    private RemotingClient? _clientForConnect;
-
-    [Benchmark]
-    public void Connect()
-    {
-        _clientForConnect!.Connect();
+        using var client = new RemotingClient(config);
+        client.Connect();
     }
 
     [Benchmark]

--- a/CoreRemoting.Benchmark/Setup.cs
+++ b/CoreRemoting.Benchmark/Setup.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using CoreRemoting.Channels;
+﻿using CoreRemoting.Channels;
 using CoreRemoting.Channels.NamedPipe;
 using CoreRemoting.Channels.Null;
 using CoreRemoting.Channels.Tcp;
@@ -13,58 +12,48 @@ namespace CoreRemoting.Benchmark;
 
 public static class Setup
 {
-    public interface ICase
+    public interface IScenario
     {
         IServerChannel CreateServer();
         IClientChannel CreateClient();
-        bool Encrypted { get; }
+        bool MessageEncryption { get; }
         string ConnectionName { get; }
     }
 
-    // --- Two-parameter case: plain -------------------------------------------
-
-    private class Case<TServer, TClient> : ICase
+    private class Plain<TServer, TClient> : IScenario
         where TServer : IServerChannel, new()
         where TClient : IClientChannel, new()
     {
         public IServerChannel CreateServer() => new TServer();
         public IClientChannel CreateClient() => new TClient();
-        public virtual bool Encrypted => false;
+        public virtual bool MessageEncryption => false;
         public string ConnectionName { get; } = "Bench" + Guid.NewGuid();
         public override string ToString() => $"{Short(typeof(TServer).Name)}_Plain";
         protected static string Short(string name) =>
         	name.Replace("ServerChannel", "").Replace("ClientChannel", "");
     }
 
-    // --- Three-parameter case: encrypted -------------------------------------
-
-    private sealed class Case<TServer, TClient, TSecure> : Case<TServer, TClient>
+    private sealed class Encrypted<TServer, TClient> : Plain<TServer, TClient>
         where TServer : IServerChannel, new()
         where TClient : IClientChannel, new()
     {
-        public override bool Encrypted => true;
+        public override bool MessageEncryption => true;
         public override string ToString() => $"{Short(typeof(TServer).Name)}_Secure";
     }
 
-    // --- Dummy marker for the third generic parameter ------------------------
-
-    private sealed class Secure;
-
-    // --- Scenarios сatalog ---------------------------------------------------
-
-    public static ICase[] Scenarios { get; } =
+    public static IScenario[] Scenarios { get; } =
     [
-        new Case<NullServerChannel, NullClientChannel>(),
-        new Case<NullServerChannel, NullClientChannel, Secure>(),
-        new Case<NamedPipeServerChannel, NamedPipeClientChannel>(),
-        new Case<NamedPipeServerChannel, NamedPipeClientChannel, Secure>(),
-        new Case<TcpServerChannel, TcpClientChannel>(),
-        new Case<TcpServerChannel, TcpClientChannel, Secure>(),
-        new Case<WebsocketServerChannel, WebsocketClientChannel>(),
-        new Case<WebsocketServerChannel, WebsocketClientChannel, Secure>(),
+        new Plain<NullServerChannel, NullClientChannel>(),
+        new Encrypted<NullServerChannel, NullClientChannel>(),
+        new Plain<NamedPipeServerChannel, NamedPipeClientChannel>(),
+        new Encrypted<NamedPipeServerChannel, NamedPipeClientChannel>(),
+        new Plain<TcpServerChannel, TcpClientChannel>(),
+        new Encrypted<TcpServerChannel, TcpClientChannel>(),
+        new Plain<WebsocketServerChannel, WebsocketClientChannel>(),
+        new Encrypted<WebsocketServerChannel, WebsocketClientChannel>(),
       #if NET9_0_OR_GREATER
-        new Case<QuicServerChannel, QuicClientChannel>(),
-        new Case<QuicServerChannel, QuicClientChannel, Secure>(),
+        new Plain<QuicServerChannel, QuicClientChannel>(),
+        new Encrypted<QuicServerChannel, QuicClientChannel>(),
       #endif
     ];
 }

--- a/CoreRemoting.Benchmark/Setup.cs
+++ b/CoreRemoting.Benchmark/Setup.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using CoreRemoting.Channels;
+using CoreRemoting.Channels.NamedPipe;
+using CoreRemoting.Channels.Null;
+using CoreRemoting.Channels.Tcp;
+using CoreRemoting.Channels.Websocket;
+
+#if NET9_0_OR_GREATER
+using CoreRemoting.Channels.Quic;
+#endif
+
+namespace CoreRemoting.Benchmark;
+
+public static class Setup
+{
+    public interface ICase
+    {
+        IServerChannel CreateServer();
+        IClientChannel CreateClient();
+        bool Encrypted { get; }
+        string ConnectionName { get; }
+    }
+
+    // --- Two-parameter case: plain -------------------------------------------
+
+    private class Case<TServer, TClient> : ICase
+        where TServer : IServerChannel, new()
+        where TClient : IClientChannel, new()
+    {
+        public IServerChannel CreateServer() => new TServer();
+        public IClientChannel CreateClient() => new TClient();
+        public virtual bool Encrypted => false;
+        public string ConnectionName { get; } = "Bench" + Guid.NewGuid();
+        public override string ToString() => $"{Short(typeof(TServer).Name)}_Plain";
+        protected static string Short(string name) =>
+        	name.Replace("ServerChannel", "").Replace("ClientChannel", "");
+    }
+
+    // --- Three-parameter case: encrypted -------------------------------------
+
+    private sealed class Case<TServer, TClient, TSecure> : Case<TServer, TClient>
+        where TServer : IServerChannel, new()
+        where TClient : IClientChannel, new()
+    {
+        public override bool Encrypted => true;
+        public override string ToString() => $"{Short(typeof(TServer).Name)}_Secure";
+    }
+
+    // --- Dummy marker for the third generic parameter ------------------------
+
+    private sealed class Secure;
+
+    // --- Scenarios сatalog ---------------------------------------------------
+
+    public static ICase[] Scenarios { get; } =
+    [
+        new Case<NullServerChannel, NullClientChannel>(),
+        new Case<NullServerChannel, NullClientChannel, Secure>(),
+        new Case<NamedPipeServerChannel, NamedPipeClientChannel>(),
+        new Case<NamedPipeServerChannel, NamedPipeClientChannel, Secure>(),
+        new Case<TcpServerChannel, TcpClientChannel>(),
+        new Case<TcpServerChannel, TcpClientChannel, Secure>(),
+        new Case<WebsocketServerChannel, WebsocketClientChannel>(),
+        new Case<WebsocketServerChannel, WebsocketClientChannel, Secure>(),
+      #if NET9_0_OR_GREATER
+        new Case<QuicServerChannel, QuicClientChannel>(),
+        new Case<QuicServerChannel, QuicClientChannel, Secure>(),
+      #endif
+    ];
+}

--- a/CoreRemoting.Tests/CoreRemoting.Tests.csproj
+++ b/CoreRemoting.Tests/CoreRemoting.Tests.csproj
@@ -76,37 +76,16 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Compile Update="DicTests_DryIoc.cs">
+      <Compile Update="DicTests_*.cs">
         <DependentUpon>DicTests.cs</DependentUpon>
       </Compile>
-      <Compile Update="DicTests_Microsoft.cs">
-        <DependentUpon>DicTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="RpcTests_NamedPipe.cs">
+      <Compile Update="RpcTests_*.cs">
         <DependentUpon>RpcTests.cs</DependentUpon>
       </Compile>
-      <Compile Update="RpcTests_NullChannel.cs">
-        <DependentUpon>RpcTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="RpcTests_Websockets.cs">
-        <DependentUpon>RpcTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="SessionResumeTestsNoEncryption.cs">
+      <Compile Update="SessionResumeTests?*.cs">
         <DependentUpon>SessionResumeTests.cs</DependentUpon>
       </Compile>
-      <Compile Update="SessionResumeTestsNullChannel.cs">
-        <DependentUpon>SessionResumeTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="SessionResumeTestsNullNoEncr.cs">
-        <DependentUpon>SessionResumeTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="SessionResumeTestsWebSockets.cs">
-        <DependentUpon>SessionResumeTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="SessionResumeTestsWsockNoEncr.cs">
-        <DependentUpon>SessionResumeTests.cs</DependentUpon>
-      </Compile>
-      <Compile Update="SessionTests_Websockets.cs">
+      <Compile Update="SessionTests_*.cs">
         <DependentUpon>SessionTests.cs</DependentUpon>
       </Compile>
     </ItemGroup>

--- a/CoreRemoting.Tests/RpcTests.cs
+++ b/CoreRemoting.Tests/RpcTests.cs
@@ -1762,6 +1762,37 @@ public class RpcTests : IClassFixture<ServerFixture>
     }
 
     [Theory]
+    [InlineData(1024)]
+    [InlineData(2048)]
+    [InlineData(4096)]
+    [SuppressMessage("Usage", "xUnit1030:Do not call ConfigureAwait(false) in test method", Justification = "<Pending>")]
+    public virtual async Task Server_and_client_can_use_different_KeySize(int clientKeySize)
+    {
+        using var ctx = ValidationSyncContext.Install();
+
+        _serverFixture.Server.Config.KeySize = 2048;
+
+        using var client = new RemotingClient(new ClientConfig()
+        {
+            ConnectionTimeout = 20,
+            Channel = ClientChannel,
+            MessageEncryption = true,
+            KeySize = clientKeySize,
+            ServerPort = _serverFixture.Server.Config.NetworkPort,
+        });
+
+        await client.ConnectAsync()
+            .ConfigureAwait(false);
+
+        var proxy = client.CreateProxy<ITestService>();
+        var echoed = proxy.Echo("@echo off");
+        Assert.Equal("@echo off", echoed);
+        Assert.Equal(clientKeySize, client.KeySize);
+
+        CheckServerErrorCount();
+    }
+
+    [Theory]
     [InlineData(256, 256)]
     [InlineData(384, 384)]
     [InlineData(128, 256)] // server minimum wins

--- a/CoreRemoting/Encryption/EcdsaSessionKeyPair.cs
+++ b/CoreRemoting/Encryption/EcdsaSessionKeyPair.cs
@@ -46,10 +46,13 @@ public sealed class EcdsaSessionKeyPair : ISessionKeyPair
     /// <returns>A key pair instance that can only verify signatures.</returns>
     public static EcdsaSessionKeyPair FromPublicKey(byte[] publicKey)
     {
-        var ecdsa = ECDsa.Create();
+        using var ecdsa = ECDsa.Create();
         ecdsa.ImportPublicKey(publicKey);
         return new EcdsaSessionKeyPair(ecdsa, publicKey);
     }
+
+    /// <inheritdoc/>
+    public int KeySize => _ecdsa.KeySize;
 
     /// <inheritdoc/>
     public byte[] PublicKey => _publicKey ??= _ecdsa.ExportPublicKey();

--- a/CoreRemoting/Encryption/EcdsaSessionKeyPair.cs
+++ b/CoreRemoting/Encryption/EcdsaSessionKeyPair.cs
@@ -46,7 +46,7 @@ public sealed class EcdsaSessionKeyPair : ISessionKeyPair
     /// <returns>A key pair instance that can only verify signatures.</returns>
     public static EcdsaSessionKeyPair FromPublicKey(byte[] publicKey)
     {
-        using var ecdsa = ECDsa.Create();
+        var ecdsa = ECDsa.Create();
         ecdsa.ImportPublicKey(publicKey);
         return new EcdsaSessionKeyPair(ecdsa, publicKey);
     }

--- a/CoreRemoting/Encryption/ISessionKeyPair.cs
+++ b/CoreRemoting/Encryption/ISessionKeyPair.cs
@@ -27,6 +27,11 @@ public interface ISessionKeyPair : IDisposable
     bool VerifySignature(byte[] data, byte[] signature);
 
     /// <summary>
+    /// Gets the currently used key size, for reference.
+    /// </summary>
+    int KeySize { get; }
+
+    /// <summary>
     /// Gets the public key.
     /// </summary>
     byte[] PublicKey { get; }

--- a/CoreRemoting/RemotingClient.cs
+++ b/CoreRemoting/RemotingClient.cs
@@ -269,6 +269,11 @@ public sealed class RemotingClient : IRemotingClient, IAuthenticationProvider
             : null;
 
     /// <summary>
+    /// Gets the currently used key size.
+    /// </summary>
+    internal int KeySize => _keyPair.KeySize;
+
+    /// <summary>
     /// Gets the currently used shared key size.
     /// </summary>
     internal int SharedKeySize => _sharedSecretLength * 8;


### PR DESCRIPTION
- NamedPipes and NullChannel are now encryption-agnostic, so they support both modes.
- QuickChannel is TLS-based, so even in unencrypted mode it uses secure connection.
- Connect benchmark actually measures new() + Connect() + Dispose() all at once.
- ClientConfig.KeySize and ServerConfig.KeySize are not required to be the same.

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9445/25H2/2025Update/HudsonValley2)
Intel Core i7-9750H CPU 2.60GHz (Max: 2.59GHz), 1 CPU, 12 logical and 6 physical cores
.NET SDK 10.0.303
  [Host]     : .NET 9.0.20 (9.0.20, 9.0.2026.41315), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 9.0.20 (9.0.20, 9.0.2026.41315), X64 RyuJIT x86-64-v3


```
| Method    | Setup            | Mean           | Median         | Gen0    | Gen1    | Allocated  |
|---------- |----------------- |---------------:|---------------:|--------:|--------:|-----------:|
| **Connect**   | **NamedPipe_Plain**  |     **2,675.5 μs** |     **2,677.7 μs** | **19.5313** |  **3.9063** |  **127.47 KB** |
| Method    | NamedPipe_Plain  |       354.7 μs |       355.5 μs | 18.5547 |  0.9766 |  113.35 KB |
| Property  | NamedPipe_Plain  |       319.5 μs |       321.5 μs | 15.6250 |  0.9766 |   99.17 KB |
| FireEvent | NamedPipe_Plain  |       312.5 μs |       315.1 μs | 15.6250 |  0.9766 |   97.03 KB |
| **Connect**   | **NamedPipe_Secure** |     **8,305.0 μs** |     **8,288.5 μs** | **31.2500** |       **-** |  **265.74 KB** |
| Method    | NamedPipe_Secure |     2,568.7 μs |     2,562.4 μs | 31.2500 |       - |  199.46 KB |
| Property  | NamedPipe_Secure |     2,559.5 μs |     2,550.6 μs | 27.3438 |       - |  179.66 KB |
| FireEvent | NamedPipe_Secure |     2,552.9 μs |     2,553.1 μs | 27.3438 |       - |  176.17 KB |
| **Connect**   | **Null_Plain**       |     **2,070.6 μs** |     **2,071.4 μs** | **15.6250** |  **3.9063** |   **105.2 KB** |
| Method    | Null_Plain       |       231.6 μs |       231.0 μs | 17.5781 |  0.9766 |  109.89 KB |
| Property  | Null_Plain       |       208.6 μs |       207.5 μs | 15.6250 |       - |   96.15 KB |
| FireEvent | Null_Plain       |       206.1 μs |       204.4 μs | 14.6484 |       - |   94.25 KB |
| **Connect**   | **Null_Secure**      |     **7,766.9 μs** |     **7,741.9 μs** | **31.2500** | **15.6250** |  **230.71 KB** |
| Method    | Null_Secure      |     2,317.7 μs |     2,313.7 μs | 31.2500 |       - |  194.89 KB |
| Property  | Null_Secure      |     2,360.9 μs |     2,356.5 μs | 27.3438 |       - |  175.57 KB |
| FireEvent | Null_Secure      |     2,308.9 μs |     2,313.8 μs | 27.3438 |       - |  172.18 KB |
| **Connect**   | **Quic_Plain**       |     **7,917.7 μs** |     **7,935.8 μs** | **31.2500** | **15.6250** |  **232.52 KB** |
| Method    | Quic_Plain       |       662.9 μs |       654.7 μs | 17.5781 |       - |   114.2 KB |
| Property  | Quic_Plain       |       620.3 μs |       621.1 μs | 15.6250 |       - |   99.84 KB |
| FireEvent | Quic_Plain       |       519.5 μs |       519.0 μs | 15.6250 |       - |   97.34 KB |
| **Connect**   | **Quic_Secure**      |    **14,009.2 μs** |    **14,006.9 μs** | **31.2500** |       **-** |  **360.34 KB** |
| Method    | Quic_Secure      |     3,067.4 μs |     3,060.1 μs | 31.2500 |       - |  200.51 KB |
| Property  | Quic_Secure      |     3,006.4 μs |     3,005.8 μs | 27.3438 |       - |  180.74 KB |
| FireEvent | Quic_Secure      |     3,018.8 μs |     2,993.3 μs | 27.3438 |       - |  177.25 KB |
| **Connect**   | **Tcp_Plain**        | **2,061,047.1 μs** | **2,057,930.7 μs** |       **-** |       **-** | **1348.99 KB** |
| Method    | Tcp_Plain        |       886.9 μs |       878.5 μs | 62.5000 |  5.8594 |  385.75 KB |
| Property  | Tcp_Plain        |       874.9 μs |       869.3 μs | 60.5469 |  3.9063 |  369.95 KB |
| FireEvent | Tcp_Plain        |       884.6 μs |       882.9 μs | 58.5938 |       - |  367.24 KB |
| **Connect**   | **Tcp_Secure**       | **2,067,700.6 μs** | **2,064,549.2 μs** |       **-** |       **-** | **1517.97 KB** |
| Method    | Tcp_Secure       |     3,233.5 μs |     3,191.1 μs | 78.1250 |  7.8125 |  480.31 KB |
| Property  | Tcp_Secure       |     3,101.0 μs |     3,076.7 μs | 70.3125 |  7.8125 |  458.09 KB |
| FireEvent | Tcp_Secure       |     3,110.2 μs |     3,091.8 μs | 70.3125 |  7.8125 |   453.6 KB |
| **Connect**   | **Websocket_Plain**  |     **3,760.2 μs** |     **3,756.0 μs** | **31.2500** | **15.6250** |  **219.32 KB** |
| Method    | Websocket_Plain  |       366.0 μs |       366.2 μs | 18.5547 |  0.9766 |  117.12 KB |
| Property  | Websocket_Plain  |       338.7 μs |       339.0 μs | 16.6016 |  0.9766 |  102.52 KB |
| FireEvent | Websocket_Plain  |       336.4 μs |       336.6 μs | 15.6250 |  0.9766 |  100.26 KB |
| **Connect**   | **Websocket_Secure** |     **9,820.4 μs** |     **9,732.9 μs** | **46.8750** | **15.6250** |  **350.33 KB** |
| Method    | Websocket_Secure |     2,618.4 μs |     2,618.3 μs | 31.2500 |       - |  204.31 KB |
| Property  | Websocket_Secure |     2,573.6 μs |     2,535.9 μs | 27.3438 |       - |  181.93 KB |
| FireEvent | Websocket_Secure |     2,514.6 μs |     2,514.0 μs | 27.3438 |       - |  180.46 KB |
